### PR TITLE
fix osx panic

### DIFF
--- a/glutin_examples/examples/support/mod.rs
+++ b/glutin_examples/examples/support/mod.rs
@@ -11,34 +11,9 @@ pub struct Gl {
     pub gl: gl::Gl,
 }
 
-extern "system" fn dbg_callback(
-    source: gl::types::GLenum,
-    etype: gl::types::GLenum,
-    _id: gl::types::GLuint,
-    severity: gl::types::GLenum,
-    _msg_length: gl::types::GLsizei,
-    msg: *const gl::types::GLchar,
-    _user_data: *mut std::ffi::c_void,
-) {
-    unsafe {
-        println!(
-            "dbg_callback {:#X} {:#X} {:#X} {:?}",
-            source,
-            etype,
-            severity,
-            std::ffi::CStr::from_ptr(msg),
-        );
-    }
-}
-
 pub fn load(gl_context: &glutin::Context<PossiblyCurrent>) -> Gl {
     let gl =
         gl::Gl::load_with(|ptr| gl_context.get_proc_address(ptr) as *const _);
-
-    unsafe {
-        gl.Enable(gl::DEBUG_OUTPUT);
-        gl.DebugMessageCallback(dbg_callback, std::ptr::null());
-    }
 
     let version = unsafe {
         let data = CStr::from_ptr(gl.GetString(gl::VERSION) as *const _)

--- a/glutin_examples/examples/window.rs
+++ b/glutin_examples/examples/window.rs
@@ -5,20 +5,21 @@ use glutin::event_loop::{ControlFlow, EventLoop};
 use glutin::window::WindowBuilder;
 use glutin::ContextBuilder;
 
-fn main() {
+fn main() -> Result<(), glutin::CreationError> {
     let el = EventLoop::new();
     let wb = WindowBuilder::new().with_title("A fantastic window!");
 
     let windowed_context =
-        ContextBuilder::new().build_windowed(wb, &el).unwrap();
+        ContextBuilder::new().build_windowed(wb, &el)?;
 
-    let windowed_context = unsafe { windowed_context.make_current().unwrap() };
+    let windowed_context = unsafe {
+       windowed_context.make_current().expect("Make current fail")
+    };
 
     println!(
         "Pixel format of the window's GL context: {:?}",
         windowed_context.get_pixel_format()
     );
-
     let gl = support::load(&windowed_context.context());
 
     el.run(move |event, _, control_flow| {
@@ -36,9 +37,10 @@ fn main() {
                 }
                 WindowEvent::RedrawRequested => {
                     gl.draw_frame([1.0, 0.5, 0.7, 1.0]);
-                    windowed_context.swap_buffers().unwrap();
+                    windowed_context.swap_buffers().expect("Swapbuffer fail");
                 }
                 WindowEvent::CloseRequested => {
+                    println!("Close requested.");
                     *control_flow = ControlFlow::Exit
                 }
                 _ => (),


### PR DESCRIPTION
Deleted code in `mod` causes a panic on osx.

This circumvents the problem.