### PR TITLE
Add changelog entry for 0.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Unreleased
 
-# Version 0.22.0 (2020-1-07)
+# Version 0.21.1 (2020-01-29)
+
+- Fixed incorrectly documented default value for `ContextBuilder::with_srgb`
+
+# Version 0.22.0 (2020-01-07)
 
 - Updated winit dependency to 0.20.0. See [winit's CHANGELOG](https://github.com/rust-windowing/winit/blob/master/CHANGELOG.md#0200-2020-01-05) for more info.
 
-# Version 0.22.0-alpha6 (2020-1-05)
+# Version 0.22.0-alpha6 (2020-01-05)
 
 - Fixed dependencies so wrong winit version is not used.
 - On X11, got rid of mistaken `XRenderFindVisualFormat` call so that glutin doesn't ignore configs that lack a `XRenderPictFormat`.


### PR DESCRIPTION
After checking out if the 0.22.1 change had any impact on Alacritty, I was confused that it didn't look like its contents were documented yet. However after looking at the git log, it seems like the changes were mostly irrelevant.

I think it's still nice to have a change log entry for every release though, because it removes that initial confusion if there's actually any relevant changes or not. After all, if there are no changes at all, there probably shouldn't be any release.

I've decided against explicitly listing the bumped parking_lot depedency, even though that does have a nice benefit for some consumers, but I didn't want to make it seem like that's anything but an internal change. Of course it can affect downstream by resulting in more/fewer duplicates.