### PR TITLE
Get iOS compiling again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,13 +36,13 @@ matrix:
       os: osx
       rust: stable
 
-    # # iOS
-    # - env: TARGET=x86_64-apple-ios
-    #   os: osx
-    #   rust: nightly
-    # - env: TARGET=x86_64-apple-ios
-    #   os: osx
-    #   rust: stable
+    # iOS
+    - env: TARGET=x86_64-apple-ios
+      os: osx
+      rust: nightly
+    - env: TARGET=x86_64-apple-ios
+      os: osx
+      rust: stable
 
 addons:
   apt:

--- a/glutin/src/api/ios/mod.rs
+++ b/glutin/src/api/ios/mod.rs
@@ -205,7 +205,7 @@ impl Context {
         let win = builder.build(el)?;
         let context = unsafe {
             let eagl_context = Context::create_context(version)?;
-            let view = win.uiview() as ffi::id;
+            let view = win.ui_view() as ffi::id;
             let mut context = Context { eagl_context, view };
             context.init_context(&win);
             context
@@ -221,7 +221,7 @@ impl Context {
         size: dpi::PhysicalSize,
     ) -> Result<Self, CreationError> {
         let wb = winit::window::WindowBuilder::new()
-            .with_visibility(false)
+            .with_visible(false)
             .with_inner_size(size.to_logical(1.));
         Self::new_windowed(wb, el, pf_reqs, gl_attr)
             .map(|(_window, context)| context)

--- a/glutin/src/platform/mod.rs
+++ b/glutin/src/platform/mod.rs
@@ -21,6 +21,15 @@ pub mod unix;
 pub mod windows;
 /// Platform-specific methods for desktop operating systems.
 pub mod desktop {
+    #![cfg(any(
+        target_os = "windows",
+        target_os = "macos",
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    ))]
     pub use winit::platform::desktop::*;
 }
 


### PR DESCRIPTION
Seeing as there is noone else around with iOS to work on https://github.com/rust-windowing/glutin/issues/1170 and its blocking gfx from using winit 0.20 and I dont have access to iOS

Its time for everyones favorite development technique.
...
Throwing code at CI until it compiles.