### PR TITLE
Fix build failure

### DIFF
--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -19,7 +19,7 @@ serde = ["winit/serde"]
 [dependencies]
 lazy_static = "1.3"
 #winit = "^0.19.1"
-winit = { git = "https://github.com/rust-windowing/winit.git", branch = "eventloop-2.0"}
+winit = { git = "https://github.com/rust-windowing/winit.git", rev = "0eefa3b" }
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_glue = "0.2"

--- a/glutin/src/api/ios/mod.rs
+++ b/glutin/src/api/ios/mod.rs
@@ -205,7 +205,7 @@ impl Context {
         let win = builder.build(el)?;
         let context = unsafe {
             let eagl_context = Context::create_context(version)?;
-            let view = win.get_uiview() as ffi::id;
+            let view = win.uiview() as ffi::id;
             let mut context = Context { eagl_context, view };
             context.init_context(&win);
             context
@@ -222,7 +222,7 @@ impl Context {
     ) -> Result<Self, CreationError> {
         let wb = winit::window::WindowBuilder::new()
             .with_visibility(false)
-            .with_dimensions(size.to_logical(1.));
+            .with_inner_size(size.to_logical(1.));
         Self::new_windowed(wb, el, pf_reqs, gl_attr)
             .map(|(_window, context)| context)
     }

--- a/glutin/src/api/ios/mod.rs
+++ b/glutin/src/api/ios/mod.rs
@@ -270,7 +270,7 @@ impl Context {
         self.make_current().unwrap();
 
         let view = self.view;
-        let scale_factor = win.get_hidpi_factor() as ffi::CGFloat;
+        let scale_factor = win.hidpi_factor() as ffi::CGFloat;
         let _: () = msg_send![view, setContentScaleFactor: scale_factor];
         let layer: ffi::id = msg_send![view, layer];
         let _: () = msg_send![layer, setContentsScale: scale_factor];

--- a/glutin/src/lib.rs
+++ b/glutin/src/lib.rs
@@ -15,7 +15,7 @@
 //! let el = glutin::event_loop::EventLoop::new();
 //! let wb = glutin::window::WindowBuilder::new()
 //!     .with_title("Hello world!")
-//!     .with_dimensions(glutin::dpi::LogicalSize::new(1024.0, 768.0));
+//!     .with_inner_size(glutin::dpi::LogicalSize::new(1024.0, 768.0));
 //! let windowed_context = glutin::ContextBuilder::new()
 //!     .build_windowed(wb, &el)
 //!     .unwrap();

--- a/glutin/src/platform_impl/emscripten/mod.rs
+++ b/glutin/src/platform_impl/emscripten/mod.rs
@@ -79,7 +79,7 @@ impl Context {
     ) -> Result<Self, CreationError> {
         let wb = winit::window::WindowBuilder::new()
             .with_visibility(false)
-            .with_dimensions(size.to_logical(1.));
+            .with_inner_size(size.to_logical(1.));
 
         Self::new_windowed(wb, el, pf_reqs, gl_attr).map(|(w, c)| match c {
             Context::Window(c) => Context::WindowedContext(w, c),

--- a/glutin/src/platform_impl/macos/mod.rs
+++ b/glutin/src/platform_impl/macos/mod.rs
@@ -69,7 +69,7 @@ impl Context {
             _ => (),
         }
 
-        let view = win.get_nsview() as id;
+        let view = win.nsview() as id;
 
         let gl_profile = helpers::get_gl_profile(gl_attr, pf_reqs)?;
         let attributes = helpers::build_nsattributes(pf_reqs, gl_profile)?;

--- a/glutin/src/platform_impl/unix/wayland.rs
+++ b/glutin/src/platform_impl/unix/wayland.rs
@@ -52,7 +52,7 @@ impl Context {
         size: Option<dpi::PhysicalSize>,
     ) -> Result<Self, CreationError> {
         let gl_attr = gl_attr.clone().map_sharing(|c| &**c);
-        let display_ptr = el.get_wayland_display().unwrap() as *const _;
+        let display_ptr = el.wayland_display().unwrap() as *const _;
         let native_display =
             NativeDisplay::Wayland(Some(display_ptr as *const _));
         if let Some(size) = size {
@@ -90,12 +90,12 @@ impl Context {
     ) -> Result<(Window, Self), CreationError> {
         let win = wb.build(el)?;
 
-        let dpi_factor = win.get_hidpi_factor();
-        let size = win.get_inner_size().unwrap().to_physical(dpi_factor);
+        let dpi_factor = win.hidpi_factor();
+        let size = win.inner_size().to_physical(dpi_factor);
         let (width, height): (u32, u32) = size.into();
 
-        let display_ptr = win.get_wayland_display().unwrap() as *const _;
-        let surface = win.get_wayland_surface();
+        let display_ptr = win.wayland_display().unwrap() as *const _;
+        let surface = win.wayland_surface();
         let surface = match surface {
             Some(s) => s,
             None => {

--- a/glutin/src/platform_impl/unix/x11.rs
+++ b/glutin/src/platform_impl/unix/x11.rs
@@ -209,7 +209,7 @@ impl Context {
         size: Option<dpi::PhysicalSize>,
         fallback: bool,
     ) -> Result<Self, CreationError> {
-        let xconn = match el.get_xlib_xconnection() {
+        let xconn = match el.xlib_xconnection() {
             Some(xconn) => xconn,
             None => {
                 return Err(CreationError::NoBackendAvailable(Box::new(
@@ -466,7 +466,7 @@ impl Context {
         gl_attr: &GlAttributes<&Context>,
         fallback: bool,
     ) -> Result<(Window, Self), CreationError> {
-        let xconn = match el.get_xlib_xconnection() {
+        let xconn = match el.xlib_xconnection() {
             Some(xconn) => xconn,
             None => {
                 return Err(CreationError::NoBackendAvailable(Box::new(
@@ -510,7 +510,7 @@ impl Context {
             .with_x11_screen(screen_id)
             .build(el)?;
 
-        let xwin = win.get_xlib_window().unwrap();
+        let xwin = win.xlib_window().unwrap();
         // finish creating the OpenGL context
         let context = match context {
             Prototype::Glx(ctx) => X11Context::Glx(ctx.finish(xwin)?),

--- a/glutin/src/platform_impl/windows/mod.rs
+++ b/glutin/src/platform_impl/windows/mod.rs
@@ -53,7 +53,7 @@ impl Context {
         gl_attr: &GlAttributes<&Self>,
     ) -> Result<(Window, Self), CreationError> {
         let win = wb.build(el)?;
-        let hwnd = win.get_hwnd() as HWND;
+        let hwnd = win.hwnd() as HWND;
         let ctx = Self::new_raw_context(hwnd, pf_reqs, gl_attr)?;
 
         Ok((win, ctx))
@@ -187,7 +187,7 @@ impl Context {
 
         let wb = WindowBuilder::new()
             .with_visibility(false)
-            .with_dimensions(size.to_logical(1.));
+            .with_inner_size(size.to_logical(1.));
         Self::new_windowed(wb, &el, pf_reqs, gl_attr).map(|(win, context)| {
             match context {
                 Context::Egl(context) => Context::HiddenWindowEgl(win, context),

--- a/glutin_examples/examples/fullscreen.rs
+++ b/glutin_examples/examples/fullscreen.rs
@@ -110,7 +110,7 @@ fn main() {
                             windowed_context.window().set_fullscreen(None);
                         } else {
                             windowed_context.window().set_fullscreen(Some(
-                                windowed_context.window().get_current_monitor(),
+                                windowed_context.window().current_monitor(),
                             ));
                         }
                     }
@@ -133,8 +133,8 @@ fn main() {
 
 // Enumerate monitors and prompt user to choose one
 fn prompt_for_monitor(el: &EventLoop<()>) -> MonitorHandle {
-    for (num, monitor) in el.get_available_monitors().enumerate() {
-        println!("Monitor #{}: {:?}", num, monitor.get_name());
+    for (num, monitor) in el.available_monitors().enumerate() {
+        println!("Monitor #{}: {:?}", num, monitor.name());
     }
 
     print!("Please write the number of the monitor to use: ");
@@ -144,11 +144,11 @@ fn prompt_for_monitor(el: &EventLoop<()>) -> MonitorHandle {
     std::io::stdin().read_line(&mut num).unwrap();
     let num = num.trim().parse().ok().expect("Please enter a number");
     let monitor = el
-        .get_available_monitors()
+        .available_monitors()
         .nth(num)
         .expect("Please enter a valid ID");
 
-    println!("Using {:?}", monitor.get_name());
+    println!("Using {:?}", monitor.name());
 
     monitor
 }

--- a/glutin_examples/examples/fullscreen.rs
+++ b/glutin_examples/examples/fullscreen.rs
@@ -67,7 +67,7 @@ fn main() {
             Event::WindowEvent { event, .. } => match event {
                 WindowEvent::Resized(logical_size) => {
                     let dpi_factor =
-                        windowed_context.window().get_hidpi_factor();
+                        windowed_context.window().hidpi_factor();
                     windowed_context
                         .resize(logical_size.to_physical(dpi_factor));
                 }

--- a/glutin_examples/examples/multiwindow.rs
+++ b/glutin_examples/examples/multiwindow.rs
@@ -36,7 +36,7 @@ fn main() {
                         ct.get_current(windows[&window_id].0).unwrap();
                     let windowed_context = windowed_context.windowed();
                     let dpi_factor =
-                        windowed_context.window().get_hidpi_factor();
+                        windowed_context.window().hidpi_factor();
                     windowed_context
                         .resize(logical_size.to_physical(dpi_factor));
                 }

--- a/glutin_examples/examples/raw_context.rs
+++ b/glutin_examples/examples/raw_context.rs
@@ -45,14 +45,14 @@ mod this_example {
 
                 if el.is_wayland() {
                     let win = wb.build(&el).unwrap();
-                    let dpi_factor = win.get_hidpi_factor();
+                    let dpi_factor = win.hidpi_factor();
                     let size =
-                        win.get_inner_size().unwrap().to_physical(dpi_factor);
+                        win.inner_size().to_physical(dpi_factor);
                     let (width, height): (u32, u32) = size.into();
 
                     let display_ptr =
-                        win.get_wayland_display().unwrap() as *const _;
-                    let surface = win.get_wayland_surface().unwrap();
+                        win.wayland_display().unwrap() as *const _;
+                    let surface = win.wayland_surface().unwrap();
 
                     let raw_context = ContextBuilder::new()
                         .build_raw_wayland_context(
@@ -85,8 +85,8 @@ File a PR if you are interested in implementing the latter.
                     }
 
                     let win = wb.build(&el).unwrap();
-                    let xconn = el.get_xlib_xconnection().unwrap();
-                    let xwindow = win.get_xlib_window().unwrap();
+                    let xconn = el.xlib_xconnection().unwrap();
+                    let xwindow = win.xlib_window().unwrap();
                     let raw_context = ContextBuilder::new()
                         .build_raw_x11_context(xconn, xwindow)
                         .unwrap();
@@ -131,7 +131,7 @@ File a PR if you are interested in implementing the latter.
                 }
                 Event::WindowEvent { ref event, .. } => match event {
                     WindowEvent::Resized(logical_size) => {
-                        let dpi_factor = win.get_hidpi_factor();
+                        let dpi_factor = win.hidpi_factor();
                         raw_context
                             .resize(logical_size.to_physical(dpi_factor));
                     }

--- a/glutin_examples/examples/raw_context.rs
+++ b/glutin_examples/examples/raw_context.rs
@@ -102,7 +102,7 @@ File a PR if you are interested in implementing the latter.
                     RawContextExt, WindowExtWindows,
                 };
 
-                let hwnd = win.get_hwnd();
+                let hwnd = win.hwnd();
                 let raw_context =
                     ContextBuilder::new().build_raw_context(hwnd).unwrap();
 

--- a/glutin_examples/examples/sharing.rs
+++ b/glutin_examples/examples/sharing.rs
@@ -35,7 +35,7 @@ fn main() {
 
     let wb = WindowBuilder::new()
         .with_title("A fantastic window!")
-        .with_dimensions(LogicalSize::from_physical(size, 1.0));
+        .with_inner_size(LogicalSize::from_physical(size, 1.0));
     let windowed_context = ContextBuilder::new()
         .with_shared_lists(&headless_context)
         .build_windowed(wb, &el)

--- a/glutin_examples/examples/sharing.rs
+++ b/glutin_examples/examples/sharing.rs
@@ -115,7 +115,7 @@ fn main() {
                 WindowEvent::Resized(logical_size) => {
                     let windowed_context = ct.get_current(windowed_id).unwrap();
                     let dpi_factor =
-                        windowed_context.windowed().window().get_hidpi_factor();
+                        windowed_context.windowed().window().hidpi_factor();
                     size = logical_size.to_physical(dpi_factor);
                     windowed_context.windowed().resize(size);
 

--- a/glutin_examples/examples/transparent.rs
+++ b/glutin_examples/examples/transparent.rs
@@ -33,7 +33,7 @@ fn main() {
             Event::WindowEvent { ref event, .. } => match event {
                 WindowEvent::Resized(logical_size) => {
                     let dpi_factor =
-                        windowed_context.window().get_hidpi_factor();
+                        windowed_context.window().hidpi_factor();
                     windowed_context
                         .resize(logical_size.to_physical(dpi_factor));
                 }

--- a/glutin_examples/examples/window.rs
+++ b/glutin_examples/examples/window.rs
@@ -30,7 +30,7 @@ fn main() {
             Event::WindowEvent { ref event, .. } => match event {
                 WindowEvent::Resized(logical_size) => {
                     let dpi_factor =
-                        windowed_context.window().get_hidpi_factor();
+                        windowed_context.window().hidpi_factor();
                     windowed_context
                         .resize(logical_size.to_physical(dpi_factor));
                 }


### PR DESCRIPTION
This updates glutin to the latest winit commit to resolve all build
failures which occured because of name changes.

It also locks winit to a fixed revision, so things can be updated in a
more controlled manner.

This should at least fix the build failures on Linux, I'll try to update it
if CI complains about other platforms. Let me know if you'd prefer to
keep the winit version pointing to the branch instead of the commit.