### PR TITLE
Damaged buffer swap

### DIFF
--- a/glutin/src/api/android/mod.rs
+++ b/glutin/src/api/android/mod.rs
@@ -188,6 +188,11 @@ impl Context {
     }
 
     #[inline]
+    pub fn swap_buffers_with_damage_supported(&self) -> bool {
+        self.0.egl_context.swap_buffers_with_damage_supported()
+    }
+
+    #[inline]
     pub fn get_api(&self) -> Api {
         self.0.egl_context.get_api()
     }

--- a/glutin/src/api/android/mod.rs
+++ b/glutin/src/api/android/mod.rs
@@ -5,7 +5,7 @@ use crate::api::egl::{
 };
 use crate::CreationError::{self, OsError};
 use crate::{
-    Api, ContextError, GlAttributes, PixelFormat, PixelFormatRequirements,
+    Api, ContextError, GlAttributes, PixelFormat, PixelFormatRequirements, Rect,
 };
 
 use winit::window::WindowBuilder;
@@ -174,6 +174,17 @@ impl Context {
             }
         }
         self.0.egl_context.swap_buffers()
+    }
+
+    #[inline]
+    pub fn swap_buffers_with_damage(&self, rects: &[Rect]) -> Result<(), ContextError> {
+        if let Some(ref stopped) = self.0.stopped {
+            let stopped = stopped.lock();
+            if *stopped {
+                return Err(ContextError::ContextLost);
+            }
+        }
+        self.0.egl_context.swap_buffers_with_damage(rects)
     }
 
     #[inline]

--- a/glutin/src/api/dlloader.rs
+++ b/glutin/src/api/dlloader.rs
@@ -20,7 +20,7 @@ pub struct SymWrapper<T> {
 }
 
 pub trait SymTrait {
-    fn load_with<F>(loadfn: F) -> Self
+    fn load_with<F>(lib: &Library, loadfn: F) -> Self
     where
         F: FnMut(&'static str) -> *const std::os::raw::c_void;
 }
@@ -31,7 +31,7 @@ impl<T: SymTrait> SymWrapper<T> {
             let lib = Library::new(path);
             if lib.is_ok() {
                 return Ok(SymWrapper {
-                    inner: T::load_with(|sym| unsafe {
+                    inner: T::load_with(lib.as_ref().unwrap(), |sym| unsafe {
                         lib.as_ref()
                             .unwrap()
                             .get(

--- a/glutin/src/api/dlloader.rs
+++ b/glutin/src/api/dlloader.rs
@@ -9,7 +9,6 @@
 
 use libloading::Library;
 
-use std::ffi::CString;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
@@ -20,9 +19,7 @@ pub struct SymWrapper<T> {
 }
 
 pub trait SymTrait {
-    fn load_with<F>(lib: &Library, loadfn: F) -> Self
-    where
-        F: FnMut(&'static str) -> *const std::os::raw::c_void;
+    fn load_with(lib: &Library) -> Self;
 }
 
 impl<T: SymTrait> SymWrapper<T> {
@@ -31,17 +28,7 @@ impl<T: SymTrait> SymWrapper<T> {
             let lib = Library::new(path);
             if lib.is_ok() {
                 return Ok(SymWrapper {
-                    inner: T::load_with(lib.as_ref().unwrap(), |sym| unsafe {
-                        lib.as_ref()
-                            .unwrap()
-                            .get(
-                                CString::new(sym.as_bytes())
-                                    .unwrap()
-                                    .as_bytes_with_nul(),
-                            )
-                            .map(|sym| *sym)
-                            .unwrap_or(std::ptr::null_mut())
-                    }),
+                    inner: T::load_with(lib.as_ref().unwrap()),
                     _lib: Arc::new(lib.unwrap()),
                 });
             }

--- a/glutin/src/api/egl/mod.rs
+++ b/glutin/src/api/egl/mod.rs
@@ -14,12 +14,29 @@ mod egl {
     use super::ffi;
     use crate::api::dlloader::{SymTrait, SymWrapper};
     use libloading;
+    use std::sync::{Arc, Mutex};
+
+    #[cfg(unix)]
+    use libloading::os::unix as libloading_os;
+    #[cfg(windows)]
+    use libloading::os::windows as libloading_os;
 
     #[derive(Clone)]
     pub struct Egl(pub SymWrapper<ffi::egl::Egl>);
 
     /// Because `*const raw::c_void` doesn't implement `Sync`.
     unsafe impl Sync for Egl {}
+
+    type EglGetProcAddressType = libloading_os::Symbol<
+        unsafe extern "C" fn(
+            *const std::os::raw::c_void,
+        ) -> *const std::os::raw::c_void,
+    >;
+
+    lazy_static! {
+        static ref EGL_GET_PROC_ADDRESS: Arc<Mutex<Option<EglGetProcAddressType>>> =
+            Arc::new(Mutex::new(None));
+    }
 
     impl SymTrait for ffi::egl::Egl {
         fn load_with(lib: &libloading::Library) -> Self {
@@ -37,27 +54,32 @@ mod egl {
                     Err(_) => (),
                 };
 
-                // The symbol was not available in the library, so ask
-                // eglGetProcAddress for it. Note that eglGetProcAddress was
-                // only able to look up extension functions prior to EGL 1.5,
-                // hence this two-part dance.
-                match unsafe { lib.get(b"eglGetProcAddress") } {
-                    Ok(sym) => {
+                let mut egl_get_proc_address =
+                    (*EGL_GET_PROC_ADDRESS).lock().unwrap();
+                if egl_get_proc_address.is_none() {
+                    unsafe {
                         let sym: libloading::Symbol<
                             unsafe extern "C" fn(
                                 *const std::os::raw::c_void,
                             )
                                 -> *const std::os::raw::c_void,
-                        > = sym;
-                        unsafe {
-                            sym(std::ffi::CString::new(s.as_bytes())
-                                .unwrap()
-                                .as_bytes_with_nul()
-                                .as_ptr()
-                                as *const std::os::raw::c_void)
-                        }
+                        > = lib.get(b"eglGetProcAddress").unwrap();
+                        *egl_get_proc_address = Some(sym.into_raw());
                     }
-                    Err(_) => std::ptr::null(),
+                }
+
+                // The symbol was not available in the library, so ask
+                // eglGetProcAddress for it. Note that eglGetProcAddress was
+                // only able to look up extension functions prior to EGL 1.5,
+                // hence this two-part dance.
+                unsafe {
+                    (egl_get_proc_address.as_ref().unwrap())(
+                        std::ffi::CString::new(s.as_bytes())
+                            .unwrap()
+                            .as_bytes_with_nul()
+                            .as_ptr()
+                            as *const std::os::raw::c_void,
+                    )
                 }
             };
 

--- a/glutin/src/api/egl/mod.rs
+++ b/glutin/src/api/egl/mod.rs
@@ -52,22 +52,16 @@ mod egl {
                             )
                                 -> *const std::os::raw::c_void,
                         > = sym;
-                        let ptr = unsafe {
+                        unsafe {
                             sym(std::ffi::CString::new(s.as_bytes())
                                 .unwrap()
                                 .as_bytes_with_nul()
                                 .as_ptr()
                                 as *const std::os::raw::c_void)
-                        };
-                        if ptr.is_null() {
-                            panic!("unable to load symbol {:}", s)
                         }
-                        return ptr;
                     }
-                    Err(_) => (),
-                };
-
-                std::ptr::null()
+                    Err(_) => std::ptr::null(),
+                }
             };
 
             Self::load_with(f)

--- a/glutin/src/api/egl/mod.rs
+++ b/glutin/src/api/egl/mod.rs
@@ -22,10 +22,7 @@ mod egl {
     unsafe impl Sync for Egl {}
 
     impl SymTrait for ffi::egl::Egl {
-        fn load_with<F>(lib: &libloading::Library, _: F) -> Self
-        where
-            F: FnMut(&'static str) -> *const std::os::raw::c_void,
-        {
+        fn load_with(lib: &libloading::Library) -> Self {
             let f = move |s: &'static str| -> *const std::os::raw::c_void {
                 // Check if the symbol is available in the library directly. If
                 // it is, just return it.

--- a/glutin/src/api/egl/mod.rs
+++ b/glutin/src/api/egl/mod.rs
@@ -722,6 +722,12 @@ impl Context {
     }
 
     #[inline]
+    pub fn swap_buffers_with_damage_supported(&self) -> bool {
+        let egl = EGL.as_ref().unwrap();
+        egl.SwapBuffersWithDamageKHR.is_loaded()
+    }
+
+    #[inline]
     pub fn get_pixel_format(&self) -> PixelFormat {
         self.pixel_format.clone()
     }

--- a/glutin/src/api/glx/mod.rs
+++ b/glutin/src/api/glx/mod.rs
@@ -19,7 +19,7 @@ mod glx {
     unsafe impl Sync for Glx {}
 
     impl SymTrait for ffi::glx::Glx {
-        fn load_with<F>(loadfn: F) -> Self
+        fn load_with<F>(_: &libloading::Library, loadfn: F) -> Self
         where
             F: FnMut(&'static str) -> *const std::os::raw::c_void,
         {

--- a/glutin/src/api/glx/mod.rs
+++ b/glutin/src/api/glx/mod.rs
@@ -19,11 +19,16 @@ mod glx {
     unsafe impl Sync for Glx {}
 
     impl SymTrait for ffi::glx::Glx {
-        fn load_with<F>(_: &libloading::Library, loadfn: F) -> Self
-        where
-            F: FnMut(&'static str) -> *const std::os::raw::c_void,
-        {
-            Self::load_with(loadfn)
+        fn load_with(lib: &libloading::Library) -> Self {
+            Self::load_with(|sym| unsafe {
+                lib.get(
+                        std::ffi::CString::new(sym.as_bytes())
+                            .unwrap()
+                            .as_bytes_with_nul(),
+                    )
+                    .map(|sym| *sym)
+                    .unwrap_or(std::ptr::null_mut())
+            })
         }
     }
 

--- a/glutin/src/api/ios/mod.rs
+++ b/glutin/src/api/ios/mod.rs
@@ -63,7 +63,7 @@
 use crate::platform::ios::{WindowBuilderExtIOS, WindowExtIOS};
 use crate::{
     Api, ContextError, CreationError, GlAttributes, GlRequest, PixelFormat,
-    PixelFormatRequirements,
+    PixelFormatRequirements, Rect,
 };
 
 use winit::window::WindowBuilder;
@@ -325,6 +325,14 @@ impl Context {
                 )))
             }
         }
+    }
+
+    #[inline]
+    pub fn swap_buffers_with_damage(
+        &self,
+        rects: &[Rect],
+    ) -> Result<(), ContextError> {
+        Err(ContextError::OsError("buffer damage not suported".to_string()))
     }
 
     #[inline]

--- a/glutin/src/api/ios/mod.rs
+++ b/glutin/src/api/ios/mod.rs
@@ -336,6 +336,11 @@ impl Context {
     }
 
     #[inline]
+    pub fn swap_buffers_with_damage_supported(&self) -> bool {
+        false
+    }
+
+    #[inline]
     pub fn get_pixel_format(&self) -> PixelFormat {
         let color_format = ColorFormat::for_view(self.view);
         PixelFormat {

--- a/glutin/src/lib.rs
+++ b/glutin/src/lib.rs
@@ -754,7 +754,6 @@ impl<S> Default for GlAttributes<S> {
 }
 
 // Rectangles to submit as buffer damage.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Rect {
     pub x: u32,

--- a/glutin/src/lib.rs
+++ b/glutin/src/lib.rs
@@ -404,6 +404,7 @@ pub enum ContextError {
     OsError(String),
     IoError(io::Error),
     ContextLost,
+    FunctionUnavailable,
 }
 
 impl ContextError {
@@ -413,6 +414,7 @@ impl ContextError {
             ContextError::OsError(ref string) => string,
             ContextError::IoError(ref err) => err.description(),
             ContextError::ContextLost => "Context lost",
+            ContextError::FunctionUnavailable => "Function unavailable",
         }
     }
 }
@@ -749,4 +751,14 @@ impl<S> Default for GlAttributes<S> {
             vsync: false,
         }
     }
+}
+
+// Rectangles to submit as buffer damage.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Rect {
+    pub x: u32,
+    pub y: u32,
+    pub width: u32,
+    pub height: u32,
 }

--- a/glutin/src/platform_impl/emscripten/mod.rs
+++ b/glutin/src/platform_impl/emscripten/mod.rs
@@ -169,6 +169,11 @@ impl Context {
     }
 
     #[inline]
+    pub fn swap_buffers_with_damage_supported(&self) -> bool {
+        false
+    }
+
+    #[inline]
     pub fn get_pixel_format(&self) -> PixelFormat {
         // FIXME: this is a dummy pixel format
         PixelFormat {

--- a/glutin/src/platform_impl/emscripten/mod.rs
+++ b/glutin/src/platform_impl/emscripten/mod.rs
@@ -161,6 +161,14 @@ impl Context {
     }
 
     #[inline]
+    pub fn swap_buffers_with_damage(
+        &self,
+        rects: &[Rect],
+    ) -> Result<(), ContextError> {
+        Err(ContextError::OsError("buffer damage not suported".to_string()))
+    }
+
+    #[inline]
     pub fn get_pixel_format(&self) -> PixelFormat {
         // FIXME: this is a dummy pixel format
         PixelFormat {

--- a/glutin/src/platform_impl/macos/mod.rs
+++ b/glutin/src/platform_impl/macos/mod.rs
@@ -298,6 +298,11 @@ impl Context {
     }
 
     #[inline]
+    pub fn swap_buffers_with_damage_supported(&self) -> bool {
+        false
+    }
+
+    #[inline]
     pub fn get_api(&self) -> crate::Api {
         crate::Api::OpenGl
     }

--- a/glutin/src/platform_impl/macos/mod.rs
+++ b/glutin/src/platform_impl/macos/mod.rs
@@ -1,7 +1,7 @@
 #![cfg(target_os = "macos")]
 use crate::{
     ContextError, CreationError, GlAttributes, PixelFormat,
-    PixelFormatRequirements, Robustness,
+    PixelFormatRequirements, Robustness, Rect,
 };
 
 use cgl::{
@@ -287,6 +287,14 @@ impl Context {
             }
         }
         Ok(())
+    }
+
+    #[inline]
+    pub fn swap_buffers_with_damage(
+        &self,
+        rects: &[Rect],
+    ) -> Result<(), ContextError> {
+        Err(ContextError::OsError("buffer damage not suported".to_string()))
     }
 
     #[inline]

--- a/glutin/src/platform_impl/unix/mod.rs
+++ b/glutin/src/platform_impl/unix/mod.rs
@@ -13,7 +13,7 @@ use self::x11::X11Context;
 use crate::api::osmesa;
 use crate::{
     Api, ContextCurrentState, ContextError, CreationError, GlAttributes,
-    NotCurrent, PixelFormat, PixelFormatRequirements,
+    NotCurrent, PixelFormat, PixelFormatRequirements, Rect,
 };
 pub use x11::utils as x11_utils;
 
@@ -232,6 +232,18 @@ impl Context {
         match *self {
             Context::X11(ref ctx) => ctx.swap_buffers(),
             Context::Wayland(ref ctx) => ctx.swap_buffers(),
+            _ => unreachable!(),
+        }
+    }
+
+    #[inline]
+    pub fn swap_buffers_with_damage(
+        &self,
+        rects: &[Rect],
+    ) -> Result<(), ContextError> {
+        match *self {
+            Context::X11(ref ctx) => ctx.swap_buffers_with_damage(rects),
+            Context::Wayland(ref ctx) => ctx.swap_buffers_with_damage(rects),
             _ => unreachable!(),
         }
     }

--- a/glutin/src/platform_impl/unix/mod.rs
+++ b/glutin/src/platform_impl/unix/mod.rs
@@ -249,6 +249,15 @@ impl Context {
     }
 
     #[inline]
+    pub fn swap_buffers_with_damage_supported(&self) -> bool {
+        match *self {
+            Context::X11(ref ctx) => ctx.swap_buffers_with_damage_supported(),
+            Context::Wayland(ref ctx) => ctx.swap_buffers_with_damage_supported(),
+            _ => unreachable!(),
+        }
+    }
+
+    #[inline]
     pub fn get_pixel_format(&self) -> PixelFormat {
         match *self {
             Context::X11(ref ctx) => ctx.get_pixel_format(),

--- a/glutin/src/platform_impl/unix/wayland.rs
+++ b/glutin/src/platform_impl/unix/wayland.rs
@@ -3,7 +3,7 @@ use crate::api::egl::{
 };
 use crate::{
     ContextError, CreationError, GlAttributes, PixelFormat,
-    PixelFormatRequirements,
+    PixelFormatRequirements, Rect,
 };
 
 use crate::platform::unix::{EventLoopWindowTargetExtUnix, WindowExtUnix};
@@ -201,6 +201,14 @@ impl Context {
     #[inline]
     pub fn swap_buffers(&self) -> Result<(), ContextError> {
         (**self).swap_buffers()
+    }
+
+    #[inline]
+    pub fn swap_buffers_with_damage(
+        &self,
+        rects: &[Rect],
+    ) -> Result<(), ContextError> {
+        (**self).swap_buffers_with_damage(rects)
     }
 
     #[inline]

--- a/glutin/src/platform_impl/unix/wayland.rs
+++ b/glutin/src/platform_impl/unix/wayland.rs
@@ -212,6 +212,11 @@ impl Context {
     }
 
     #[inline]
+    pub fn swap_buffers_with_damage_supported(&self) -> bool {
+        (**self).swap_buffers_with_damage_supported()
+    }
+
+    #[inline]
     pub fn get_pixel_format(&self) -> PixelFormat {
         (**self).get_pixel_format().clone()
     }

--- a/glutin/src/platform_impl/unix/x11.rs
+++ b/glutin/src/platform_impl/unix/x11.rs
@@ -10,7 +10,7 @@ use crate::platform::unix::{
 use crate::platform_impl::x11_utils;
 use crate::{
     Api, ContextError, CreationError, GlAttributes, GlRequest, PixelFormat,
-    PixelFormatRequirements,
+    PixelFormatRequirements, Rect,
 };
 
 use glutin_glx_sys as ffi;
@@ -667,6 +667,19 @@ impl Context {
         match self.context {
             X11Context::Glx(ref ctx) => ctx.swap_buffers(),
             X11Context::Egl(ref ctx) => ctx.swap_buffers(),
+        }
+    }
+
+    #[inline]
+    pub fn swap_buffers_with_damage(
+        &self,
+        rects: &[Rect],
+    ) -> Result<(), ContextError> {
+        match self.context {
+            X11Context::Glx(_) => Err(ContextError::OsError(
+                "buffer damage not suported".to_string(),
+            )),
+            X11Context::Egl(ref ctx) => ctx.swap_buffers_with_damage(rects),
         }
     }
 

--- a/glutin/src/platform_impl/unix/x11.rs
+++ b/glutin/src/platform_impl/unix/x11.rs
@@ -684,6 +684,14 @@ impl Context {
     }
 
     #[inline]
+    pub fn swap_buffers_with_damage_supported(&self) -> bool {
+        match self.context {
+            X11Context::Glx(_) => false,
+            X11Context::Egl(ref ctx) => ctx.swap_buffers_with_damage_supported(),
+        }
+    }
+
+    #[inline]
     pub fn get_pixel_format(&self) -> PixelFormat {
         match self.context {
             X11Context::Glx(ref ctx) => ctx.get_pixel_format(),

--- a/glutin/src/platform_impl/windows/mod.rs
+++ b/glutin/src/platform_impl/windows/mod.rs
@@ -268,6 +268,11 @@ impl Context {
     }
 
     #[inline]
+    pub fn swap_buffers_with_damage_supported(&self) -> bool {
+        false
+    }
+
+    #[inline]
     pub fn get_api(&self) -> Api {
         match *self {
             Context::Wgl(ref c) | Context::HiddenWindowWgl(_, ref c) => {

--- a/glutin/src/platform_impl/windows/mod.rs
+++ b/glutin/src/platform_impl/windows/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     Api, ContextCurrentState, ContextError, CreationError, GlAttributes,
-    GlRequest, NotCurrent, PixelFormat, PixelFormatRequirements,
+    GlRequest, NotCurrent, PixelFormat, PixelFormatRequirements, Rect,
 };
 
 use crate::api::egl::{
@@ -257,6 +257,14 @@ impl Context {
             Context::Egl(ref c) => c.swap_buffers(),
             _ => unreachable!(),
         }
+    }
+
+    #[inline]
+    pub fn swap_buffers_with_damage(
+        &self,
+        rects: &[Rect],
+    ) -> Result<(), ContextError> {
+        Err(ContextError::OsError("buffer damage not suported".to_string()))
     }
 
     #[inline]

--- a/glutin/src/windowed.rs
+++ b/glutin/src/windowed.rs
@@ -136,6 +136,23 @@ impl<W> ContextWrapper<PossiblyCurrent, W> {
         self.context.context.swap_buffers()
     }
 
+    /// Swaps the buffers in case of double or triple buffering using specified
+    /// damage rects.
+    ///
+    /// You should call this function every time you have finished rendering, or
+    /// the image may not be displayed on the screen.
+    ///
+    /// **Warning**: if you enabled vsync, this function will block until the
+    /// next time the screen is refreshed. However drivers can choose to
+    /// override your vsync settings, which means that you can't know in
+    /// advance whether `swap_buffers` will block or not.
+    pub fn swap_buffers_with_damage(
+        &self,
+        rects: &[Rect],
+    ) -> Result<(), ContextError> {
+        self.context.context.swap_buffers_with_damage(rects)
+    }
+
     /// Returns the pixel format of the main framebuffer of the context.
     pub fn get_pixel_format(&self) -> PixelFormat {
         self.context.context.get_pixel_format()

--- a/glutin/src/windowed.rs
+++ b/glutin/src/windowed.rs
@@ -153,6 +153,9 @@ impl<W> ContextWrapper<PossiblyCurrent, W> {
         self.context.context.swap_buffers_with_damage(rects)
     }
 
+    /// Returns whether or not swap_buffer_with_damage is available. If this
+    /// function returns false, any call to swap_buffers_with_damage will
+    /// return an error.
     pub fn swap_buffers_with_damage_supported(&self) -> bool {
         self.context.context.swap_buffers_with_damage_supported()
     }

--- a/glutin/src/windowed.rs
+++ b/glutin/src/windowed.rs
@@ -153,6 +153,10 @@ impl<W> ContextWrapper<PossiblyCurrent, W> {
         self.context.context.swap_buffers_with_damage(rects)
     }
 
+    pub fn swap_buffers_with_damage_supported(&self) -> bool {
+        self.context.context.swap_buffers_with_damage_supported()
+    }
+
     /// Returns the pixel format of the main framebuffer of the context.
     pub fn get_pixel_format(&self) -> PixelFormat {
         self.context.context.get_pixel_format()

--- a/glutin_egl_sys/build.rs
+++ b/glutin_egl_sys/build.rs
@@ -37,6 +37,7 @@ fn main() {
                 "EGL_MESA_platform_gbm",
                 "EGL_EXT_platform_wayland",
                 "EGL_EXT_platform_device",
+                "EGL_KHR_swap_buffers_with_damage",
             ],
         );
 

--- a/glutin_examples/examples/damage.rs
+++ b/glutin_examples/examples/damage.rs
@@ -1,0 +1,97 @@
+mod support;
+
+use glutin::event::{Event, WindowEvent};
+use glutin::event_loop::{ControlFlow, EventLoop};
+use glutin::window::WindowBuilder;
+use glutin::ContextBuilder;
+use glutin::Rect;
+
+struct Color {
+    red: f32,
+    green: f32,
+    blue: f32,
+}
+
+impl Color {
+    fn new() -> Color {
+        Color {
+            red: 1.0,
+            green: 0.5,
+            blue: 0.0,
+        }
+    }
+    fn next(&self) -> Color {
+        Color {
+            red: if self.red >= 1.0 { 0.0 } else { self.red + 0.01 },
+            green: if self.green >= 1.0 { 0.0 } else { self.green + 0.01 },
+            blue: if self.blue >= 1.0 { 0.0 } else { self.blue + 0.01 },
+        }
+    }
+}
+
+fn main() {
+    let el = EventLoop::new();
+    let wb = WindowBuilder::new().with_title("A fantastic window!");
+
+    let windowed_context =
+        ContextBuilder::new().build_windowed(wb, &el).unwrap();
+
+    let windowed_context = unsafe { windowed_context.make_current().unwrap() };
+
+    println!(
+        "Pixel format of the window's GL context: {:?}",
+        windowed_context.get_pixel_format()
+    );
+
+    let gl = support::load(&windowed_context.context());
+
+    let mut color = Color::new();
+
+    gl.draw_frame([color.red, color.green, color.blue, 1.0]);
+    windowed_context.swap_buffers().unwrap();
+
+    el.run(move |event, _, control_flow| {
+        println!("{:?}", event);
+        *control_flow = ControlFlow::Wait;
+
+        match event {
+            Event::LoopDestroyed => return,
+            Event::WindowEvent { ref event, .. } => match event {
+                WindowEvent::Resized(logical_size) => {
+                    let dpi_factor =
+                        windowed_context.window().hidpi_factor();
+                    windowed_context
+                        .resize(logical_size.to_physical(dpi_factor));
+                }
+                WindowEvent::CloseRequested => {
+                    *control_flow = ControlFlow::Exit
+                }
+                WindowEvent::CursorMoved{ .. } => {
+                    // Select a new color to render, draw and swap buffers.
+                    //
+                    // Note that damage is *intentionally* being misreported
+                    // here to display the effect of damage. All changes must
+                    // be covered by the reported damage, as the compositor is
+                    // free to read more from the buffer than damage was
+                    // reported, such as when windows unhide.
+                    //
+                    // However, here we only damage the lower left corner to
+                    // show that it is (usually) only the damage that gets
+                    // composited to screen.
+                    //
+                    // Panics if damage is not supported due to the unwrap.
+                    color = color.next();
+                    gl.draw_frame([color.red, color.green, color.blue, 1.0]);
+                    windowed_context.swap_buffers_with_damage(&[Rect{
+                        x: 0,
+                        y: 0,
+                        height: 100,
+                        width: 100,
+                    }]).unwrap();
+                }
+                _ => (),
+            },
+            _ => (),
+        }
+    });
+}

--- a/glutin_examples/examples/damage.rs
+++ b/glutin_examples/examples/damage.rs
@@ -38,6 +38,10 @@ fn main() {
 
     let windowed_context = unsafe { windowed_context.make_current().unwrap() };
 
+    if !windowed_context.swap_buffers_with_damage_supported() {
+        panic!("Damage not supported, this demo will instead perform full buffer swaps");
+    }
+
     println!(
         "Pixel format of the window's GL context: {:?}",
         windowed_context.get_pixel_format()
@@ -82,12 +86,16 @@ fn main() {
                     // Panics if damage is not supported due to the unwrap.
                     color = color.next();
                     gl.draw_frame([color.red, color.green, color.blue, 1.0]);
-                    windowed_context.swap_buffers_with_damage(&[Rect{
-                        x: 0,
-                        y: 0,
-                        height: 100,
-                        width: 100,
-                    }]).unwrap();
+                    if windowed_context.swap_buffers_with_damage_supported() {
+                        windowed_context.swap_buffers_with_damage(&[Rect{
+                            x: 0,
+                            y: 0,
+                            height: 100,
+                            width: 100,
+                        }]).unwrap();
+                    } else {
+                        windowed_context.swap_buffers().unwrap();
+                    }
                 }
                 _ => (),
             },

--- a/glutin_examples/examples/damage.rs
+++ b/glutin_examples/examples/damage.rs
@@ -39,7 +39,7 @@ fn main() {
     let windowed_context = unsafe { windowed_context.make_current().unwrap() };
 
     if !windowed_context.swap_buffers_with_damage_supported() {
-        panic!("Damage not supported, this demo will instead perform full buffer swaps");
+        panic!("Damage not supported!");
     }
 
     println!(


### PR DESCRIPTION
Implement damaged buffer swap for EGL.

This allows compositors to do significantly less work, especially for very large window buffers with small changes (think blinking cursor in a large window on a 4k display). It can theoretically also be used to aid screencopy, such as remote desktop-like scenarios (waypipe, rdp, vnc, ...).

On Wayland, clients are expected to always report correct damage, so this allows for glutin consumers to follow suit.

A version of this on the backport21 branch is used by this WIP PR for alacritty: https://github.com/jwilm/alacritty/pull/2724.

Outstanding:
- Should we communicate damage support separately, or just let clients try and see?
- Only EGL is implemented, and only Wayland has been tested. Do we have other platforms that also support damage that we wish to integrate?