### PR TITLE
Make x11 and wayland features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- X11 and Wayland are now optional features (enabled by default)
+
 # Version 0.25.0 (2020-10-02)
 
 - Updated winit dependency to 0.23.0. See [winit's CHANGELOG](https://github.com/rust-windowing/winit/blob/master/CHANGELOG.md#0230-2020-10-02) for more info.

--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -15,10 +15,13 @@ features = ["serde"]
 
 [features]
 serde = ["winit/serde"]
+x11 = ["winit/x11", "glutin_glx_sys"]
+wayland = ["winit/wayland", "wayland-client", "wayland-egl"]
+default = ["x11", "wayland"]
 
 [dependencies]
 lazy_static = "1.3"
-winit = "0.23.0"
+winit = { version = "0.23.0", default-features = false }
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_glue = "0.2"
@@ -54,10 +57,10 @@ parking_lot = "0.11"
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
 osmesa-sys = "0.1"
-wayland-client = { version = "0.28", features = ["dlopen"] }
-wayland-egl = "0.28"
+wayland-client = { version = "0.28", features = ["dlopen"], optional = true }
+wayland-egl = { version = "0.28", optional = true }
 libloading = "0.6.1"
 glutin_egl_sys = { version = "0.1.4", path = "../glutin_egl_sys" }
-glutin_glx_sys = { version = "0.1.6", path = "../glutin_glx_sys" }
+glutin_glx_sys = { version = "0.1.6", path = "../glutin_glx_sys", optional = true }
 parking_lot = "0.11"
 log = "0.4"

--- a/glutin/src/api/egl/mod.rs
+++ b/glutin/src/api/egl/mod.rs
@@ -863,6 +863,7 @@ pub struct ContextPrototype<'a> {
     target_os = "netbsd",
     target_os = "openbsd",
 ))]
+#[cfg(feature = "x11")]
 pub fn get_native_visual_id(
     display: ffi::egl::types::EGLDisplay,
     config_id: ffi::egl::types::EGLConfig,
@@ -894,6 +895,7 @@ impl<'a> ContextPrototype<'a> {
         target_os = "netbsd",
         target_os = "openbsd",
     ))]
+    #[cfg(feature = "x11")]
     pub fn get_native_visual_id(&self) -> ffi::egl::types::EGLint {
         get_native_visual_id(self.display, self.config_id)
     }

--- a/glutin/src/api/glx/mod.rs
+++ b/glutin/src/api/glx/mod.rs
@@ -5,6 +5,7 @@
     target_os = "netbsd",
     target_os = "openbsd",
 ))]
+#![cfg(feature = "x11")]
 
 mod make_current_guard;
 mod glx {

--- a/glutin/src/lib.rs
+++ b/glutin/src/lib.rs
@@ -318,6 +318,7 @@ impl CreationError {
         target_os = "netbsd",
         target_os = "openbsd",
     ))]
+    #[cfg(feature = "x11")]
     pub(crate) fn append(self, err: CreationError) -> Self {
         match self {
             CreationError::CreationErrors(mut errs) => {

--- a/glutin/src/platform/unix.rs
+++ b/glutin/src/platform/unix.rs
@@ -10,6 +10,7 @@ use crate::platform::ContextTraitExt;
 pub use crate::platform_impl::{HeadlessContextExt, RawContextExt, RawHandle};
 use crate::{Context, ContextCurrentState};
 pub use glutin_egl_sys::EGLContext;
+#[cfg(feature = "x11")]
 pub use glutin_glx_sys::GLXContext;
 
 pub use winit::platform::unix::*;

--- a/glutin/src/platform_impl/unix/wayland.rs
+++ b/glutin/src/platform_impl/unix/wayland.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "wayland")]
+
 use crate::api::egl::{
     Context as EglContext, NativeDisplay, SurfaceType as EglSurfaceType,
 };

--- a/glutin/src/platform_impl/unix/x11.rs
+++ b/glutin/src/platform_impl/unix/x11.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "x11")]
+
 use crate::api::egl::{
     self, Context as EglContext, NativeDisplay, SurfaceType as EglSurfaceType,
     EGL,


### PR DESCRIPTION
winit now has a x11 and wayland feature that can be used to disable one of them, make uses of these feature also in this crate.

My goal is to reduce binary size of my binaries that does not use wayland.

- [X] Tested on all platforms changed
- [X] Compilation warnings were addressed  (i made sure not to introduce new warnings)
- [X] `cargo fmt` has been run on this branch
- [X] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
