### PR TITLE
Fix winit desktop reexports

### DIFF
--- a/glutin/src/platform/mod.rs
+++ b/glutin/src/platform/mod.rs
@@ -19,6 +19,10 @@ pub mod macos;
 pub mod unix;
 /// Platform-specific methods for Windows.
 pub mod windows;
+/// Platform-specific methods for desktop operating systems.
+pub mod desktop {
+    pub use winit::platform::desktop::*;
+}
 
 use std::os::raw;
 


### PR DESCRIPTION
Since glutin does not correctly reexport the desktop module, it's not
possible to make use of the `run_return` method.

This creates a separate `desktop` module which is just responsible for
reexporting winit's desktop module under the correct namespace.