### PR TITLE
Update wayland-client to 0.27

### DIFF
--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -55,7 +55,8 @@ parking_lot = "0.10"
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
 osmesa-sys = "0.1"
-wayland-client = { version = "0.23", features = ["egl", "dlopen"] }
+wayland-client = { version = "0.27", features = ["dlopen"] }
+wayland-egl = "0.27"
 libloading = "0.6.1"
 glutin_egl_sys = { version = "0.1.4", path = "../glutin_egl_sys" }
 glutin_glx_sys = { version = "0.1.6", path = "../glutin_glx_sys" }

--- a/glutin/src/platform_impl/unix/wayland.rs
+++ b/glutin/src/platform_impl/unix/wayland.rs
@@ -8,7 +8,6 @@ use crate::{
 
 use crate::platform::unix::{EventLoopWindowTargetExtUnix, WindowExtUnix};
 use glutin_egl_sys as ffi;
-use wayland_client::egl as wegl;
 pub use wayland_client::sys::client::wl_display;
 use winit;
 use winit::dpi;
@@ -19,7 +18,7 @@ use std::ops::Deref;
 use std::os::raw;
 use std::sync::Arc;
 
-pub struct EglSurface(Arc<wegl::WlEglSurface>);
+pub struct EglSurface(Arc<wayland_egl::WlEglSurface>);
 
 impl std::fmt::Debug for EglSurface {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -128,7 +127,7 @@ impl Context {
         gl_attr: &GlAttributes<&Context>,
     ) -> Result<Self, CreationError> {
         let egl_surface = unsafe {
-            wegl::WlEglSurface::new_from_raw(
+            wayland_egl::WlEglSurface::new_from_raw(
                 surface as *mut _,
                 width as i32,
                 height as i32,


### PR DESCRIPTION
This branch is used primary for testing https://github.com/rust-windowing/winit/pull/1653.

Once the upstream branch will be merged, the latest git commit will be reverted and the patch to bump wayland-client to 0.27 will be merged.