### PR TITLE
Don't unnecessarily instantiate GLX or EGL

### DIFF
--- a/glutin/src/platform_impl/unix/x11.rs
+++ b/glutin/src/platform_impl/unix/x11.rs
@@ -401,10 +401,14 @@ impl Context {
                         "both libGL and libEGL are not present".to_string(),
                     ));
                 } else {
-                    match (&*GLX, &*EGL, prefer_egl) {
-                        (Some(_), Some(_), true) => return egl(builder_egl_u),
-                        (Some(_), Some(_), false) => return glx(builder_glx_u),
-                        _ => (),
+                    if prefer_egl {
+                        if let Some(_) = &*EGL {
+                            return egl(builder_egl_u);
+                        }
+                    } else {
+                        if let Some(_) = &*GLX {
+                            return glx(builder_glx_u);
+                        }
                     }
 
                     return Err(CreationError::NotSupported(

--- a/glutin/src/platform_impl/unix/x11.rs
+++ b/glutin/src/platform_impl/unix/x11.rs
@@ -381,16 +381,20 @@ impl Context {
                 // That way, they'll try their fallback if available, unless
                 // it was their only option and they have already tried it.
                 if !force_prefer_unless_only {
-                    match (&*GLX, &*EGL, prefer_egl) {
-                        (Some(_), _, false) => return glx(builder_glx_u),
-                        (_, Some(_), true) => return egl(builder_egl_u),
-                        _ => (),
-                    }
-
-                    match (&*GLX, &*EGL, prefer_egl) {
-                        (_, Some(_), false) => return egl(builder_egl_u),
-                        (Some(_), _, true) => return glx(builder_glx_u),
-                        _ => (),
+                    // If the preferred choice works, don't spend time testing
+                    // if the other works.
+                    if prefer_egl {
+                        if let Some(_) = &*EGL {
+                            return egl(builder_egl_u);
+                        } else if let Some(_) = &*GLX {
+                            return glx(builder_glx_u);
+                        }
+                    } else {
+                        if let Some(_) = &*GLX {
+                            return glx(builder_glx_u);
+                        } else if let Some(_) = &*EGL {
+                            return egl(builder_egl_u);
+                        }
                     }
 
                     return Err(CreationError::NotSupported(


### PR DESCRIPTION
On my system, this removes a 1-4s delay. I think this delay was introduced sometime 0.21.0. I only tested on my one Ubuntu 18.04 box.

- [ ] Tested on all platforms changed
- [X ] Compilation warnings were addressed
- [X] `cargo fmt` has been run on this branch
- [X] `cargo doc` builds successfully
- [n/a] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [n/a] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [n/a] Created or updated an example program if it would help users understand this functionality