### PR TITLE
Update to winit 0.20.0

### DIFF
--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -18,7 +18,7 @@ serde = ["winit/serde"]
 
 [dependencies]
 lazy_static = "1.3"
-winit = "=0.20.0-alpha4" #
+winit = "0.20.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_glue = "0.2"

--- a/glutin/src/api/android/mod.rs
+++ b/glutin/src/api/android/mod.rs
@@ -110,7 +110,7 @@ impl Context {
         _el: &EventLoopWindowTarget<T>,
         pf_reqs: &PixelFormatRequirements,
         gl_attr: &GlAttributes<&Context>,
-        size: dpi::PhysicalSize,
+        size: dpi::PhysicalSize<u32>,
     ) -> Result<Self, CreationError> {
         let gl_attr = gl_attr.clone().map_sharing(|c| &c.0.egl_context);
         let context = EglContext::new(

--- a/glutin/src/api/egl/mod.rs
+++ b/glutin/src/api/egl/mod.rs
@@ -956,7 +956,7 @@ impl<'a> ContextPrototype<'a> {
     ))]
     pub fn finish_pbuffer(
         self,
-        size: dpi::PhysicalSize,
+        size: dpi::PhysicalSize<u32>,
     ) -> Result<Context, CreationError> {
         let size: (u32, u32) = size.into();
 

--- a/glutin/src/api/glx/mod.rs
+++ b/glutin/src/api/glx/mod.rs
@@ -378,7 +378,7 @@ impl<'a> ContextPrototype<'a> {
 
     pub fn finish_pbuffer(
         self,
-        size: dpi::PhysicalSize,
+        size: dpi::PhysicalSize<u32>,
     ) -> Result<Context, CreationError> {
         let glx = GLX.as_ref().unwrap();
         let size: (u32, u32) = size.into();

--- a/glutin/src/api/ios/mod.rs
+++ b/glutin/src/api/ios/mod.rs
@@ -220,7 +220,7 @@ impl Context {
         el: &EventLoopWindowTarget<T>,
         pf_reqs: &PixelFormatRequirements,
         gl_attr: &GlAttributes<&Context>,
-        size: dpi::PhysicalSize,
+        size: dpi::PhysicalSize<u32>,
     ) -> Result<Self, CreationError> {
         let wb = winit::window::WindowBuilder::new()
             .with_visible(false)

--- a/glutin/src/api/ios/mod.rs
+++ b/glutin/src/api/ios/mod.rs
@@ -224,7 +224,7 @@ impl Context {
     ) -> Result<Self, CreationError> {
         let wb = winit::window::WindowBuilder::new()
             .with_visible(false)
-            .with_inner_size(size.to_logical(1.));
+            .with_inner_size(size);
         Self::new_windowed(wb, el, pf_reqs, gl_attr)
             .map(|(_window, context)| context)
     }
@@ -272,7 +272,7 @@ impl Context {
         self.make_current().unwrap();
 
         let view = self.view;
-        let scale_factor = win.hidpi_factor() as ffi::CGFloat;
+        let scale_factor = win.scale_factor() as ffi::CGFloat;
         let _: () = msg_send![view, setContentScaleFactor: scale_factor];
         let layer: ffi::id = msg_send![view, layer];
         let _: () = msg_send![layer, setContentsScale: scale_factor];

--- a/glutin/src/api/osmesa/mod.rs
+++ b/glutin/src/api/osmesa/mod.rs
@@ -71,7 +71,7 @@ impl OsMesaContext {
     pub fn new(
         _pf_reqs: &PixelFormatRequirements,
         opengl: &GlAttributes<&OsMesaContext>,
-        size: dpi::PhysicalSize,
+        size: dpi::PhysicalSize<u32>,
     ) -> Result<Self, CreationError> {
         osmesa_sys::OsMesa::try_loading()
             .map_err(LoadingError::new)

--- a/glutin/src/context.rs
+++ b/glutin/src/context.rs
@@ -175,7 +175,7 @@ impl<'a, T: ContextCurrentState> ContextBuilder<'a, T> {
     pub fn build_headless<TE>(
         self,
         el: &EventLoopWindowTarget<TE>,
-        size: dpi::PhysicalSize,
+        size: dpi::PhysicalSize<u32>,
     ) -> Result<Context<NotCurrent>, CreationError> {
         let ContextBuilder { pf_reqs, gl_attr } = self;
         let gl_attr = gl_attr.map_sharing(|ctx| &ctx.context);

--- a/glutin/src/platform_impl/emscripten/mod.rs
+++ b/glutin/src/platform_impl/emscripten/mod.rs
@@ -77,7 +77,7 @@ impl Context {
         el: &EventLoopWindowTarget<T>,
         pf_reqs: &PixelFormatRequirements,
         gl_attr: &GlAttributes<&Context>,
-        size: dpi::PhysicalSize,
+        size: dpi::PhysicalSize<u32>,
     ) -> Result<Self, CreationError> {
         let wb = winit::window::WindowBuilder::new()
             .with_visibility(false)

--- a/glutin/src/platform_impl/macos/mod.rs
+++ b/glutin/src/platform_impl/macos/mod.rs
@@ -168,7 +168,7 @@ impl Context {
         _el: &EventLoopWindowTarget<T>,
         pf_reqs: &PixelFormatRequirements,
         gl_attr: &GlAttributes<&Context>,
-        _size: dpi::PhysicalSize,
+        _size: dpi::PhysicalSize<u32>,
     ) -> Result<Self, CreationError> {
         let gl_profile = helpers::get_gl_profile(gl_attr, pf_reqs)?;
         let attributes = helpers::build_nsattributes(pf_reqs, gl_profile)?;

--- a/glutin/src/platform_impl/unix/mod.rs
+++ b/glutin/src/platform_impl/unix/mod.rs
@@ -122,7 +122,7 @@ impl Context {
         el: &EventLoopWindowTarget<T>,
         pf_reqs: &PixelFormatRequirements,
         gl_attr: &GlAttributes<&Context>,
-        size: dpi::PhysicalSize,
+        size: dpi::PhysicalSize<u32>,
     ) -> Result<Self, CreationError> {
         Self::new_headless_impl(el, pf_reqs, gl_attr, Some(size))
     }
@@ -131,7 +131,7 @@ impl Context {
         el: &EventLoopWindowTarget<T>,
         pf_reqs: &PixelFormatRequirements,
         gl_attr: &GlAttributes<&Context>,
-        size: Option<dpi::PhysicalSize>,
+        size: Option<dpi::PhysicalSize<u32>>,
     ) -> Result<Self, CreationError> {
         if el.is_wayland() {
             Context::is_compatible(&gl_attr.sharing, ContextType::Wayland)?;
@@ -283,7 +283,7 @@ pub trait HeadlessContextExt {
     /// [`Context`]: struct.Context.html
     fn build_osmesa(
         self,
-        size: dpi::PhysicalSize,
+        size: dpi::PhysicalSize<u32>,
     ) -> Result<crate::Context<NotCurrent>, CreationError>
     where
         Self: Sized;
@@ -309,7 +309,7 @@ impl<'a, T: ContextCurrentState> HeadlessContextExt
     #[inline]
     fn build_osmesa(
         self,
-        size: dpi::PhysicalSize,
+        size: dpi::PhysicalSize<u32>,
     ) -> Result<crate::Context<NotCurrent>, CreationError>
     where
         Self: Sized,

--- a/glutin/src/platform_impl/unix/wayland.rs
+++ b/glutin/src/platform_impl/unix/wayland.rs
@@ -52,7 +52,7 @@ impl Context {
         el: &EventLoopWindowTarget<T>,
         pf_reqs: &PixelFormatRequirements,
         gl_attr: &GlAttributes<&Context>,
-        size: Option<dpi::PhysicalSize>,
+        size: Option<dpi::PhysicalSize<u32>>,
     ) -> Result<Self, CreationError> {
         let gl_attr = gl_attr.clone().map_sharing(|c| &**c);
         let display_ptr = el.wayland_display().unwrap() as *const _;
@@ -93,8 +93,7 @@ impl Context {
     ) -> Result<(Window, Self), CreationError> {
         let win = wb.build(el)?;
 
-        let dpi_factor = win.hidpi_factor();
-        let size = win.inner_size().to_physical(dpi_factor);
+        let size = win.inner_size();
         let (width, height): (u32, u32) = size.into();
 
         let display_ptr = win.wayland_display().unwrap() as *const _;

--- a/glutin/src/platform_impl/unix/x11.rs
+++ b/glutin/src/platform_impl/unix/x11.rs
@@ -179,7 +179,7 @@ impl Context {
         el: &EventLoopWindowTarget<T>,
         pf_reqs: &PixelFormatRequirements,
         gl_attr: &GlAttributes<&Context>,
-        size: Option<dpi::PhysicalSize>,
+        size: Option<dpi::PhysicalSize<u32>>,
     ) -> Result<Self, CreationError> {
         Self::try_then_fallback(|fallback| {
             Self::new_headless_impl(
@@ -196,7 +196,7 @@ impl Context {
         el: &EventLoopWindowTarget<T>,
         pf_reqs: &PixelFormatRequirements,
         gl_attr: &GlAttributes<&Context>,
-        size: Option<dpi::PhysicalSize>,
+        size: Option<dpi::PhysicalSize<u32>>,
         fallback: bool,
     ) -> Result<Self, CreationError> {
         let xconn = match el.xlib_xconnection() {

--- a/glutin/src/platform_impl/windows/mod.rs
+++ b/glutin/src/platform_impl/windows/mod.rs
@@ -150,7 +150,7 @@ impl Context {
         el: &EventLoopWindowTarget<T>,
         pf_reqs: &PixelFormatRequirements,
         gl_attr: &GlAttributes<&Context>,
-        size: dpi::PhysicalSize,
+        size: dpi::PhysicalSize<u32>,
     ) -> Result<Self, CreationError> {
         // if EGL is available, we try using EGL first
         // if EGL returns an error, we try the hidden window method

--- a/glutin/src/platform_impl/windows/mod.rs
+++ b/glutin/src/platform_impl/windows/mod.rs
@@ -187,7 +187,7 @@ impl Context {
 
         let wb = WindowBuilder::new()
             .with_visible(false)
-            .with_inner_size(size.to_logical(1.));
+            .with_inner_size(size);
         Self::new_windowed(wb, &el, pf_reqs, gl_attr).map(|(win, context)| {
             match context {
                 Context::Egl(context) => Context::HiddenWindowEgl(win, context),

--- a/glutin/src/windowed.rs
+++ b/glutin/src/windowed.rs
@@ -177,7 +177,7 @@ impl<W> ContextWrapper<PossiblyCurrent, W> {
     /// [`LogicalSize`]: dpi/struct.LogicalSize.html
     /// [`PhysicalSize`]: dpi/struct.PhysicalSize.html
     /// [`Resized`]: event/enum.WindowEvent.html#variant.Resized
-    pub fn resize(&self, size: dpi::PhysicalSize) {
+    pub fn resize(&self, size: dpi::PhysicalSize<u32>) {
         let (width, height) = size.into();
         self.context.context.resize(width, height);
     }

--- a/glutin_examples/examples/damage.rs
+++ b/glutin_examples/examples/damage.rs
@@ -72,12 +72,8 @@ fn main() {
 
         match event {
             Event::LoopDestroyed => return,
-            Event::WindowEvent { ref event, .. } => match event {
-                WindowEvent::Resized(logical_size) => {
-                    let dpi_factor = windowed_context.window().hidpi_factor();
-                    windowed_context
-                        .resize(logical_size.to_physical(dpi_factor));
-                }
+            Event::WindowEvent { event, .. } => match event {
+                WindowEvent::Resized(physical_size) => windowed_context.resize(physical_size),
                 WindowEvent::CloseRequested => {
                     *control_flow = ControlFlow::Exit
                 }

--- a/glutin_examples/examples/damage.rs
+++ b/glutin_examples/examples/damage.rs
@@ -73,7 +73,9 @@ fn main() {
         match event {
             Event::LoopDestroyed => return,
             Event::WindowEvent { event, .. } => match event {
-                WindowEvent::Resized(physical_size) => windowed_context.resize(physical_size),
+                WindowEvent::Resized(physical_size) => {
+                    windowed_context.resize(physical_size)
+                }
                 WindowEvent::CloseRequested => {
                     *control_flow = ControlFlow::Exit
                 }

--- a/glutin_examples/examples/fullscreen.rs
+++ b/glutin_examples/examples/fullscreen.rs
@@ -50,10 +50,6 @@ fn main() {
                 WindowEvent::CloseRequested => {
                     *control_flow = ControlFlow::Exit
                 }
-                WindowEvent::RedrawRequested => {
-                    gl.draw_frame([1.0, 0.5, 0.7, 1.0]);
-                    windowed_context.swap_buffers().unwrap();
-                }
                 WindowEvent::KeyboardInput {
                     input:
                         KeyboardInput {
@@ -92,6 +88,10 @@ fn main() {
                     _ => (),
                 },
                 _ => (),
+            },
+            Event::RedrawRequested(_) => {
+                gl.draw_frame([1.0, 0.5, 0.7, 1.0]);
+                windowed_context.swap_buffers().unwrap();
             },
             _ => {}
         }

--- a/glutin_examples/examples/fullscreen.rs
+++ b/glutin_examples/examples/fullscreen.rs
@@ -92,7 +92,7 @@ fn main() {
             Event::RedrawRequested(_) => {
                 gl.draw_frame([1.0, 0.5, 0.7, 1.0]);
                 windowed_context.swap_buffers().unwrap();
-            },
+            }
             _ => {}
         }
     });

--- a/glutin_examples/examples/headless.rs
+++ b/glutin_examples/examples/headless.rs
@@ -22,7 +22,7 @@ fn build_context_headless<T1: ContextCurrentState>(
     cb: ContextBuilder<T1>,
     el: &EventLoop<()>,
 ) -> Result<Context<NotCurrent>, CreationError> {
-    let size_one = PhysicalSize::new(1., 1.);
+    let size_one = PhysicalSize::new(1, 1);
     cb.build_headless(&el, size_one)
 }
 
@@ -31,7 +31,7 @@ fn build_context_osmesa<T1: ContextCurrentState>(
     cb: ContextBuilder<T1>,
 ) -> Result<Context<NotCurrent>, CreationError> {
     use glutin::platform::unix::HeadlessContextExt;
-    let size_one = PhysicalSize::new(1., 1.);
+    let size_one = PhysicalSize::new(1, 1);
     cb.build_osmesa(size_one)
 }
 

--- a/glutin_examples/examples/multiwindow.rs
+++ b/glutin_examples/examples/multiwindow.rs
@@ -31,13 +31,11 @@ fn main() {
         match event {
             Event::LoopDestroyed => return,
             Event::WindowEvent { event, window_id } => match event {
-                WindowEvent::Resized(logical_size) => {
+                WindowEvent::Resized(physical_size) => {
                     let windowed_context =
                         ct.get_current(windows[&window_id].0).unwrap();
                     let windowed_context = windowed_context.windowed();
-                    let dpi_factor = windowed_context.window().hidpi_factor();
-                    windowed_context
-                        .resize(logical_size.to_physical(dpi_factor));
+                    windowed_context.resize(physical_size);
                 }
                 WindowEvent::CloseRequested => {
                     if let Some((cid, _, _)) = windows.remove(&window_id) {
@@ -48,18 +46,18 @@ fn main() {
                         );
                     }
                 }
-                WindowEvent::RedrawRequested => {
-                    let window = &windows[&window_id];
-
-                    let mut color = [1.0, 0.5, 0.7, 1.0];
-                    color.swap(0, window.2 % 3);
-
-                    let windowed_context = ct.get_current(window.0).unwrap();
-
-                    window.1.draw_frame(color);
-                    windowed_context.windowed().swap_buffers().unwrap();
-                }
                 _ => (),
+            },
+            Event::RedrawRequested(window_id) => {
+                let window = &windows[&window_id];
+
+                let mut color = [1.0, 0.5, 0.7, 1.0];
+                color.swap(0, window.2 % 3);
+
+                let windowed_context = ct.get_current(window.0).unwrap();
+
+                window.1.draw_frame(color);
+                windowed_context.windowed().swap_buffers().unwrap();
             },
             _ => (),
         }

--- a/glutin_examples/examples/multiwindow.rs
+++ b/glutin_examples/examples/multiwindow.rs
@@ -58,7 +58,7 @@ fn main() {
 
                 window.1.draw_frame(color);
                 windowed_context.windowed().swap_buffers().unwrap();
-            },
+            }
             _ => (),
         }
 

--- a/glutin_examples/examples/raw_context.rs
+++ b/glutin_examples/examples/raw_context.rs
@@ -128,7 +128,9 @@ File a PR if you are interested in implementing the latter.
                     return;
                 }
                 Event::WindowEvent { event, .. } => match event {
-                    WindowEvent::Resized(physical_size) => raw_context.resize(physical_size),
+                    WindowEvent::Resized(physical_size) => {
+                        raw_context.resize(physical_size)
+                    }
                     WindowEvent::CloseRequested => {
                         *control_flow = ControlFlow::Exit
                     }
@@ -141,7 +143,7 @@ File a PR if you are interested in implementing the latter.
                         [1.0, 0.5, 0.7, 1.0]
                     });
                     raw_context.swap_buffers().unwrap();
-                },
+                }
                 _ => (),
             }
         });

--- a/glutin_examples/examples/sharing.rs
+++ b/glutin_examples/examples/sharing.rs
@@ -7,7 +7,10 @@ use glutin::window::WindowBuilder;
 use glutin::ContextBuilder;
 use support::{gl, ContextCurrentWrapper, ContextTracker, ContextWrapper};
 
-fn make_renderbuf(gl: &support::Gl, size: PhysicalSize<u32>) -> gl::types::GLuint {
+fn make_renderbuf(
+    gl: &support::Gl,
+    size: PhysicalSize<u32>,
+) -> gl::types::GLuint {
     let mut render_buf = 0;
     unsafe {
         gl.gl.GenRenderbuffers(1, &mut render_buf);
@@ -167,7 +170,7 @@ fn main() {
                     );
                 }
                 windowed_context.windowed().swap_buffers().unwrap();
-            },
+            }
             _ => (),
         }
     });

--- a/glutin_examples/examples/transparent.rs
+++ b/glutin_examples/examples/transparent.rs
@@ -30,20 +30,16 @@ fn main() {
 
         match event {
             Event::LoopDestroyed => return,
-            Event::WindowEvent { ref event, .. } => match event {
-                WindowEvent::Resized(logical_size) => {
-                    let dpi_factor = windowed_context.window().hidpi_factor();
-                    windowed_context
-                        .resize(logical_size.to_physical(dpi_factor));
-                }
-                WindowEvent::RedrawRequested => {
-                    gl.draw_frame([0.0; 4]);
-                    windowed_context.swap_buffers().unwrap();
-                }
+            Event::WindowEvent { event, .. } => match event {
+                WindowEvent::Resized(physical_size) => windowed_context.resize(physical_size),
                 WindowEvent::CloseRequested => {
                     *control_flow = ControlFlow::Exit
                 }
                 _ => (),
+            },
+            Event::RedrawRequested(_) => {
+                gl.draw_frame([0.0; 4]);
+                windowed_context.swap_buffers().unwrap();
             },
             _ => (),
         }

--- a/glutin_examples/examples/transparent.rs
+++ b/glutin_examples/examples/transparent.rs
@@ -31,7 +31,9 @@ fn main() {
         match event {
             Event::LoopDestroyed => return,
             Event::WindowEvent { event, .. } => match event {
-                WindowEvent::Resized(physical_size) => windowed_context.resize(physical_size),
+                WindowEvent::Resized(physical_size) => {
+                    windowed_context.resize(physical_size)
+                }
                 WindowEvent::CloseRequested => {
                     *control_flow = ControlFlow::Exit
                 }
@@ -40,7 +42,7 @@ fn main() {
             Event::RedrawRequested(_) => {
                 gl.draw_frame([0.0; 4]);
                 windowed_context.swap_buffers().unwrap();
-            },
+            }
             _ => (),
         }
     });

--- a/glutin_examples/examples/window.rs
+++ b/glutin_examples/examples/window.rs
@@ -28,7 +28,9 @@ fn main() {
         match event {
             Event::LoopDestroyed => return,
             Event::WindowEvent { event, .. } => match event {
-                WindowEvent::Resized(physical_size) => windowed_context.resize(physical_size),
+                WindowEvent::Resized(physical_size) => {
+                    windowed_context.resize(physical_size)
+                }
                 WindowEvent::CloseRequested => {
                     *control_flow = ControlFlow::Exit
                 }
@@ -37,7 +39,7 @@ fn main() {
             Event::RedrawRequested(_) => {
                 gl.draw_frame([1.0, 0.5, 0.7, 1.0]);
                 windowed_context.swap_buffers().unwrap();
-            },
+            }
             _ => (),
         }
     });

--- a/glutin_examples/examples/window.rs
+++ b/glutin_examples/examples/window.rs
@@ -27,20 +27,16 @@ fn main() {
 
         match event {
             Event::LoopDestroyed => return,
-            Event::WindowEvent { ref event, .. } => match event {
-                WindowEvent::Resized(logical_size) => {
-                    let dpi_factor = windowed_context.window().hidpi_factor();
-                    windowed_context
-                        .resize(logical_size.to_physical(dpi_factor));
-                }
-                WindowEvent::RedrawRequested => {
-                    gl.draw_frame([1.0, 0.5, 0.7, 1.0]);
-                    windowed_context.swap_buffers().unwrap();
-                }
+            Event::WindowEvent { event, .. } => match event {
+                WindowEvent::Resized(physical_size) => windowed_context.resize(physical_size),
                 WindowEvent::CloseRequested => {
                     *control_flow = ControlFlow::Exit
                 }
                 _ => (),
+            },
+            Event::RedrawRequested(_) => {
+                gl.draw_frame([1.0, 0.5, 0.7, 1.0]);
+                windowed_context.swap_buffers().unwrap();
             },
             _ => (),
         }

--- a/glutin_examples/ios-example/rust/src/lib.rs
+++ b/glutin_examples/ios-example/rust/src/lib.rs
@@ -31,7 +31,9 @@ fn main() {
         match event {
             Event::LoopDestroyed => return,
             Event::WindowEvent { event, .. } => match event {
-                WindowEvent::Resized(physical_size) => windowed_context.resize(physical_size),
+                WindowEvent::Resized(physical_size) => {
+                    windowed_context.resize(physical_size)
+                }
                 WindowEvent::Touch(_touch) => {
                     const INCREMENTER: f32 = 0.05;
                     inc += INCREMENTER;
@@ -51,7 +53,7 @@ fn main() {
             Event::RedrawRequested(_) => {
                 gl.draw_frame([0.0; 4]);
                 windowed_context.swap_buffers().unwrap();
-            },
+            }
             _ => (),
         }
     });

--- a/glutin_examples/ios-example/rust/src/lib.rs
+++ b/glutin_examples/ios-example/rust/src/lib.rs
@@ -30,12 +30,8 @@ fn main() {
 
         match event {
             Event::LoopDestroyed => return,
-            Event::WindowEvent { ref event, .. } => match event {
-                WindowEvent::Resized(logical_size) => {
-                    let dpi_factor = windowed_context.window().hidpi_factor();
-                    windowed_context
-                        .resize(logical_size.to_physical(dpi_factor));
-                }
+            Event::WindowEvent { event, .. } => match event {
+                WindowEvent::Resized(physical_size) => windowed_context.resize(physical_size),
                 WindowEvent::Touch(_touch) => {
                     const INCREMENTER: f32 = 0.05;
                     inc += INCREMENTER;
@@ -47,14 +43,14 @@ fn main() {
                     ]);
                     windowed_context.swap_buffers().unwrap();
                 }
-                WindowEvent::RedrawRequested => {
-                    gl.draw_frame([0.0; 4]);
-                    windowed_context.swap_buffers().unwrap();
-                }
                 WindowEvent::CloseRequested => {
                     *control_flow = ControlFlow::Exit
                 }
                 _ => (),
+            },
+            Event::RedrawRequested(_) => {
+                gl.draw_frame([0.0; 4]);
+                windowed_context.swap_buffers().unwrap();
             },
             _ => (),
         }


### PR DESCRIPTION
I've taken the liberty to bump winit to version 0.20.0, since the recent DPI changes all have been merged.

I think the only potentially controversial thing is that I've blindly made all `PhysicalSize` instances to `PhysicalSize<u32>`, since most usecases I saw in the code used `let _: (u32, u32) = size.into();` to immediately destructure the physical size into its width/height. However it's possible that there is an instance where u32 is not the optimal choice, I can't fully judge that myself.
