### PR TITLE
Make gles work when not specifying version

### DIFF
--- a/glutin/src/api/egl/mod.rs
+++ b/glutin/src/api/egl/mod.rs
@@ -1180,7 +1180,14 @@ where
                     out.push(ffi::egl::OPENGL_ES_BIT as raw::c_int);
                 }
             }
-            (Api::OpenGlEs, _) => unimplemented!(),
+            (Api::OpenGlEs, None) => {
+                if egl_version >= &(1, 3) {
+                    out.push(ffi::egl::RENDERABLE_TYPE as raw::c_int);
+                    out.push(ffi::egl::OPENGL_ES_BIT as raw::c_int);
+                    out.push(ffi::egl::CONFORMANT as raw::c_int);
+                    out.push(ffi::egl::OPENGL_ES_BIT as raw::c_int);
+                }
+            }
             (Api::OpenGl, _) => {
                 if egl_version < &(1, 3) {
                     return Err(CreationError::NoAvailablePixelFormat);


### PR DESCRIPTION
This PR makes glutin work with GLES when a requested version is not given. I think ignoring the version is ok because we don't know it until we try to create a context. I've copied the oldest gles version code to be conservative.

- [ ] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users

