### PR TITLE
Add notes about compiling on iOS to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ The plan is that glutin tries to dynamically link-to and use wayland if possible
 
 Due to an issue with how mesa and Wayland play together, all shared contexts must use the same events pool as each other.
 
+### iOS
+
+In order to build in XCode, you must link both `UIKit.framework` and `OpenGLES.framework`. In order for your app to not crash while attempting to obtain a context, you must also link `CoreFoundation.framework` and `GLKit.framework`.
+
 ## Common issues
 
 Help! I'm receiving `NoAvailablePixelFormat`!


### PR DESCRIPTION
re: rust-windowing/glutin#1154

Add notes to the README about getting it compile and run properly on iOS—for now just including the explicitly and implicitly required frameworks.