### PR TITLE
Add Apple Silicon support

### DIFF
--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -21,7 +21,7 @@ default = ["x11", "wayland"]
 
 [dependencies]
 lazy_static = "1.3"
-winit = { version = "0.23.0", default-features = false }
+winit = { git = "https://github.com/rust-windowing/winit", default-features = false }
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_glue = "0.2"

--- a/glutin/src/platform/mod.rs
+++ b/glutin/src/platform/mod.rs
@@ -30,7 +30,7 @@ pub mod desktop {
         target_os = "netbsd",
         target_os = "openbsd",
     ))]
-    pub use winit::platform::desktop::*;
+    pub use winit::platform::run_return::*;
 }
 
 use std::os::raw;


### PR DESCRIPTION
Apple Silicon support was added to winit in the latest (unreleased)
master version. It also renamed some types, so we'll need to do the
same here to keep compatible.

The dependency update won't be the `git` version ultimately, of course,
but I'm adding it in for now in case anyone else wants to know how
to build on M1 in the meantime.

- [ ] Tested on all platforms changed
- [ ] Compilation warnings were addressed
- [ ] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
