### PR TITLE
Fix several crashes on Windows

### DIFF
--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -18,7 +18,7 @@ serde = ["winit/serde"]
 
 [dependencies]
 lazy_static = "1.3"
-winit = "0.22.0"
+winit = "0.22.2"
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_glue = "0.2"


### PR DESCRIPTION
Winit pushed https://github.com/rust-windowing/winit/commit/b4c6cdf9a33530a2116f37a21547341c34537be1 fixing several crashes that I'm currently experiencing in Windows, then pushed version 0.22.2. This PR updates the dependency version to 0.22.2 from 0.22.0.