### PR TITLE
Update Glutin build to latest Winit master and make it compile

### DIFF
--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -19,7 +19,7 @@ serde = ["winit/serde"]
 [dependencies]
 lazy_static = "1.3"
 #winit = "^0.19.1"
-winit = { git = "https://github.com/rust-windowing/winit.git", rev = "0eefa3b" }
+winit = { git = "https://github.com/Osspial/winit.git", rev = "06244dd4929d1acf1f4650ecb38ca73c1ec22743" }
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_glue = "0.2"

--- a/glutin/src/platform_impl/macos/mod.rs
+++ b/glutin/src/platform_impl/macos/mod.rs
@@ -69,7 +69,7 @@ impl Context {
             _ => (),
         }
 
-        let view = win.nsview() as id;
+        let view = win.ns_view() as id;
 
         let gl_profile = helpers::get_gl_profile(gl_attr, pf_reqs)?;
         let attributes = helpers::build_nsattributes(pf_reqs, gl_profile)?;

--- a/glutin/src/platform_impl/windows/mod.rs
+++ b/glutin/src/platform_impl/windows/mod.rs
@@ -186,7 +186,7 @@ impl Context {
         }
 
         let wb = WindowBuilder::new()
-            .with_visibility(false)
+            .with_visible(false)
             .with_inner_size(size.to_logical(1.));
         Self::new_windowed(wb, &el, pf_reqs, gl_attr).map(|(win, context)| {
             match context {

--- a/glutin_examples/examples/raw_context.rs
+++ b/glutin_examples/examples/raw_context.rs
@@ -34,7 +34,7 @@ mod this_example {
             let mut wb = WindowBuilder::new().with_title("A fantastic window!");
 
             if transparency {
-                wb = wb.with_decorations(false).with_transparency(true);
+                wb = wb.with_decorations(false).with_transparent(true);
             }
 
             #[cfg(target_os = "linux")]

--- a/glutin_examples/examples/transparent.rs
+++ b/glutin_examples/examples/transparent.rs
@@ -10,7 +10,7 @@ fn main() {
     let wb = WindowBuilder::new()
         .with_title("A transparent window!")
         .with_decorations(false)
-        .with_transparency(true);
+        .with_transparent(true);
 
     let windowed_context =
         ContextBuilder::new().build_windowed(wb, &el).unwrap();


### PR DESCRIPTION
The build on Windows was failing because of the late `with_visibility`->`with_visible` rename. This fixes that.