### PR TITLE
Allow context sharing for headless contexts on MacOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- On macOS, add support for sharing of headless contexts.
+
 # Version 0.28.0 (2021-12-02)
 
 - On Windows, fixed a panic for headless contexts because of active drag-and-drop (OleInitialize failed! Result was: `RPC_E_CHANGED_MODE`)

--- a/glutin/src/platform_impl/macos/mod.rs
+++ b/glutin/src/platform_impl/macos/mod.rs
@@ -150,6 +150,8 @@ impl Context {
     ) -> Result<Self, CreationError> {
         let gl_profile = helpers::get_gl_profile(gl_attr, pf_reqs)?;
         let attributes = helpers::build_nsattributes(pf_reqs, gl_profile)?;
+        let share_ctx = gl_attr.sharing.map_or(nil, |c| *c.get_id());
+
         let context = unsafe {
             let pixelformat = NSOpenGLPixelFormat::alloc(nil).initWithAttributes_(&attributes);
             if pixelformat == nil {
@@ -158,7 +160,7 @@ impl Context {
                 ));
             }
             let context =
-                NSOpenGLContext::alloc(nil).initWithFormat_shareContext_(pixelformat, nil);
+                NSOpenGLContext::alloc(nil).initWithFormat_shareContext_(pixelformat, share_ctx);
             if context == nil {
                 return Err(CreationError::OsError(
                     "Could not create the rendering context".to_string(),


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality

Original issue: #899

This was originally implemented in https://github.com/rust-windowing/glutin/pull/1132, however sharing support was never added for headless contexts. This is essentially the same change as before, just in `new_headless`.

I tested this in a company application which uses multi-threaded OpenGL contexts with texture sharing, and this change fixed an issue I was having. However, in `master` before this change, `cargo run --example sharing` just showed a black screen. It also showed a black screen after this change, so I can't claim the example runs correctly. There's some other issue for MacOS at play for that.