### PR TITLE
Add better attribute handling for sRGB in WGL

### DIFF
--- a/glutin/src/api/wgl/mod.rs
+++ b/glutin/src/api/wgl/mod.rs
@@ -701,26 +701,28 @@ unsafe fn choose_arb_pixel_format_id(
         out.push(gl::wgl_extra::STEREO_ARB as raw::c_int);
         out.push(if pf_reqs.stereoscopy { 1 } else { 0 });
 
-        if pf_reqs.srgb {
-            if extensions
-                .split(' ')
-                .find(|&i| i == "WGL_ARB_framebuffer_sRGB")
-                .is_some()
-            {
-                out.push(
-                    gl::wgl_extra::FRAMEBUFFER_SRGB_CAPABLE_ARB as raw::c_int,
-                );
-                out.push(1);
-            } else if extensions
-                .split(' ')
-                .find(|&i| i == "WGL_EXT_framebuffer_sRGB")
-                .is_some()
-            {
-                out.push(
-                    gl::wgl_extra::FRAMEBUFFER_SRGB_CAPABLE_EXT as raw::c_int,
-                );
-                out.push(1);
-            } else {
+        // WGL_*_FRAMEBUFFER_SRGB might be assumed to be true if not listed;
+        // so it's best to list it out and set its value as necessary.
+        if extensions
+            .split(' ')
+            .find(|&i| i == "WGL_ARB_framebuffer_sRGB")
+            .is_some()
+        {
+            out.push(
+                gl::wgl_extra::FRAMEBUFFER_SRGB_CAPABLE_ARB as raw::c_int,
+            );
+            out.push(pf_reqs.srgb as raw::c_int);
+        } else if extensions
+            .split(' ')
+            .find(|&i| i == "WGL_EXT_framebuffer_sRGB")
+            .is_some()
+        {
+            out.push(
+                gl::wgl_extra::FRAMEBUFFER_SRGB_CAPABLE_EXT as raw::c_int,
+            );
+            out.push(pf_reqs.srgb as raw::c_int);
+        } else {
+            if pf_reqs.srgb {
                 return Err(());
             }
         }

--- a/glutin/src/api/wgl/mod.rs
+++ b/glutin/src/api/wgl/mod.rs
@@ -721,10 +721,8 @@ unsafe fn choose_arb_pixel_format_id(
                 gl::wgl_extra::FRAMEBUFFER_SRGB_CAPABLE_EXT as raw::c_int,
             );
             out.push(pf_reqs.srgb as raw::c_int);
-        } else {
-            if pf_reqs.srgb {
-                return Err(());
-            }
+        } else if pf_reqs.srgb {
+            return Err(());
         }
 
         match pf_reqs.release_behavior {


### PR DESCRIPTION
Based on a discussion in #1175 , this PR changes `choose_pixel_format_id` to ensure that the right extension for SRGB is always added to the descriptor, and its value is set according to the `with_srgb` parameter supplied by the user.

Tested on Windows 10 x64; no warnings/errors reported.