### PR TITLE
Temporarily remove iOS from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,13 +36,13 @@ matrix:
       os: osx
       rust: stable
 
-    # iOS
-    - env: TARGET=x86_64-apple-ios
-      os: osx
-      rust: nightly
-    - env: TARGET=x86_64-apple-ios
-      os: osx
-      rust: stable
+    # # iOS
+    # - env: TARGET=x86_64-apple-ios
+    #   os: osx
+    #   rust: nightly
+    # - env: TARGET=x86_64-apple-ios
+    #   os: osx
+    #   rust: stable
 
 addons:
   apt:
@@ -69,7 +69,7 @@ after_success:
         [ $TRAVIS_BRANCH = master ] &&
         [ $TRAVIS_PULL_REQUEST = false ] && {
             cd glutin
-            for crate in ../glutin_*_sys; do 
+            for crate in ../glutin_*_sys; do
                 cd "$crate"
                 cargo publish --token ${CRATESIO_TOKEN_GENTZ}
             done


### PR DESCRIPTION
Similarly to how we're removing CircleCI from Winit while we don't have working backends. The failing iOS build is preventing the release of Glutin's new version, so this removes it from the CI.