### PR TITLE
Changed type of vsync from bool to Option<bool>

### DIFF
--- a/glutin/src/api/glx/mod.rs
+++ b/glutin/src/api/glx/mod.rs
@@ -413,51 +413,53 @@ impl<'a> ContextPrototype<'a> {
         let (extra_functions, context) = self.create_context()?;
 
         // vsync
-        if self.opengl.vsync {
-            let _guard = MakeCurrentGuard::new(&self.xconn, window, context)
-                .map_err(|err| CreationError::OsError(err))?;
+        if let Some(vsync) = self.opengl.vsync {
+            if vsync {
+                let _guard = MakeCurrentGuard::new(&self.xconn, window, context)
+                    .map_err(|err| CreationError::OsError(err))?;
 
-            if check_ext(&self.extensions, "GLX_EXT_swap_control")
-                && extra_functions.SwapIntervalEXT.is_loaded()
-            {
-                // this should be the most common extension
-                unsafe {
-                    extra_functions.SwapIntervalEXT(
-                        self.xconn.display as *mut _,
-                        window,
-                        1,
-                    );
-                }
+                if check_ext(&self.extensions, "GLX_EXT_swap_control")
+                    && extra_functions.SwapIntervalEXT.is_loaded()
+                    {
+                        // this should be the most common extension
+                        unsafe {
+                            extra_functions.SwapIntervalEXT(
+                                self.xconn.display as *mut _,
+                                window,
+                                1,
+                                );
+                        }
 
-                let mut swap = unsafe { std::mem::zeroed() };
-                unsafe {
-                    glx.QueryDrawable(
-                        self.xconn.display as *mut _,
-                        window,
-                        ffi::glx_extra::SWAP_INTERVAL_EXT as i32,
-                        &mut swap,
-                    );
-                }
+                        let mut swap = unsafe { std::mem::zeroed() };
+                        unsafe {
+                            glx.QueryDrawable(
+                                self.xconn.display as *mut _,
+                                window,
+                                ffi::glx_extra::SWAP_INTERVAL_EXT as i32,
+                                &mut swap,
+                                );
+                        }
 
-                if swap != 1 {
-                    return Err(CreationError::OsError(format!("Couldn't setup vsync: expected interval `1` but got `{}`", swap)));
-                }
-            } else if check_ext(&self.extensions, "GLX_MESA_swap_control")
-                && extra_functions.SwapIntervalMESA.is_loaded()
-            {
-                unsafe {
-                    extra_functions.SwapIntervalMESA(1);
-                }
-            } else if check_ext(&self.extensions, "GLX_SGI_swap_control")
-                && extra_functions.SwapIntervalSGI.is_loaded()
-            {
-                unsafe {
-                    extra_functions.SwapIntervalSGI(1);
-                }
-            } else {
-                return Err(CreationError::OsError(
-                    "Couldn't find any available vsync extension".to_string(),
-                ));
+                        if swap != 1 {
+                            return Err(CreationError::OsError(format!("Couldn't setup vsync: expected interval `1` but got `{}`", swap)));
+                        }
+                    } else if check_ext(&self.extensions, "GLX_MESA_swap_control")
+                        && extra_functions.SwapIntervalMESA.is_loaded()
+                        {
+                            unsafe {
+                                extra_functions.SwapIntervalMESA(1);
+                            }
+                        } else if check_ext(&self.extensions, "GLX_SGI_swap_control")
+                            && extra_functions.SwapIntervalSGI.is_loaded()
+                            {
+                                unsafe {
+                                    extra_functions.SwapIntervalSGI(1);
+                                }
+                            } else {
+                                return Err(CreationError::OsError(
+                                        "Couldn't find any available vsync extension".to_string(),
+                                        ));
+                            }
             }
         }
 

--- a/glutin/src/lib.rs
+++ b/glutin/src/lib.rs
@@ -181,7 +181,7 @@ impl<'a, T: ContextCurrentState> ContextBuilder<'a, T> {
     ///
     /// By default, vsync is not enabled.
     #[inline]
-    pub fn with_vsync(mut self, vsync: bool) -> Self {
+    pub fn with_vsync(mut self, vsync: Option<bool>) -> Self {
         self.gl_attr.vsync = vsync;
         self
     }
@@ -705,7 +705,7 @@ pub struct GlAttributes<S> {
     /// screen tearing.
     ///
     /// The default is `false`.
-    pub vsync: bool,
+    pub vsync: Option<bool>,
 }
 
 impl<S> GlAttributes<S> {
@@ -748,7 +748,7 @@ impl<S> Default for GlAttributes<S> {
             profile: None,
             debug: cfg!(debug_assertions),
             robustness: Robustness::NotRobust,
-            vsync: false,
+            vsync: Some(false),
         }
     }
 }


### PR DESCRIPTION
Hi,

This is to address issue #631 

I am not really sure about  glutin/src/api/egl/mod.rs line 1089, if the Option is none, should it be treated as if the bool was false? The comment `// VSync defaults to enabled; disable it if it was not requested.` seems to be at odds with the ones in lib.rs `/// By default, vsync is not enabled.