### PR TITLE
Update android backend.

### DIFF
--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -18,10 +18,11 @@ serde = ["winit/serde"]
 
 [dependencies]
 lazy_static = "1.3"
-winit = "0.20.0-alpha4"
+winit = { git = "https://github.com/dvc94ch/winit", branch = "android" }
 
 [target.'cfg(target_os = "android")'.dependencies]
-android_glue = "0.2"
+android_glue = { git = "https://github.com/rust-windowing/android-rs-glue" }
+android-ndk = { git = "https://github.com/rust-windowing/android-ndk-rs" }
 glutin_egl_sys = { version = "0.1.4", path = "../glutin_egl_sys" }
 parking_lot = "0.9"
 

--- a/glutin/src/lib.rs
+++ b/glutin/src/lib.rs
@@ -744,7 +744,10 @@ impl<S> Default for GlAttributes<S> {
     fn default() -> GlAttributes<S> {
         GlAttributes {
             sharing: None,
+            #[cfg(not(target_os = "android"))]
             version: GlRequest::Latest,
+            #[cfg(target_os = "android")]
+            version: GlRequest::Specific(Api::OpenGlEs, (2, 0)),
             profile: None,
             debug: cfg!(debug_assertions),
             robustness: Robustness::NotRobust,

--- a/glutin_examples/Cargo.toml
+++ b/glutin_examples/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 
 [dependencies]
 glutin = { path = "../glutin" }
-winit = "0.20.0-alpha4"
+winit = { git = "https://github.com/dvc94ch/winit", branch = "android" }
 takeable-option = "0.4"
 image = "0.21"
 


### PR DESCRIPTION
This adds basic support for android to glutin. The android build failure is due a too old version of `cargo-apk`, the docker image needs to use https://github.com/rust-windowing/android-rs-glue/pull/256