### PR TITLE
Update winit to winit-alpha4, update version in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Update winit dependency to 0.20.0-alpha4. See [winit's CHANGELOG](https://github.com/rust-windowing/winit/blob/master/CHANGELOG.md#0200-alpha-4) for more info.
+
 # Version 0.22.0-alpha2 (2019-08-15)
 
 - Fixed attribute handling for sRGB in WGL.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A low-level library for OpenGL context creation, written in pure Rust.
 
 ```toml
 [dependencies]
-glutin = "0.22.0-alpha2"
+glutin = "0.22.0-alpha3"
 ```
 
 ## [Documentation](https://docs.rs/glutin)

--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -18,7 +18,7 @@ serde = ["winit/serde"]
 
 [dependencies]
 lazy_static = "1.3"
-winit = "0.20.0-alpha3"
+winit = "0.20.0-alpha4"
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_glue = "0.2"

--- a/glutin_examples/Cargo.toml
+++ b/glutin_examples/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 
 [dependencies]
 glutin = { path = "../glutin" }
-winit = "0.20.0-alpha3"
+winit = "0.20.0-alpha4"
 takeable-option = "0.4"
 image = "0.21"
 


### PR DESCRIPTION
Winit has a new version released (alpha4) that has some bugfixes, no major API breaks. This PR simply updates the version in the README, CHANGELOG + Cargo.toml