### PR TITLE
Update winit crate to 0.21.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,6 @@ jobs:
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest,   }
           - { target: x86_64-apple-darwin,      os: macos-latest,    }
           - { target: x86_64-apple-ios,         os: macos-latest,    }
-          - { target: armv7-apple-ios,          os: macos-latest,    }
           - { target: aarch64-apple-ios,        os: macos-latest,    }
           # We're using Windows rather than Ubuntu to run the wasm tests because caching cargo-web
           # doesn't currently work on Linux.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 
-# Version 0.21.1 (2020-01-29)
+- Updated winit dependency to 0.21.0. See [winit's CHANGELOG](https://github.com/rust-windowing/winit/blob/master/CHANGELOG.md#0210-2020-02-04) for more info.
+
+# Version 0.22.1 (2020-01-29)
 
 - Fixed incorrectly documented default value for `ContextBuilder::with_srgb`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Unreleased
 
+# Version 0.23.0 (2020-02-06)
+
 - Updated winit dependency to 0.21.0. See [winit's CHANGELOG](https://github.com/rust-windowing/winit/blob/master/CHANGELOG.md#0210-2020-02-04) for more info.
+- Removed broken CI for the `armv7-apple-ios` target.
 
 # Version 0.22.1 (2020-01-29)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A low-level library for OpenGL context creation, written in pure Rust.
 
 ```toml
 [dependencies]
-glutin = "0.22"
+glutin = "0.23"
 ```
 
 ## [Documentation](https://docs.rs/glutin)
@@ -21,7 +21,7 @@ Join us in any of these:
 
 ## Usage Examples
 
-Warning: these are examples for master. For the latest released version, 0.22, view [here.](https://github.com/rust-windowing/glutin/tree/447f3526dcf90a460d52afefd0b29eb2ed7f87f3)
+Warning: these are examples for master. For the latest released version, 0.23, view [here.](https://github.com/rust-windowing/glutin/tree/447f3526dcf90a460d52afefd0b29eb2ed7f87f3)
 
 ### Try it!
 

--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -18,7 +18,7 @@ serde = ["winit/serde"]
 
 [dependencies]
 lazy_static = "1.3"
-winit = "0.20.0"
+winit = "0.21.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_glue = "0.2"

--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glutin"
-version = "0.22.1"
+version = "0.23.0"
 authors = ["The glutin contributors", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform OpenGL context provider."
 keywords = ["windowing", "opengl"]


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality

`winit` version 0.21.0 fixes a bug in another project at https://github.com/alacritty/alacritty/issues/3191.

This builds correctly, and all checks seem to pass. [`winit`](https://github.com/rust-windowing/winit/compare/627a127f1b96608649eee5ac474bf762daffbc3a..28f0eb598d8a309f528caf540751a28ec3c68ace) should have only 2 breaking changes, and they both seem to not affect this crate.

I've done some minor testing with Alacritty using Wayland on Linux, and it seems to work fine, plus the fixed bug.

Let me know if there is anything else I need to do!