### PR TITLE
MacOSX's raw_handle trait method returns CGLContext object

### DIFF
--- a/glutin/src/platform_impl/macos/mod.rs
+++ b/glutin/src/platform_impl/macos/mod.rs
@@ -317,9 +317,13 @@ impl Context {
 
     #[inline]
     pub unsafe fn raw_handle(&self) -> *mut raw::c_void {
-        match *self {
-            Context::WindowedContext(ref c) => *c.context.deref() as *mut _,
-            Context::HeadlessContext(ref c) => *c.context.deref() as *mut _,
+        match self {
+            Context::WindowedContext(c) => {
+                c.context.deref().CGLContextObj() as *mut _
+            }
+            Context::HeadlessContext(c) => {
+                c.context.deref().CGLContextObj() as *mut _
+            }
         }
     }
 


### PR DESCRIPTION
Righ now MacOS' raw_handler() from ContextTraitExt returns NSOpenGLContext object, from cocoa-rs appkit. It's address is not useful for sharing the real GL context address, which is a CGLContextObj.

This patch propose to return the return value of CGLContextObj() 