### PR TITLE
Fix context resize documentation

### DIFF
--- a/glutin/src/windowed.rs
+++ b/glutin/src/windowed.rs
@@ -171,10 +171,8 @@ impl<W> ContextWrapper<PossiblyCurrent, W> {
     /// their window or surface is resized.
     ///
     /// The easiest way of doing this is to take every [`Resized`] window event
-    /// that is received with a [`LogicalSize`] and convert it to a
-    /// [`PhysicalSize`] and pass it into this function.
+    /// that is received and pass its [`PhysicalSize`] into this function.
     ///
-    /// [`LogicalSize`]: dpi/struct.LogicalSize.html
     /// [`PhysicalSize`]: dpi/struct.PhysicalSize.html
     /// [`Resized`]: event/enum.WindowEvent.html#variant.Resized
     pub fn resize(&self, size: dpi::PhysicalSize<u32>) {


### PR DESCRIPTION
Since the latest winit versions don't return a LogicalSize for Resized
events anymore, conversion is no longer required.