### PR TITLE
Disable caching on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: rust
 
-cache: cargo
-
 matrix:
   include:
     # Linux 32bit


### PR DESCRIPTION
Travis builds are stalling due to the caches growing too large. See rust-windowing/winit#918 for the same issue in the winit repository. This pull request solves the problem by disabling caching.