### PR TITLE
Usa stable version of rustfmt for formatting

### DIFF
--- a/glutin/src/api/android/mod.rs
+++ b/glutin/src/api/android/mod.rs
@@ -1,12 +1,8 @@
 #![cfg(target_os = "android")]
 
-use crate::api::egl::{
-    Context as EglContext, NativeDisplay, SurfaceType as EglSurfaceType,
-};
+use crate::api::egl::{Context as EglContext, NativeDisplay, SurfaceType as EglSurfaceType};
 use crate::CreationError::{self, OsError};
-use crate::{
-    Api, ContextError, GlAttributes, PixelFormat, PixelFormatRequirements, Rect,
-};
+use crate::{Api, ContextError, GlAttributes, PixelFormat, PixelFormatRequirements, Rect};
 
 use crate::platform::android::EventLoopExtAndroid;
 use glutin_egl_sys as ffi;
@@ -66,18 +62,12 @@ impl Context {
             return Err(OsError("Android's native window is null".to_string()));
         }
         let native_display = NativeDisplay::Android;
-        let egl_context = EglContext::new(
-            pf_reqs,
-            &gl_attr,
-            native_display,
-            EglSurfaceType::Window,
-            |c, _| Ok(c[0]),
-        )
-        .and_then(|p| p.finish(nwin as *const _))?;
-        let ctx = Arc::new(AndroidContext {
-            egl_context,
-            stopped: Some(Mutex::new(false)),
-        });
+        let egl_context =
+            EglContext::new(pf_reqs, &gl_attr, native_display, EglSurfaceType::Window, |c, _| {
+                Ok(c[0])
+            })
+            .and_then(|p| p.finish(nwin as *const _))?;
+        let ctx = Arc::new(AndroidContext { egl_context, stopped: Some(Mutex::new(false)) });
 
         let handler = Box::new(AndroidSyncEventHandler(ctx.clone()));
         android_glue::add_sync_event_handler(handler);
@@ -121,10 +111,7 @@ impl Context {
             |c, _| Ok(c[0]),
         )?;
         let egl_context = context.finish_pbuffer(size)?;
-        let ctx = Arc::new(AndroidContext {
-            egl_context,
-            stopped: None,
-        });
+        let ctx = Arc::new(AndroidContext { egl_context, stopped: None });
         Ok(Context(ctx))
     }
 
@@ -177,10 +164,7 @@ impl Context {
     }
 
     #[inline]
-    pub fn swap_buffers_with_damage(
-        &self,
-        rects: &[Rect],
-    ) -> Result<(), ContextError> {
+    pub fn swap_buffers_with_damage(&self, rects: &[Rect]) -> Result<(), ContextError> {
         if let Some(ref stopped) = self.0.stopped {
             let stopped = stopped.lock();
             if *stopped {

--- a/glutin/src/api/dlloader.rs
+++ b/glutin/src/api/dlloader.rs
@@ -33,11 +33,8 @@ impl<T: SymTrait> SymWrapper<T> {
         for path in lib_paths {
             // Avoid loading from PATH
             #[cfg(target_os = "windows")]
-            let lib = windows::Library::load_with_flags(
-                path,
-                LOAD_LIBRARY_SEARCH_DEFAULT_DIRS,
-            )
-            .map(From::from);
+            let lib = windows::Library::load_with_flags(path, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS)
+                .map(From::from);
 
             #[cfg(not(target_os = "windows"))]
             let lib = Library::new(path);

--- a/glutin/src/api/egl/make_current_guard.rs
+++ b/glutin/src/api/egl/make_current_guard.rs
@@ -30,10 +30,8 @@ impl MakeCurrentGuard {
                 display,
                 old_display: egl.GetCurrentDisplay(),
                 possibly_invalid: Some(MakeCurrentGuardInner {
-                    old_draw_surface: egl
-                        .GetCurrentSurface(ffi::egl::DRAW as i32),
-                    old_read_surface: egl
-                        .GetCurrentSurface(ffi::egl::READ as i32),
+                    old_draw_surface: egl.GetCurrentSurface(ffi::egl::DRAW as i32),
+                    old_read_surface: egl.GetCurrentSurface(ffi::egl::READ as i32),
                     old_context: egl.GetCurrentContext(),
                 }),
             };
@@ -42,8 +40,7 @@ impl MakeCurrentGuard {
                 ret.invalidate();
             }
 
-            let res =
-                egl.MakeCurrent(display, draw_surface, read_surface, context);
+            let res = egl.MakeCurrent(display, draw_surface, read_surface, context);
 
             if res == 0 {
                 let err = egl.GetError();
@@ -62,10 +59,8 @@ impl MakeCurrentGuard {
     ) {
         if self.possibly_invalid.is_some() {
             let pi = self.possibly_invalid.as_ref().unwrap();
-            if pi.old_draw_surface == draw_surface
-                && draw_surface != ffi::egl::NO_SURFACE
-                || pi.old_read_surface == read_surface
-                    && read_surface != ffi::egl::NO_SURFACE
+            if pi.old_draw_surface == draw_surface && draw_surface != ffi::egl::NO_SURFACE
+                || pi.old_read_surface == read_surface && read_surface != ffi::egl::NO_SURFACE
                 || pi.old_context == context
             {
                 self.invalidate();
@@ -81,19 +76,10 @@ impl MakeCurrentGuard {
 impl Drop for MakeCurrentGuard {
     fn drop(&mut self) {
         let egl = super::EGL.as_ref().unwrap();
-        let (draw_surface, read_surface, context) =
-            match self.possibly_invalid.take() {
-                Some(inner) => (
-                    inner.old_draw_surface,
-                    inner.old_read_surface,
-                    inner.old_context,
-                ),
-                None => (
-                    ffi::egl::NO_SURFACE,
-                    ffi::egl::NO_SURFACE,
-                    ffi::egl::NO_CONTEXT,
-                ),
-            };
+        let (draw_surface, read_surface, context) = match self.possibly_invalid.take() {
+            Some(inner) => (inner.old_draw_surface, inner.old_read_surface, inner.old_context),
+            None => (ffi::egl::NO_SURFACE, ffi::egl::NO_SURFACE, ffi::egl::NO_CONTEXT),
+        };
 
         let display = match self.old_display {
             ffi::egl::NO_DISPLAY => self.display,
@@ -101,8 +87,7 @@ impl Drop for MakeCurrentGuard {
         };
 
         unsafe {
-            let res =
-                egl.MakeCurrent(display, draw_surface, read_surface, context);
+            let res = egl.MakeCurrent(display, draw_surface, read_surface, context);
 
             if res == 0 {
                 let err = egl.GetError();

--- a/glutin/src/api/egl/mod.rs
+++ b/glutin/src/api/egl/mod.rs
@@ -28,9 +28,7 @@ mod egl {
     unsafe impl Sync for Egl {}
 
     type EglGetProcAddressType = libloading_os::Symbol<
-        unsafe extern "C" fn(
-            *const std::os::raw::c_void,
-        ) -> *const std::os::raw::c_void,
+        unsafe extern "C" fn(*const std::os::raw::c_void) -> *const std::os::raw::c_void,
     >;
 
     lazy_static! {
@@ -44,18 +42,13 @@ mod egl {
                 // Check if the symbol is available in the library directly. If
                 // it is, just return it.
                 match unsafe {
-                    lib.get(
-                        std::ffi::CString::new(s.as_bytes())
-                            .unwrap()
-                            .as_bytes_with_nul(),
-                    )
+                    lib.get(std::ffi::CString::new(s.as_bytes()).unwrap().as_bytes_with_nul())
                 } {
                     Ok(sym) => return *sym,
                     Err(_) => (),
                 };
 
-                let mut egl_get_proc_address =
-                    (*EGL_GET_PROC_ADDRESS).lock().unwrap();
+                let mut egl_get_proc_address = (*EGL_GET_PROC_ADDRESS).lock().unwrap();
                 if egl_get_proc_address.is_none() {
                     unsafe {
                         let sym: libloading::Symbol<
@@ -74,10 +67,7 @@ mod egl {
                 // hence this two-part dance.
                 unsafe {
                     (egl_get_proc_address.as_ref().unwrap())(
-                        std::ffi::CString::new(s.as_bytes())
-                            .unwrap()
-                            .as_bytes_with_nul()
-                            .as_ptr()
+                        std::ffi::CString::new(s.as_bytes()).unwrap().as_bytes_with_nul().as_ptr()
                             as *const std::os::raw::c_void,
                     )
                 }
@@ -204,9 +194,7 @@ fn get_egl_version(
         let mut minor: ffi::egl::types::EGLint = std::mem::zeroed();
 
         if egl.Initialize(display, &mut major, &mut minor) == 0 {
-            return Err(CreationError::OsError(
-                "eglInitialize failed".to_string(),
-            ));
+            return Err(CreationError::OsError("eglInitialize failed".to_string()));
         }
 
         Ok((major, minor))
@@ -249,13 +237,8 @@ unsafe fn bind_and_get_api<'a>(
             }
             Ok((Some(version), Api::OpenGl))
         }
-        GlRequest::Specific(_, _) => {
-            Err(CreationError::OpenGlVersionNotSupported)
-        }
-        GlRequest::GlThenGles {
-            opengles_version,
-            opengl_version,
-        } => {
+        GlRequest::Specific(_, _) => Err(CreationError::OpenGlVersionNotSupported),
+        GlRequest::GlThenGles { opengles_version, opengl_version } => {
             if egl_version >= (1, 4) {
                 if egl.BindAPI(ffi::egl::OPENGL_API) != 0 {
                     Ok((Some(opengl_version), Api::OpenGl))
@@ -277,8 +260,7 @@ fn get_native_display(native_display: &NativeDisplay) -> *const raw::c_void {
     // the first step is to query the list of extensions without any display, if
     // supported
     let dp_extensions = unsafe {
-        let p =
-            egl.QueryString(ffi::egl::NO_DISPLAY, ffi::egl::EXTENSIONS as i32);
+        let p = egl.QueryString(ffi::egl::NO_DISPLAY, ffi::egl::EXTENSIONS as i32);
 
         // this possibility is available only with EGL 1.5 or
         // EGL_EXT_platform_base, otherwise `eglQueryString` returns an
@@ -287,14 +269,12 @@ fn get_native_display(native_display: &NativeDisplay) -> *const raw::c_void {
             vec![]
         } else {
             let p = CStr::from_ptr(p);
-            let list = String::from_utf8(p.to_bytes().to_vec())
-                .unwrap_or_else(|_| format!(""));
+            let list = String::from_utf8(p.to_bytes().to_vec()).unwrap_or_else(|_| format!(""));
             list.split(' ').map(|e| e.to_string()).collect::<Vec<_>>()
         }
     };
 
-    let has_dp_extension =
-        |e: &str| dp_extensions.iter().find(|s| s == &e).is_some();
+    let has_dp_extension = |e: &str| dp_extensions.iter().find(|s| s == &e).is_some();
 
     match *native_display {
         // Note: Some EGL implementations are missing the
@@ -303,17 +283,12 @@ fn get_native_display(native_display: &NativeDisplay) -> *const raw::c_void {
         //       Therefore we detect whether the symbol is loaded in addition to
         // checking for       extensions.
         NativeDisplay::X11(display)
-            if has_dp_extension("EGL_KHR_platform_x11")
-                && egl.GetPlatformDisplay.is_loaded() =>
+            if has_dp_extension("EGL_KHR_platform_x11") && egl.GetPlatformDisplay.is_loaded() =>
         {
             let d = display.unwrap_or(ffi::egl::DEFAULT_DISPLAY as *const _);
             // TODO: `PLATFORM_X11_SCREEN_KHR`
             unsafe {
-                egl.GetPlatformDisplay(
-                    ffi::egl::PLATFORM_X11_KHR,
-                    d as *mut _,
-                    std::ptr::null(),
-                )
+                egl.GetPlatformDisplay(ffi::egl::PLATFORM_X11_KHR, d as *mut _, std::ptr::null())
             }
         }
 
@@ -324,25 +299,16 @@ fn get_native_display(native_display: &NativeDisplay) -> *const raw::c_void {
             let d = display.unwrap_or(ffi::egl::DEFAULT_DISPLAY as *const _);
             // TODO: `PLATFORM_X11_SCREEN_EXT`
             unsafe {
-                egl.GetPlatformDisplayEXT(
-                    ffi::egl::PLATFORM_X11_EXT,
-                    d as *mut _,
-                    std::ptr::null(),
-                )
+                egl.GetPlatformDisplayEXT(ffi::egl::PLATFORM_X11_EXT, d as *mut _, std::ptr::null())
             }
         }
 
         NativeDisplay::Gbm(display)
-            if has_dp_extension("EGL_KHR_platform_gbm")
-                && egl.GetPlatformDisplay.is_loaded() =>
+            if has_dp_extension("EGL_KHR_platform_gbm") && egl.GetPlatformDisplay.is_loaded() =>
         {
             let d = display.unwrap_or(ffi::egl::DEFAULT_DISPLAY as *const _);
             unsafe {
-                egl.GetPlatformDisplay(
-                    ffi::egl::PLATFORM_GBM_KHR,
-                    d as *mut _,
-                    std::ptr::null(),
-                )
+                egl.GetPlatformDisplay(ffi::egl::PLATFORM_GBM_KHR, d as *mut _, std::ptr::null())
             }
         }
 
@@ -352,11 +318,7 @@ fn get_native_display(native_display: &NativeDisplay) -> *const raw::c_void {
         {
             let d = display.unwrap_or(ffi::egl::DEFAULT_DISPLAY as *const _);
             unsafe {
-                egl.GetPlatformDisplayEXT(
-                    ffi::egl::PLATFORM_GBM_KHR,
-                    d as *mut _,
-                    std::ptr::null(),
-                )
+                egl.GetPlatformDisplayEXT(ffi::egl::PLATFORM_GBM_KHR, d as *mut _, std::ptr::null())
             }
         }
 
@@ -417,9 +379,7 @@ fn get_native_display(native_display: &NativeDisplay) -> *const raw::c_void {
         | NativeDisplay::Gbm(Some(display))
         | NativeDisplay::Wayland(Some(display))
         | NativeDisplay::Device(display)
-        | NativeDisplay::Other(Some(display)) => unsafe {
-            egl.GetDisplay(display as *mut _)
-        },
+        | NativeDisplay::Other(Some(display)) => unsafe { egl.GetDisplay(display as *mut _) },
 
         NativeDisplay::X11(None)
         | NativeDisplay::Gbm(None)
@@ -464,9 +424,7 @@ impl Context {
         let display = get_native_display(&native_display);
 
         if display.is_null() {
-            return Err(CreationError::OsError(
-                "Could not create EGL display object".to_string(),
-            ));
+            return Err(CreationError::OsError("Could not create EGL display object".to_string()));
         }
 
         let egl_version = get_egl_version(display)?;
@@ -474,13 +432,9 @@ impl Context {
         // the list of extensions supported by the client once initialized is
         // different from the list of extensions obtained earlier
         let extensions = if egl_version >= (1, 2) {
-            let p = unsafe {
-                CStr::from_ptr(
-                    egl.QueryString(display, ffi::egl::EXTENSIONS as i32),
-                )
-            };
-            let list = String::from_utf8(p.to_bytes().to_vec())
-                .unwrap_or_else(|_| format!(""));
+            let p =
+                unsafe { CStr::from_ptr(egl.QueryString(display, ffi::egl::EXTENSIONS as i32)) };
+            let list = String::from_utf8(p.to_bytes().to_vec()).unwrap_or_else(|_| format!(""));
             list.split(' ').map(|e| e.to_string()).collect::<Vec<_>>()
         } else {
             vec![]
@@ -514,18 +468,14 @@ impl Context {
         })
     }
 
-    unsafe fn check_make_current(
-        &self,
-        ret: Option<u32>,
-    ) -> Result<(), ContextError> {
+    unsafe fn check_make_current(&self, ret: Option<u32>) -> Result<(), ContextError> {
         let egl = EGL.as_ref().unwrap();
         if ret == Some(0) {
             match egl.GetError() as u32 {
                 ffi::egl::CONTEXT_LOST => Err(ContextError::ContextLost),
-                err => panic!(
-                    "make_current: eglMakeCurrent failed (eglGetError returned 0x{:x})",
-                    err
-                ),
+                err => {
+                    panic!("make_current: eglMakeCurrent failed (eglGetError returned 0x{:x})", err)
+                }
             }
         } else {
             Ok(())
@@ -534,11 +484,7 @@ impl Context {
 
     pub unsafe fn make_current(&self) -> Result<(), ContextError> {
         let egl = EGL.as_ref().unwrap();
-        let surface = self
-            .surface
-            .as_ref()
-            .map(|s| *s.lock())
-            .unwrap_or(ffi::egl::NO_SURFACE);
+        let surface = self.surface.as_ref().map(|s| *s.lock()).unwrap_or(ffi::egl::NO_SURFACE);
         let ret = egl.MakeCurrent(self.display, surface, surface, self.context);
 
         self.check_make_current(Some(ret))
@@ -547,13 +493,12 @@ impl Context {
     pub unsafe fn make_not_current(&self) -> Result<(), ContextError> {
         let egl = EGL.as_ref().unwrap();
 
-        let surface_eq =
-            if let Some(surface) = self.surface.as_ref().map(|s| *s.lock()) {
-                egl.GetCurrentSurface(ffi::egl::DRAW as i32) == surface
-                    || egl.GetCurrentSurface(ffi::egl::READ as i32) == surface
-            } else {
-                false
-            };
+        let surface_eq = if let Some(surface) = self.surface.as_ref().map(|s| *s.lock()) {
+            egl.GetCurrentSurface(ffi::egl::DRAW as i32) == surface
+                || egl.GetCurrentSurface(ffi::egl::READ as i32) == surface
+        } else {
+            false
+        };
 
         if surface_eq || egl.GetCurrentContext() == self.context {
             let ret = egl.MakeCurrent(
@@ -601,25 +546,13 @@ impl Context {
         if *surface != ffi::egl::NO_SURFACE {
             return;
         }
-        *surface = egl.CreateWindowSurface(
-            self.display,
-            self.config_id,
-            nwin,
-            std::ptr::null(),
-        );
+        *surface = egl.CreateWindowSurface(self.display, self.config_id, nwin, std::ptr::null());
         if surface.is_null() {
-            panic!(
-                "on_surface_created: eglCreateWindowSurface failed with 0x{:x}",
-                egl.GetError()
-            )
+            panic!("on_surface_created: eglCreateWindowSurface failed with 0x{:x}", egl.GetError())
         }
-        let ret =
-            egl.MakeCurrent(self.display, *surface, *surface, self.context);
+        let ret = egl.MakeCurrent(self.display, *surface, *surface, self.context);
         if ret == 0 {
-            panic!(
-                "on_surface_created: eglMakeCurrent failed with 0x{:x}",
-                egl.GetError()
-            )
+            panic!("on_surface_created: eglMakeCurrent failed with 0x{:x}", egl.GetError())
         }
     }
 
@@ -641,10 +574,7 @@ impl Context {
             ffi::egl::NO_CONTEXT,
         );
         if ret == 0 {
-            panic!(
-                "on_surface_destroyed: eglMakeCurrent failed with 0x{:x}",
-                egl.GetError()
-            )
+            panic!("on_surface_destroyed: eglMakeCurrent failed with 0x{:x}", egl.GetError())
         }
 
         egl.DestroySurface(self.display, *surface);
@@ -671,13 +601,10 @@ impl Context {
 
         if ret == 0 {
             match unsafe { egl.GetError() } as u32 {
-                ffi::egl::CONTEXT_LOST => {
-                    return Err(ContextError::ContextLost)
+                ffi::egl::CONTEXT_LOST => return Err(ContextError::ContextLost),
+                err => {
+                    panic!("swap_buffers: eglSwapBuffers failed (eglGetError returned 0x{:x})", err)
                 }
-                err => panic!(
-                    "swap_buffers: eglSwapBuffers failed (eglGetError returned 0x{:x})",
-                    err
-                ),
             }
         } else {
             Ok(())
@@ -685,10 +612,7 @@ impl Context {
     }
 
     #[inline]
-    pub fn swap_buffers_with_damage(
-        &self,
-        rects: &[Rect],
-    ) -> Result<(), ContextError> {
+    pub fn swap_buffers_with_damage(&self, rects: &[Rect]) -> Result<(), ContextError> {
         let egl = EGL.as_ref().unwrap();
 
         if !egl.SwapBuffersWithDamageKHR.is_loaded() {
@@ -700,8 +624,7 @@ impl Context {
             return Err(ContextError::ContextLost);
         }
 
-        let mut ffirects: Vec<ffi::egl::types::EGLint> =
-            Vec::with_capacity(rects.len() * 4);
+        let mut ffirects: Vec<ffi::egl::types::EGLint> = Vec::with_capacity(rects.len() * 4);
 
         for rect in rects {
             ffirects.push(rect.x as ffi::egl::types::EGLint);
@@ -721,13 +644,10 @@ impl Context {
 
         if ret == ffi::egl::FALSE {
             match unsafe { egl.GetError() } as u32 {
-                ffi::egl::CONTEXT_LOST => {
-                    return Err(ContextError::ContextLost)
+                ffi::egl::CONTEXT_LOST => return Err(ContextError::ContextLost),
+                err => {
+                    panic!("swap_buffers: eglSwapBuffers failed (eglGetError returned 0x{:x})", err)
                 }
-                err => panic!(
-                    "swap_buffers: eglSwapBuffers failed (eglGetError returned 0x{:x})",
-                    err
-                ),
             }
         } else {
             Ok(())
@@ -754,29 +674,19 @@ impl Drop for Context {
         unsafe {
             // https://stackoverflow.com/questions/54402688/recreate-eglcreatewindowsurface-with-same-native-window
             let egl = EGL.as_ref().unwrap();
-            let surface = self
-                .surface
-                .as_ref()
-                .map(|s| *s.lock())
-                .unwrap_or(ffi::egl::NO_SURFACE);
+            let surface = self.surface.as_ref().map(|s| *s.lock()).unwrap_or(ffi::egl::NO_SURFACE);
             // Ok, so we got to call `glFinish` before destroying the context
             // to ensure it actually gets destroyed. This requires making the
             // this context current.
-            let mut guard = MakeCurrentGuard::new(
-                self.display,
-                surface,
-                surface,
-                self.context,
-            )
-            .map_err(|err| ContextError::OsError(err))
-            .unwrap();
+            let mut guard = MakeCurrentGuard::new(self.display, surface, surface, self.context)
+                .map_err(|err| ContextError::OsError(err))
+                .unwrap();
 
             guard.if_any_same_then_invalidate(surface, surface, self.context);
 
             let gl_finish_fn = self.get_proc_address("glFinish");
             assert!(gl_finish_fn != std::ptr::null());
-            let gl_finish_fn =
-                std::mem::transmute::<_, extern "system" fn()>(gl_finish_fn);
+            let gl_finish_fn = std::mem::transmute::<_, extern "system" fn()>(gl_finish_fn);
             gl_finish_fn();
 
             egl.DestroyContext(self.display, self.context);
@@ -879,10 +789,9 @@ pub fn get_native_visual_id(
         )
     };
     if ret == 0 {
-        panic!(
-            "get_native_visual_id: eglGetConfigAttrib failed with 0x{:x}",
-            unsafe { egl.GetError() }
-        )
+        panic!("get_native_visual_id: eglGetConfigAttrib failed with 0x{:x}", unsafe {
+            egl.GetError()
+        })
     };
     value
 }
@@ -900,22 +809,13 @@ impl<'a> ContextPrototype<'a> {
         get_native_visual_id(self.display, self.config_id)
     }
 
-    pub fn finish(
-        self,
-        nwin: ffi::EGLNativeWindowType,
-    ) -> Result<Context, CreationError> {
+    pub fn finish(self, nwin: ffi::EGLNativeWindowType) -> Result<Context, CreationError> {
         let egl = EGL.as_ref().unwrap();
         let surface = unsafe {
-            let surface = egl.CreateWindowSurface(
-                self.display,
-                self.config_id,
-                nwin,
-                std::ptr::null(),
-            );
+            let surface =
+                egl.CreateWindowSurface(self.display, self.config_id, nwin, std::ptr::null());
             if surface.is_null() {
-                return Err(CreationError::OsError(
-                    "eglCreateWindowSurface failed".to_string(),
-                ));
+                return Err(CreationError::OsError("eglCreateWindowSurface failed".to_string()));
             }
             surface
         };
@@ -933,15 +833,8 @@ impl<'a> ContextPrototype<'a> {
     pub fn finish_surfaceless(self) -> Result<Context, CreationError> {
         // FIXME: Also check for the GL_OES_surfaceless_context *CONTEXT*
         // extension
-        if self
-            .extensions
-            .iter()
-            .find(|s| s == &"EGL_KHR_surfaceless_context")
-            .is_none()
-        {
-            Err(CreationError::NotSupported(
-                "EGL surfaceless not supported".to_string(),
-            ))
+        if self.extensions.iter().find(|s| s == &"EGL_KHR_surfaceless_context").is_none() {
+            Err(CreationError::NotSupported("EGL surfaceless not supported".to_string()))
         } else {
             self.finish_impl(None)
         }
@@ -956,10 +849,7 @@ impl<'a> ContextPrototype<'a> {
         target_os = "netbsd",
         target_os = "openbsd",
     ))]
-    pub fn finish_pbuffer(
-        self,
-        size: dpi::PhysicalSize<u32>,
-    ) -> Result<Context, CreationError> {
+    pub fn finish_pbuffer(self, size: dpi::PhysicalSize<u32>) -> Result<Context, CreationError> {
         let size: (u32, u32) = size.into();
 
         let egl = EGL.as_ref().unwrap();
@@ -977,15 +867,9 @@ impl<'a> ContextPrototype<'a> {
         ];
 
         let surface = unsafe {
-            let surface = egl.CreatePbufferSurface(
-                self.display,
-                self.config_id,
-                attrs.as_ptr(),
-            );
+            let surface = egl.CreatePbufferSurface(self.display, self.config_id, attrs.as_ptr());
             if surface.is_null() || surface == ffi::egl::NO_SURFACE {
-                return Err(CreationError::OsError(
-                    "eglCreatePbufferSurface failed".to_string(),
-                ));
+                return Err(CreationError::OsError("eglCreatePbufferSurface failed".to_string()));
             }
             surface
         };
@@ -1089,21 +973,13 @@ impl<'a> ContextPrototype<'a> {
         if let Some(surface) = surface {
             // VSync defaults to enabled; disable it if it was not requested.
             if !self.opengl.vsync {
-                let _guard = MakeCurrentGuard::new(
-                    self.display,
-                    surface,
-                    surface,
-                    context,
-                )
-                .map_err(|err| CreationError::OsError(err))?;
+                let _guard = MakeCurrentGuard::new(self.display, surface, surface, context)
+                    .map_err(|err| CreationError::OsError(err))?;
 
                 let egl = EGL.as_ref().unwrap();
                 unsafe {
                     if egl.SwapInterval(self.display, 0) == ffi::egl::FALSE {
-                        panic!(
-                            "finish_impl: eglSwapInterval failed: 0x{:x}",
-                            egl.GetError()
-                        );
+                        panic!("finish_impl: eglSwapInterval failed: 0x{:x}", egl.GetError());
                     }
                 }
             }
@@ -1208,13 +1084,9 @@ where
             out.push(ffi::egl::RED_SIZE as raw::c_int);
             out.push((color / 3) as raw::c_int);
             out.push(ffi::egl::GREEN_SIZE as raw::c_int);
-            out.push(
-                (color / 3 + if color % 3 != 0 { 1 } else { 0 }) as raw::c_int,
-            );
+            out.push((color / 3 + if color % 3 != 0 { 1 } else { 0 }) as raw::c_int);
             out.push(ffi::egl::BLUE_SIZE as raw::c_int);
-            out.push(
-                (color / 3 + if color % 3 == 2 { 1 } else { 0 }) as raw::c_int,
-            );
+            out.push((color / 3 + if color % 3 == 2 { 1 } else { 0 }) as raw::c_int);
         }
 
         if let Some(alpha) = pf_reqs.alpha_bits {
@@ -1266,17 +1138,10 @@ where
 
     // calling `eglChooseConfig`
     let mut num_configs = std::mem::zeroed();
-    if egl.ChooseConfig(
-        display,
-        descriptor.as_ptr(),
-        std::ptr::null_mut(),
-        0,
-        &mut num_configs,
-    ) == 0
+    if egl.ChooseConfig(display, descriptor.as_ptr(), std::ptr::null_mut(), 0, &mut num_configs)
+        == 0
     {
-        return Err(CreationError::OsError(
-            "eglChooseConfig failed".to_string(),
-        ));
+        return Err(CreationError::OsError("eglChooseConfig failed".to_string()));
     }
 
     if num_configs == 0 {
@@ -1293,9 +1158,7 @@ where
         &mut num_configs,
     ) == 0
     {
-        return Err(CreationError::OsError(
-            "eglChooseConfig failed".to_string(),
-        ));
+        return Err(CreationError::OsError("eglChooseConfig failed".to_string()));
     }
 
     // We're interested in those configs which allow our desired VSync.
@@ -1336,8 +1199,8 @@ where
         return Err(CreationError::NoAvailablePixelFormat);
     }
 
-    let config_id = config_selector(config_ids, display)
-        .map_err(|_| CreationError::NoAvailablePixelFormat)?;
+    let config_id =
+        config_selector(config_ids, display).map_err(|_| CreationError::NoAvailablePixelFormat)?;
 
     // analyzing each config
     macro_rules! attrib {
@@ -1350,34 +1213,24 @@ where
                 &mut value,
             );
             if res == 0 {
-                return Err(CreationError::OsError(
-                    "eglGetConfigAttrib failed".to_string(),
-                ));
+                return Err(CreationError::OsError("eglGetConfigAttrib failed".to_string()));
             }
             value
         }};
     };
 
     let desc = PixelFormat {
-        hardware_accelerated: attrib!(
-            egl,
-            display,
-            config_id,
-            ffi::egl::CONFIG_CAVEAT
-        ) != ffi::egl::SLOW_CONFIG as i32,
+        hardware_accelerated: attrib!(egl, display, config_id, ffi::egl::CONFIG_CAVEAT)
+            != ffi::egl::SLOW_CONFIG as i32,
         color_bits: attrib!(egl, display, config_id, ffi::egl::RED_SIZE) as u8
             + attrib!(egl, display, config_id, ffi::egl::BLUE_SIZE) as u8
             + attrib!(egl, display, config_id, ffi::egl::GREEN_SIZE) as u8,
-        alpha_bits: attrib!(egl, display, config_id, ffi::egl::ALPHA_SIZE)
-            as u8,
-        depth_bits: attrib!(egl, display, config_id, ffi::egl::DEPTH_SIZE)
-            as u8,
-        stencil_bits: attrib!(egl, display, config_id, ffi::egl::STENCIL_SIZE)
-            as u8,
+        alpha_bits: attrib!(egl, display, config_id, ffi::egl::ALPHA_SIZE) as u8,
+        depth_bits: attrib!(egl, display, config_id, ffi::egl::DEPTH_SIZE) as u8,
+        stencil_bits: attrib!(egl, display, config_id, ffi::egl::STENCIL_SIZE) as u8,
         stereoscopy: false,
         double_buffer: true,
-        multisampling: match attrib!(egl, display, config_id, ffi::egl::SAMPLES)
-        {
+        multisampling: match attrib!(egl, display, config_id, ffi::egl::SAMPLES) {
             0 | 1 => None,
             a => Some(a as u16),
         },
@@ -1404,10 +1257,7 @@ unsafe fn create_context(
     let mut flags = 0;
 
     if egl_version >= &(1, 5)
-        || extensions
-            .iter()
-            .find(|s| s == &"EGL_KHR_create_context")
-            .is_some()
+        || extensions.iter().find(|s| s == &"EGL_KHR_create_context").is_some()
     {
         context_attributes.push(ffi::egl::CONTEXT_MAJOR_VERSION as i32);
         context_attributes.push(version.0 as i32);
@@ -1416,37 +1266,24 @@ unsafe fn create_context(
 
         // handling robustness
         let supports_robustness = egl_version >= &(1, 5)
-            || extensions
-                .iter()
-                .find(|s| s == &"EGL_EXT_create_context_robustness")
-                .is_some();
+            || extensions.iter().find(|s| s == &"EGL_EXT_create_context_robustness").is_some();
 
         match gl_robustness {
             Robustness::NotRobust => (),
 
             Robustness::NoError => {
-                if extensions
-                    .iter()
-                    .find(|s| s == &"EGL_KHR_create_context_no_error")
-                    .is_some()
-                {
-                    context_attributes.push(
-                        ffi::egl::CONTEXT_OPENGL_NO_ERROR_KHR as raw::c_int,
-                    );
+                if extensions.iter().find(|s| s == &"EGL_KHR_create_context_no_error").is_some() {
+                    context_attributes.push(ffi::egl::CONTEXT_OPENGL_NO_ERROR_KHR as raw::c_int);
                     context_attributes.push(1);
                 }
             }
 
             Robustness::RobustNoResetNotification => {
                 if supports_robustness {
-                    context_attributes.push(
-                        ffi::egl::CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY
-                            as raw::c_int,
-                    );
                     context_attributes
-                        .push(ffi::egl::NO_RESET_NOTIFICATION as raw::c_int);
-                    flags = flags
-                        | ffi::egl::CONTEXT_OPENGL_ROBUST_ACCESS as raw::c_int;
+                        .push(ffi::egl::CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY as raw::c_int);
+                    context_attributes.push(ffi::egl::NO_RESET_NOTIFICATION as raw::c_int);
+                    flags = flags | ffi::egl::CONTEXT_OPENGL_ROBUST_ACCESS as raw::c_int;
                 } else {
                     return Err(CreationError::RobustnessNotSupported);
                 }
@@ -1454,27 +1291,19 @@ unsafe fn create_context(
 
             Robustness::TryRobustNoResetNotification => {
                 if supports_robustness {
-                    context_attributes.push(
-                        ffi::egl::CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY
-                            as raw::c_int,
-                    );
                     context_attributes
-                        .push(ffi::egl::NO_RESET_NOTIFICATION as raw::c_int);
-                    flags = flags
-                        | ffi::egl::CONTEXT_OPENGL_ROBUST_ACCESS as raw::c_int;
+                        .push(ffi::egl::CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY as raw::c_int);
+                    context_attributes.push(ffi::egl::NO_RESET_NOTIFICATION as raw::c_int);
+                    flags = flags | ffi::egl::CONTEXT_OPENGL_ROBUST_ACCESS as raw::c_int;
                 }
             }
 
             Robustness::RobustLoseContextOnReset => {
                 if supports_robustness {
-                    context_attributes.push(
-                        ffi::egl::CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY
-                            as raw::c_int,
-                    );
                     context_attributes
-                        .push(ffi::egl::LOSE_CONTEXT_ON_RESET as raw::c_int);
-                    flags = flags
-                        | ffi::egl::CONTEXT_OPENGL_ROBUST_ACCESS as raw::c_int;
+                        .push(ffi::egl::CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY as raw::c_int);
+                    context_attributes.push(ffi::egl::LOSE_CONTEXT_ON_RESET as raw::c_int);
+                    flags = flags | ffi::egl::CONTEXT_OPENGL_ROBUST_ACCESS as raw::c_int;
                 } else {
                     return Err(CreationError::RobustnessNotSupported);
                 }
@@ -1482,14 +1311,10 @@ unsafe fn create_context(
 
             Robustness::TryRobustLoseContextOnReset => {
                 if supports_robustness {
-                    context_attributes.push(
-                        ffi::egl::CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY
-                            as raw::c_int,
-                    );
                     context_attributes
-                        .push(ffi::egl::LOSE_CONTEXT_ON_RESET as raw::c_int);
-                    flags = flags
-                        | ffi::egl::CONTEXT_OPENGL_ROBUST_ACCESS as raw::c_int;
+                        .push(ffi::egl::CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY as raw::c_int);
+                    context_attributes.push(ffi::egl::LOSE_CONTEXT_ON_RESET as raw::c_int);
+                    flags = flags | ffi::egl::CONTEXT_OPENGL_ROBUST_ACCESS as raw::c_int;
                 }
             }
         }
@@ -1519,8 +1344,7 @@ unsafe fn create_context(
     } else if egl_version >= &(1, 3) && api == Api::OpenGlEs {
         // robustness is not supported
         match gl_robustness {
-            Robustness::RobustNoResetNotification
-            | Robustness::RobustLoseContextOnReset => {
+            Robustness::RobustNoResetNotification | Robustness::RobustLoseContextOnReset => {
                 return Err(CreationError::RobustnessNotSupported);
             }
             _ => (),
@@ -1532,12 +1356,7 @@ unsafe fn create_context(
 
     context_attributes.push(ffi::egl::NONE as i32);
 
-    let context = egl.CreateContext(
-        display,
-        config_id,
-        share,
-        context_attributes.as_ptr(),
-    );
+    let context = egl.CreateContext(display, config_id, share, context_attributes.as_ptr());
 
     if context.is_null() {
         match egl.GetError() as u32 {

--- a/glutin/src/api/glx/make_current_guard.rs
+++ b/glutin/src/api/glx/make_current_guard.rs
@@ -38,8 +38,7 @@ impl MakeCurrentGuard {
                 }),
             };
 
-            let res =
-                glx.MakeCurrent(xconn.display as *mut _, drawable, context);
+            let res = glx.MakeCurrent(xconn.display as *mut _, drawable, context);
 
             if res == 0 {
                 let err = xconn.check_errors();
@@ -72,8 +71,7 @@ impl Drop for MakeCurrentGuard {
             old_display => old_display,
         };
 
-        let res =
-            unsafe { glx.MakeCurrent(display as *mut _, drawable, context) };
+        let res = unsafe { glx.MakeCurrent(display as *mut _, drawable, context) };
 
         if res == 0 {
             let err = self.xconn.check_errors();

--- a/glutin/src/api/glx/mod.rs
+++ b/glutin/src/api/glx/mod.rs
@@ -22,13 +22,9 @@ mod glx {
     impl SymTrait for ffi::glx::Glx {
         fn load_with(lib: &libloading::Library) -> Self {
             Self::load_with(|sym| unsafe {
-                lib.get(
-                    std::ffi::CString::new(sym.as_bytes())
-                        .unwrap()
-                        .as_bytes_with_nul(),
-                )
-                .map(|sym| *sym)
-                .unwrap_or(std::ptr::null_mut())
+                lib.get(std::ffi::CString::new(sym.as_bytes()).unwrap().as_bytes_with_nul())
+                    .map(|sym| *sym)
+                    .unwrap_or(std::ptr::null_mut())
             })
         }
     }
@@ -59,8 +55,8 @@ mod glx {
 pub use self::glx::Glx;
 use self::make_current_guard::MakeCurrentGuard;
 use crate::{
-    Api, ContextError, CreationError, GlAttributes, GlProfile, GlRequest,
-    PixelFormat, PixelFormatRequirements, ReleaseBehavior, Robustness,
+    Api, ContextError, CreationError, GlAttributes, GlProfile, GlRequest, PixelFormat,
+    PixelFormatRequirements, ReleaseBehavior, Robustness,
 };
 
 use crate::platform::unix::x11::XConnection;
@@ -113,14 +109,7 @@ impl Context {
 
         // finding the pixel format we want
         let (fb_config, pixel_format, visual_infos) = unsafe {
-            choose_fbconfig(
-                &extensions,
-                &xconn,
-                screen_id,
-                pf_reqs,
-                surface_type,
-                transparent,
-            )?
+            choose_fbconfig(&extensions, &xconn, screen_id, pf_reqs, surface_type, transparent)?
         };
 
         Ok(ContextPrototype {
@@ -133,16 +122,10 @@ impl Context {
         })
     }
 
-    unsafe fn check_make_current(
-        &self,
-        ret: Option<i32>,
-    ) -> Result<(), ContextError> {
+    unsafe fn check_make_current(&self, ret: Option<i32>) -> Result<(), ContextError> {
         if ret == Some(0) {
             let err = self.xconn.check_errors();
-            Err(ContextError::OsError(format!(
-                "`glXMakeCurrent` failed: {:?}",
-                err
-            )))
+            Err(ContextError::OsError(format!("`glXMakeCurrent` failed: {:?}", err)))
         } else {
             Ok(())
         }
@@ -151,25 +134,15 @@ impl Context {
     #[inline]
     pub unsafe fn make_current(&self) -> Result<(), ContextError> {
         let glx = GLX.as_ref().unwrap();
-        let res = glx.MakeCurrent(
-            self.xconn.display as *mut _,
-            self.drawable,
-            self.context,
-        );
+        let res = glx.MakeCurrent(self.xconn.display as *mut _, self.drawable, self.context);
         self.check_make_current(Some(res))
     }
 
     #[inline]
     pub unsafe fn make_not_current(&self) -> Result<(), ContextError> {
         let glx = GLX.as_ref().unwrap();
-        if self.drawable == glx.GetCurrentDrawable()
-            || self.context == glx.GetCurrentContext()
-        {
-            let res = glx.MakeCurrent(
-                self.xconn.display as *mut _,
-                0,
-                std::ptr::null(),
-            );
+        if self.drawable == glx.GetCurrentDrawable() || self.context == glx.GetCurrentContext() {
+            let res = glx.MakeCurrent(self.xconn.display as *mut _, 0, std::ptr::null());
             self.check_make_current(Some(res))
         } else {
             self.check_make_current(None)
@@ -207,10 +180,7 @@ impl Context {
             glx.SwapBuffers(self.xconn.display as *mut _, self.drawable);
         }
         if let Err(err) = self.xconn.check_errors() {
-            Err(ContextError::OsError(format!(
-                "`glXSwapBuffers` failed: {:?}",
-                err
-            )))
+            Err(ContextError::OsError(format!("`glXSwapBuffers` failed: {:?}", err)))
         } else {
             Ok(())
         }
@@ -230,15 +200,13 @@ impl Drop for Context {
         let glx = GLX.as_ref().unwrap();
         unsafe {
             // See `drop` for `crate::api::egl::Context` for rationale.
-            let mut guard =
-                MakeCurrentGuard::new(&self.xconn, self.drawable, self.context)
-                    .map_err(|err| ContextError::OsError(err))
-                    .unwrap();
+            let mut guard = MakeCurrentGuard::new(&self.xconn, self.drawable, self.context)
+                .map_err(|err| ContextError::OsError(err))
+                .unwrap();
 
             let gl_finish_fn = self.get_proc_address("glFinish");
             assert!(gl_finish_fn != std::ptr::null());
-            let gl_finish_fn =
-                std::mem::transmute::<_, extern "system" fn()>(gl_finish_fn);
+            let gl_finish_fn = std::mem::transmute::<_, extern "system" fn()>(gl_finish_fn);
             gl_finish_fn();
 
             if guard.old_context() == Some(self.context) {
@@ -268,9 +236,7 @@ impl<'a> ContextPrototype<'a> {
     }
 
     // creating GL context
-    fn create_context(
-        &self,
-    ) -> Result<(ffi::glx_extra::Glx, ffi::GLXContext), CreationError> {
+    fn create_context(&self) -> Result<(ffi::glx_extra::Glx, ffi::GLXContext), CreationError> {
         let glx = GLX.as_ref().unwrap();
         let share = match self.opengl.sharing {
             Some(ctx) => ctx.context,
@@ -280,9 +246,7 @@ impl<'a> ContextPrototype<'a> {
         // loading the extra GLX functions
         let extra_functions = ffi::glx_extra::Glx::load_with(|proc_name| {
             let c_str = CString::new(proc_name).unwrap();
-            unsafe {
-                glx.GetProcAddress(c_str.as_ptr() as *const u8) as *const _
-            }
+            unsafe { glx.GetProcAddress(c_str.as_ptr() as *const u8) as *const _ }
         });
 
         let context = match self.opengl.version {
@@ -356,10 +320,7 @@ impl<'a> ContextPrototype<'a> {
                 &self.visual_infos,
             )?,
             GlRequest::Specific(_, _) => panic!("Only OpenGL is supported"),
-            GlRequest::GlThenGles {
-                opengl_version: (major, minor),
-                ..
-            } => create_context(
+            GlRequest::GlThenGles { opengl_version: (major, minor), .. } => create_context(
                 &extra_functions,
                 &self.extensions,
                 &self.xconn.xlib,
@@ -377,10 +338,7 @@ impl<'a> ContextPrototype<'a> {
         Ok((extra_functions, context))
     }
 
-    pub fn finish_pbuffer(
-        self,
-        size: dpi::PhysicalSize<u32>,
-    ) -> Result<Context, CreationError> {
+    pub fn finish_pbuffer(self, size: dpi::PhysicalSize<u32>) -> Result<Context, CreationError> {
         let glx = GLX.as_ref().unwrap();
         let size: (u32, u32) = size.into();
         let (_extra_functions, context) = self.create_context()?;
@@ -394,11 +352,7 @@ impl<'a> ContextPrototype<'a> {
         ];
 
         let pbuffer = unsafe {
-            glx.CreatePbuffer(
-                self.xconn.display as *mut _,
-                self.fb_config,
-                attributes.as_ptr(),
-            )
+            glx.CreatePbuffer(self.xconn.display as *mut _, self.fb_config, attributes.as_ptr())
         };
 
         Ok(Context {
@@ -424,11 +378,7 @@ impl<'a> ContextPrototype<'a> {
         {
             // this should be the most common extension
             unsafe {
-                extra_functions.SwapIntervalEXT(
-                    self.xconn.display as *mut _,
-                    window,
-                    swap_mode,
-                );
+                extra_functions.SwapIntervalEXT(self.xconn.display as *mut _, window, swap_mode);
             }
 
             let mut swap = unsafe { std::mem::zeroed() };
@@ -474,10 +424,7 @@ impl<'a> ContextPrototype<'a> {
     }
 }
 
-extern "C" fn x_error_callback(
-    _dpy: *mut ffi::Display,
-    _err: *mut ffi::XErrorEvent,
-) -> i32 {
+extern "C" fn x_error_callback(_dpy: *mut ffi::Display, _err: *mut ffi::XErrorEvent) -> i32 {
     0
 }
 
@@ -500,11 +447,9 @@ fn create_context(
         let context = if check_ext(extensions, "GLX_ARB_create_context") {
             let mut attributes = Vec::with_capacity(9);
 
-            attributes
-                .push(ffi::glx_extra::CONTEXT_MAJOR_VERSION_ARB as raw::c_int);
+            attributes.push(ffi::glx_extra::CONTEXT_MAJOR_VERSION_ARB as raw::c_int);
             attributes.push(version.0 as raw::c_int);
-            attributes
-                .push(ffi::glx_extra::CONTEXT_MINOR_VERSION_ARB as raw::c_int);
+            attributes.push(ffi::glx_extra::CONTEXT_MINOR_VERSION_ARB as raw::c_int);
             attributes.push(version.1 as raw::c_int);
 
             if let Some(profile) = profile {
@@ -512,14 +457,10 @@ fn create_context(
                     GlProfile::Compatibility => {
                         ffi::glx_extra::CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB
                     }
-                    GlProfile::Core => {
-                        ffi::glx_extra::CONTEXT_CORE_PROFILE_BIT_ARB
-                    }
+                    GlProfile::Core => ffi::glx_extra::CONTEXT_CORE_PROFILE_BIT_ARB,
                 };
 
-                attributes.push(
-                    ffi::glx_extra::CONTEXT_PROFILE_MASK_ARB as raw::c_int,
-                );
+                attributes.push(ffi::glx_extra::CONTEXT_PROFILE_MASK_ARB as raw::c_int);
                 attributes.push(flag as raw::c_int);
             }
 
@@ -532,28 +473,24 @@ fn create_context(
                         Robustness::RobustNoResetNotification
                         | Robustness::TryRobustNoResetNotification => {
                             attributes.push(
-                                ffi::glx_extra::CONTEXT_RESET_NOTIFICATION_STRATEGY_ARB as raw::c_int,
-                            );
-                            attributes.push(
-                                ffi::glx_extra::NO_RESET_NOTIFICATION_ARB
+                                ffi::glx_extra::CONTEXT_RESET_NOTIFICATION_STRATEGY_ARB
                                     as raw::c_int,
                             );
-                            flags = flags
-                                | ffi::glx_extra::CONTEXT_ROBUST_ACCESS_BIT_ARB
-                                    as raw::c_int;
+                            attributes
+                                .push(ffi::glx_extra::NO_RESET_NOTIFICATION_ARB as raw::c_int);
+                            flags =
+                                flags | ffi::glx_extra::CONTEXT_ROBUST_ACCESS_BIT_ARB as raw::c_int;
                         }
                         Robustness::RobustLoseContextOnReset
                         | Robustness::TryRobustLoseContextOnReset => {
                             attributes.push(
-                                ffi::glx_extra::CONTEXT_RESET_NOTIFICATION_STRATEGY_ARB as raw::c_int,
-                            );
-                            attributes.push(
-                                ffi::glx_extra::LOSE_CONTEXT_ON_RESET_ARB
+                                ffi::glx_extra::CONTEXT_RESET_NOTIFICATION_STRATEGY_ARB
                                     as raw::c_int,
                             );
-                            flags = flags
-                                | ffi::glx_extra::CONTEXT_ROBUST_ACCESS_BIT_ARB
-                                    as raw::c_int;
+                            attributes
+                                .push(ffi::glx_extra::LOSE_CONTEXT_ON_RESET_ARB as raw::c_int);
+                            flags =
+                                flags | ffi::glx_extra::CONTEXT_ROBUST_ACCESS_BIT_ARB as raw::c_int;
                         }
                         Robustness::NotRobust => (),
                         Robustness::NoError => (),
@@ -569,8 +506,7 @@ fn create_context(
                 }
 
                 if debug {
-                    flags = flags
-                        | ffi::glx_extra::CONTEXT_DEBUG_BIT_ARB as raw::c_int;
+                    flags = flags | ffi::glx_extra::CONTEXT_DEBUG_BIT_ARB as raw::c_int;
                 }
 
                 flags
@@ -590,21 +526,14 @@ fn create_context(
             )
         } else {
             let visual_infos: *const ffi::XVisualInfo = visual_infos;
-            glx.CreateContext(
-                display as *mut _,
-                visual_infos as *mut _,
-                share,
-                1,
-            )
+            glx.CreateContext(display as *mut _, visual_infos as *mut _, share, 1)
         };
 
         (xlib.XSetErrorHandler)(old_callback);
 
         if context.is_null() {
             // TODO: check for errors and return `OpenGlVersionNotSupported`
-            return Err(CreationError::OsError(
-                "GL context creation failed".to_string(),
-            ));
+            return Err(CreationError::OsError("GL context creation failed".to_string()));
         }
 
         Ok(context)
@@ -619,10 +548,7 @@ unsafe fn choose_fbconfig(
     pf_reqs: &PixelFormatRequirements,
     surface_type: SurfaceType,
     transparent: Option<bool>,
-) -> Result<
-    (ffi::glx::types::GLXFBConfig, PixelFormat, ffi::XVisualInfo),
-    CreationError,
-> {
+) -> Result<(ffi::glx::types::GLXFBConfig, PixelFormat, ffi::XVisualInfo), CreationError> {
     let glx = GLX.as_ref().unwrap();
 
     let descriptor = {
@@ -633,9 +559,7 @@ unsafe fn choose_fbconfig(
 
         if let Some(xid) = pf_reqs.x11_visual_xid {
             // getting the visual infos
-            let fvi = crate::platform_impl::x11_utils::get_visual_info_from_xid(
-                &xconn, xid,
-            );
+            let fvi = crate::platform_impl::x11_utils::get_visual_info_from_xid(&xconn, xid);
 
             out.push(ffi::glx::X_VISUAL_TYPE as raw::c_int);
             out.push(fvi.class as raw::c_int);
@@ -672,13 +596,9 @@ unsafe fn choose_fbconfig(
             out.push(ffi::glx::RED_SIZE as raw::c_int);
             out.push((color / 3) as raw::c_int);
             out.push(ffi::glx::GREEN_SIZE as raw::c_int);
-            out.push(
-                (color / 3 + if color % 3 != 0 { 1 } else { 0 }) as raw::c_int,
-            );
+            out.push((color / 3 + if color % 3 != 0 { 1 } else { 0 }) as raw::c_int);
             out.push(ffi::glx::BLUE_SIZE as raw::c_int);
-            out.push(
-                (color / 3 + if color % 3 == 2 { 1 } else { 0 }) as raw::c_int,
-            );
+            out.push((color / 3 + if color % 3 == 2 { 1 } else { 0 }) as raw::c_int);
         }
 
         if let Some(alpha) = pf_reqs.alpha_bits {
@@ -716,14 +636,10 @@ unsafe fn choose_fbconfig(
 
         if pf_reqs.srgb {
             if check_ext(extensions, "GLX_ARB_framebuffer_sRGB") {
-                out.push(
-                    ffi::glx_extra::FRAMEBUFFER_SRGB_CAPABLE_ARB as raw::c_int,
-                );
+                out.push(ffi::glx_extra::FRAMEBUFFER_SRGB_CAPABLE_ARB as raw::c_int);
                 out.push(1);
             } else if check_ext(extensions, "GLX_EXT_framebuffer_sRGB") {
-                out.push(
-                    ffi::glx_extra::FRAMEBUFFER_SRGB_CAPABLE_EXT as raw::c_int,
-                );
+                out.push(ffi::glx_extra::FRAMEBUFFER_SRGB_CAPABLE_EXT as raw::c_int);
                 out.push(1);
             } else {
                 return Err(CreationError::NoAvailablePixelFormat);
@@ -734,14 +650,8 @@ unsafe fn choose_fbconfig(
             ReleaseBehavior::Flush => (),
             ReleaseBehavior::None => {
                 if check_ext(extensions, "GLX_ARB_context_flush_control") {
-                    out.push(
-                        ffi::glx_extra::CONTEXT_RELEASE_BEHAVIOR_ARB
-                            as raw::c_int,
-                    );
-                    out.push(
-                        ffi::glx_extra::CONTEXT_RELEASE_BEHAVIOR_NONE_ARB
-                            as raw::c_int,
-                    );
+                    out.push(ffi::glx_extra::CONTEXT_RELEASE_BEHAVIOR_ARB as raw::c_int);
+                    out.push(ffi::glx_extra::CONTEXT_RELEASE_BEHAVIOR_NONE_ARB as raw::c_int);
                 }
             }
         }
@@ -754,10 +664,7 @@ unsafe fn choose_fbconfig(
     };
 
     // calling glXChooseFBConfig
-    let (fb_config, visual_infos): (
-        ffi::glx::types::GLXFBConfig,
-        ffi::XVisualInfo,
-    ) = {
+    let (fb_config, visual_infos): (ffi::glx::types::GLXFBConfig, ffi::XVisualInfo) = {
         let mut num_configs = 0;
         let configs = glx.ChooseFBConfig(
             xconn.display as *mut _,
@@ -787,8 +694,7 @@ unsafe fn choose_fbconfig(
                     return None;
                 }
 
-                let visual_infos: ffi::XVisualInfo =
-                    std::ptr::read(visual_infos_raw as *const _);
+                let visual_infos: ffi::XVisualInfo = std::ptr::read(visual_infos_raw as *const _);
                 (xconn.xlib.XFree)(visual_infos_raw as *mut _);
                 Some(visual_infos)
             },
@@ -809,12 +715,7 @@ unsafe fn choose_fbconfig(
 
     let get_attrib = |attrib: raw::c_int| -> i32 {
         let mut value = 0;
-        glx.GetFBConfigAttrib(
-            xconn.display as *mut _,
-            fb_config,
-            attrib,
-            &mut value,
-        );
+        glx.GetFBConfigAttrib(xconn.display as *mut _, fb_config, attrib, &mut value);
         // TODO: check return value
         value
     };
@@ -830,19 +731,13 @@ unsafe fn choose_fbconfig(
         stencil_bits: get_attrib(ffi::glx::STENCIL_SIZE as raw::c_int) as u8,
         stereoscopy: get_attrib(ffi::glx::STEREO as raw::c_int) != 0,
         double_buffer: get_attrib(ffi::glx::DOUBLEBUFFER as raw::c_int) != 0,
-        multisampling: if get_attrib(ffi::glx::SAMPLE_BUFFERS as raw::c_int)
-            != 0
-        {
+        multisampling: if get_attrib(ffi::glx::SAMPLE_BUFFERS as raw::c_int) != 0 {
             Some(get_attrib(ffi::glx::SAMPLES as raw::c_int) as u16)
         } else {
             None
         },
-        srgb: get_attrib(
-            ffi::glx_extra::FRAMEBUFFER_SRGB_CAPABLE_ARB as raw::c_int,
-        ) != 0
-            || get_attrib(
-                ffi::glx_extra::FRAMEBUFFER_SRGB_CAPABLE_EXT as raw::c_int,
-            ) != 0,
+        srgb: get_attrib(ffi::glx_extra::FRAMEBUFFER_SRGB_CAPABLE_ARB as raw::c_int) != 0
+            || get_attrib(ffi::glx_extra::FRAMEBUFFER_SRGB_CAPABLE_EXT as raw::c_int) != 0,
     };
 
     Ok((fb_config, pf_desc, visual_infos))
@@ -859,12 +754,10 @@ fn load_extensions(
 ) -> Result<String, CreationError> {
     unsafe {
         let glx = GLX.as_ref().unwrap();
-        let extensions =
-            glx.QueryExtensionsString(xconn.display as *mut _, screen_id);
+        let extensions = glx.QueryExtensionsString(xconn.display as *mut _, screen_id);
         if extensions.is_null() {
             return Err(CreationError::OsError(
-                "`glXQueryExtensionsString` found no glX extensions"
-                    .to_string(),
+                "`glXQueryExtensionsString` found no glX extensions".to_string(),
             ));
         }
         let extensions = CStr::from_ptr(extensions).to_bytes().to_vec();

--- a/glutin/src/api/ios/mod.rs
+++ b/glutin/src/api/ios/mod.rs
@@ -86,8 +86,7 @@ enum ColorFormat {
 impl ColorFormat {
     #[allow(non_upper_case_globals)]
     pub fn for_view(view: ffi::id) -> Self {
-        let color_format: ffi::NSUInteger =
-            unsafe { msg_send![view, drawableColorFormat] };
+        let color_format: ffi::NSUInteger = unsafe { msg_send![view, drawableColorFormat] };
         match color_format {
             ffi::GLKViewDrawableColorFormatRGBA8888 => ColorFormat::Rgba8888,
             ffi::GLKViewDrawableColorFormatRGB565 => ColorFormat::Rgb565,
@@ -119,8 +118,7 @@ impl ColorFormat {
 
 #[allow(non_upper_case_globals)]
 fn depth_for_view(view: ffi::id) -> u8 {
-    let depth_format: ffi::NSUInteger =
-        unsafe { msg_send![view, drawableDepthFormat] };
+    let depth_format: ffi::NSUInteger = unsafe { msg_send![view, drawableDepthFormat] };
     match depth_format {
         ffi::GLKViewDrawableDepthFormatNone => 0,
         ffi::GLKViewDrawableDepthFormat16 => 16,
@@ -131,8 +129,7 @@ fn depth_for_view(view: ffi::id) -> u8 {
 
 #[allow(non_upper_case_globals)]
 fn stencil_for_view(view: ffi::id) -> u8 {
-    let stencil_format: ffi::NSUInteger =
-        unsafe { msg_send![view, drawableStencilFormat] };
+    let stencil_format: ffi::NSUInteger = unsafe { msg_send![view, drawableStencilFormat] };
     match stencil_format {
         ffi::GLKViewDrawableStencilFormatNone => 0,
         ffi::GLKViewDrawableStencilFormat8 => 8,
@@ -142,8 +139,7 @@ fn stencil_for_view(view: ffi::id) -> u8 {
 
 #[allow(non_upper_case_globals)]
 fn multisampling_for_view(view: ffi::id) -> Option<u16> {
-    let ms_format: ffi::NSUInteger =
-        unsafe { msg_send![view, drawableMultisample] };
+    let ms_format: ffi::NSUInteger = unsafe { msg_send![view, drawableMultisample] };
     match ms_format {
         ffi::GLKViewDrawableMultisampleNone => None,
         ffi::GLKViewDrawableMultisample4X => Some(4),
@@ -159,9 +155,7 @@ pub struct Context {
 
 fn validate_version(version: u8) -> Result<ffi::NSUInteger, CreationError> {
     let version = version as ffi::NSUInteger;
-    if version >= ffi::kEAGLRenderingAPIOpenGLES1
-        && version <= ffi::kEAGLRenderingAPIOpenGLES3
-    {
+    if version >= ffi::kEAGLRenderingAPIOpenGLES1 && version <= ffi::kEAGLRenderingAPIOpenGLES3 {
         Ok(version)
     } else {
         Err(CreationError::OsError(format!(
@@ -180,10 +174,8 @@ impl Context {
         gl_attrs: &GlAttributes<&Context>,
     ) -> Result<(winit::window::Window, Self), CreationError> {
         create_view_class();
-        let view_class =
-            Class::get("MainGLView").expect("Failed to get class `MainGLView`");
-        let builder =
-            builder.with_root_view_class(view_class as *const _ as *const _);
+        let view_class = Class::get("MainGLView").expect("Failed to get class `MainGLView`");
+        let builder = builder.with_root_view_class(view_class as *const _ as *const _);
         if gl_attrs.sharing.is_some() {
             unimplemented!("Shared contexts are unimplemented on iOS.");
         }
@@ -199,10 +191,9 @@ impl Context {
                 )));
                 }
             }
-            GlRequest::GlThenGles {
-                opengles_version: (major, _minor),
-                ..
-            } => validate_version(major)?,
+            GlRequest::GlThenGles { opengles_version: (major, _minor), .. } => {
+                validate_version(major)?
+            }
         };
         let win = builder.build(el)?;
         let context = unsafe {
@@ -222,18 +213,12 @@ impl Context {
         gl_attr: &GlAttributes<&Context>,
         size: dpi::PhysicalSize<u32>,
     ) -> Result<Self, CreationError> {
-        let wb = winit::window::WindowBuilder::new()
-            .with_visible(false)
-            .with_inner_size(size);
-        Self::new_windowed(wb, el, pf_reqs, gl_attr)
-            .map(|(_window, context)| context)
+        let wb = winit::window::WindowBuilder::new().with_visible(false).with_inner_size(size);
+        Self::new_windowed(wb, el, pf_reqs, gl_attr).map(|(_window, context)| context)
     }
 
-    unsafe fn create_context(
-        mut version: ffi::NSUInteger,
-    ) -> Result<ffi::id, CreationError> {
-        let context_class = Class::get("EAGLContext")
-            .expect("Failed to get class `EAGLContext`");
+    unsafe fn create_context(mut version: ffi::NSUInteger) -> Result<ffi::id, CreationError> {
+        let context_class = Class::get("EAGLContext").expect("Failed to get class `EAGLContext`");
         let eagl_context: ffi::id = msg_send![context_class, alloc];
         let mut valid_context = ffi::nil;
         while valid_context == ffi::nil && version > 0 {
@@ -242,8 +227,7 @@ impl Context {
         }
         if valid_context == ffi::nil {
             Err(CreationError::OsError(
-                "Failed to create an OpenGL ES context with any version"
-                    .to_string(),
+                "Failed to create an OpenGL ES context with any version".to_string(),
             ))
         } else {
             Ok(eagl_context)
@@ -251,10 +235,8 @@ impl Context {
     }
 
     unsafe fn init_context(&mut self, win: &winit::window::Window) {
-        let dict_class = Class::get("NSDictionary")
-            .expect("Failed to get class `NSDictionary`");
-        let number_class =
-            Class::get("NSNumber").expect("Failed to get class `NSNumber`");
+        let dict_class = Class::get("NSDictionary").expect("Failed to get class `NSDictionary`");
+        let number_class = Class::get("NSNumber").expect("Failed to get class `NSNumber`");
         let draw_props: ffi::id = msg_send![dict_class, alloc];
         let draw_props: ffi::id = msg_send![draw_props,
             initWithObjects:
@@ -302,9 +284,7 @@ impl Context {
         );
 
         let status = gl.CheckFramebufferStatus(ffi::gles::FRAMEBUFFER);
-        if gl.CheckFramebufferStatus(ffi::gles::FRAMEBUFFER)
-            != ffi::gles::FRAMEBUFFER_COMPLETE
-        {
+        if gl.CheckFramebufferStatus(ffi::gles::FRAMEBUFFER) != ffi::gles::FRAMEBUFFER_COMPLETE {
             panic!("framebuffer status: {:?}", status);
         }
     }
@@ -312,10 +292,8 @@ impl Context {
     #[inline]
     pub fn swap_buffers(&self) -> Result<(), ContextError> {
         unsafe {
-            let res: BOOL = msg_send![
-                self.eagl_context,
-                presentRenderbuffer: ffi::gles::RENDERBUFFER
-            ];
+            let res: BOOL =
+                msg_send![self.eagl_context, presentRenderbuffer: ffi::gles::RENDERBUFFER];
             if res == YES {
                 Ok(())
             } else {
@@ -328,13 +306,8 @@ impl Context {
     }
 
     #[inline]
-    pub fn swap_buffers_with_damage(
-        &self,
-        rects: &[Rect],
-    ) -> Result<(), ContextError> {
-        Err(ContextError::OsError(
-            "buffer damage not suported".to_string(),
-        ))
+    pub fn swap_buffers_with_damage(&self, rects: &[Rect]) -> Result<(), ContextError> {
+        Err(ContextError::OsError("buffer damage not suported".to_string()))
     }
 
     #[inline]
@@ -365,10 +338,8 @@ impl Context {
 
     #[inline]
     pub unsafe fn make_current(&self) -> Result<(), ContextError> {
-        let context_class = Class::get("EAGLContext")
-            .expect("Failed to get class `EAGLContext`");
-        let res: BOOL =
-            msg_send![context_class, setCurrentContext: self.eagl_context];
+        let context_class = Class::get("EAGLContext").expect("Failed to get class `EAGLContext`");
+        let res: BOOL = msg_send![context_class, setCurrentContext: self.eagl_context];
         if res == YES {
             Ok(())
         } else {
@@ -385,8 +356,7 @@ impl Context {
             return Ok(());
         }
 
-        let context_class = Class::get("EAGLContext")
-            .expect("Failed to get class `EAGLContext`");
+        let context_class = Class::get("EAGLContext").expect("Failed to get class `EAGLContext`");
         let res: BOOL = msg_send![context_class, setCurrentContext: ffi::nil];
         if res == YES {
             Ok(())
@@ -406,18 +376,12 @@ impl Context {
     }
 
     #[inline]
-    pub fn get_proc_address(
-        &self,
-        proc_name: &str,
-    ) -> *const core::ffi::c_void {
-        let proc_name_c = CString::new(proc_name)
-            .expect("proc name contained interior nul byte");
+    pub fn get_proc_address(&self, proc_name: &str) -> *const core::ffi::c_void {
+        let proc_name_c = CString::new(proc_name).expect("proc name contained interior nul byte");
         let path = b"/System/Library/Frameworks/OpenGLES.framework/OpenGLES\0";
         let addr = unsafe {
-            let lib = ffi::dlopen(
-                path.as_ptr() as *const raw::c_char,
-                ffi::RTLD_LAZY | ffi::RTLD_GLOBAL,
-            );
+            let lib =
+                ffi::dlopen(path.as_ptr() as *const raw::c_char, ffi::RTLD_LAZY | ffi::RTLD_GLOBAL);
             ffi::dlsym(lib, proc_name_c.as_ptr()) as *const _
         };
         // debug!("proc {} -> {:?}", proc_name, addr);
@@ -436,17 +400,11 @@ impl Context {
 }
 
 fn create_view_class() {
-    extern "C" fn init_with_frame(
-        this: &Object,
-        _: Sel,
-        frame: ffi::CGRect,
-    ) -> ffi::id {
+    extern "C" fn init_with_frame(this: &Object, _: Sel, frame: ffi::CGRect) -> ffi::id {
         unsafe {
-            let view: ffi::id =
-                msg_send![super(this, class!(GLKView)), initWithFrame: frame];
+            let view: ffi::id = msg_send![super(this, class!(GLKView)), initWithFrame: frame];
 
-            let mask = ffi::UIViewAutoresizingFlexibleWidth
-                | ffi::UIViewAutoresizingFlexibleHeight;
+            let mask = ffi::UIViewAutoresizingFlexibleWidth | ffi::UIViewAutoresizingFlexibleHeight;
             let _: () = msg_send![view, setAutoresizingMask: mask];
             let _: () = msg_send![view, setAutoresizesSubviews: YES];
 
@@ -460,21 +418,18 @@ fn create_view_class() {
     extern "C" fn layer_class(_: &Class, _: Sel) -> *const Class {
         unsafe {
             std::mem::transmute(
-                Class::get("CAEAGLLayer")
-                    .expect("Failed to get class `CAEAGLLayer`"),
+                Class::get("CAEAGLLayer").expect("Failed to get class `CAEAGLLayer`"),
             )
         }
     }
 
-    let superclass =
-        Class::get("GLKView").expect("Failed to get class `GLKView`");
-    let mut decl = ClassDecl::new("MainGLView", superclass)
-        .expect("Failed to declare class `MainGLView`");
+    let superclass = Class::get("GLKView").expect("Failed to get class `GLKView`");
+    let mut decl =
+        ClassDecl::new("MainGLView", superclass).expect("Failed to declare class `MainGLView`");
     unsafe {
         decl.add_method(
             sel!(initWithFrame:),
-            init_with_frame
-                as extern "C" fn(&Object, Sel, ffi::CGRect) -> ffi::id,
+            init_with_frame as extern "C" fn(&Object, Sel, ffi::CGRect) -> ffi::id,
         );
         decl.add_class_method(
             sel!(layerClass),

--- a/glutin/src/api/osmesa/mod.rs
+++ b/glutin/src/api/osmesa/mod.rs
@@ -11,8 +11,8 @@ pub mod ffi {
 }
 
 use crate::{
-    Api, ContextError, CreationError, GlAttributes, GlProfile, GlRequest,
-    PixelFormatRequirements, Robustness,
+    Api, ContextError, CreationError, GlAttributes, GlProfile, GlRequest, PixelFormatRequirements,
+    Robustness,
 };
 
 use winit::dpi;
@@ -33,10 +33,7 @@ struct NoEsOrWebGlSupported;
 
 impl std::fmt::Display for NoEsOrWebGlSupported {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-        write!(
-            f,
-            "OsMesa only works with desktop OpenGL; OpenGL ES or WebGL are not supported"
-        )
+        write!(f, "OsMesa only works with desktop OpenGL; OpenGL ES or WebGL are not supported")
     }
 }
 
@@ -82,8 +79,7 @@ impl OsMesaContext {
         }
 
         match opengl.robustness {
-            Robustness::RobustNoResetNotification
-            | Robustness::RobustLoseContextOnReset => {
+            Robustness::RobustNoResetNotification | Robustness::RobustLoseContextOnReset => {
                 return Err(CreationError::RobustnessNotSupported.into());
             }
             _ => (),
@@ -114,16 +110,10 @@ impl OsMesaContext {
                 attribs.push(osmesa_sys::OSMESA_CONTEXT_MINOR_VERSION);
                 attribs.push(minor as raw::c_int);
             }
-            GlRequest::Specific(Api::OpenGlEs, _)
-            | GlRequest::Specific(Api::WebGl, _) => {
-                return Err(CreationError::NoBackendAvailable(Box::new(
-                    NoEsOrWebGlSupported,
-                )));
+            GlRequest::Specific(Api::OpenGlEs, _) | GlRequest::Specific(Api::WebGl, _) => {
+                return Err(CreationError::NoBackendAvailable(Box::new(NoEsOrWebGlSupported)));
             }
-            GlRequest::GlThenGles {
-                opengl_version: (major, minor),
-                ..
-            } => {
+            GlRequest::GlThenGles { opengl_version: (major, minor), .. } => {
                 attribs.push(osmesa_sys::OSMESA_CONTEXT_MAJOR_VERSION);
                 attribs.push(major as raw::c_int);
                 attribs.push(osmesa_sys::OSMESA_CONTEXT_MINOR_VERSION);
@@ -143,10 +133,8 @@ impl OsMesaContext {
                 .take((size.0 * size.1) as usize)
                 .collect(),
             context: unsafe {
-                let ctx = osmesa_sys::OSMesaCreateContextAttribs(
-                    attribs.as_ptr(),
-                    std::ptr::null_mut(),
-                );
+                let ctx =
+                    osmesa_sys::OSMesaCreateContextAttribs(attribs.as_ptr(), std::ptr::null_mut());
                 if ctx.is_null() {
                     return Err(CreationError::OsError(
                         "OSMesaCreateContextAttribs failed".to_string(),
@@ -188,13 +176,8 @@ impl OsMesaContext {
             // and seeing if it work.
             //
             // https://gitlab.freedesktop.org/mesa/mesa/merge_requests/533
-            let ret = osmesa_sys::OSMesaMakeCurrent(
-                std::ptr::null_mut(),
-                std::ptr::null_mut(),
-                0,
-                0,
-                0,
-            );
+            let ret =
+                osmesa_sys::OSMesaMakeCurrent(std::ptr::null_mut(), std::ptr::null_mut(), 0, 0, 0);
 
             if ret == 0 {
                 unimplemented!(
@@ -225,9 +208,7 @@ impl OsMesaContext {
     pub fn get_proc_address(&self, addr: &str) -> *const core::ffi::c_void {
         unsafe {
             let c_str = CString::new(addr.as_bytes().to_vec()).unwrap();
-            core::mem::transmute(osmesa_sys::OSMesaGetProcAddress(
-                c_str.as_ptr() as *mut _,
-            ))
+            core::mem::transmute(osmesa_sys::OSMesaGetProcAddress(c_str.as_ptr() as *mut _))
         }
     }
 }

--- a/glutin/src/api/wgl/make_current_guard.rs
+++ b/glutin/src/api/wgl/make_current_guard.rs
@@ -34,8 +34,8 @@ impl<'a, 'b> CurrentContextGuard<'a, 'b> {
         }
 
         Ok(CurrentContextGuard {
-            previous_hdc: previous_hdc,
-            previous_hglrc: previous_hglrc,
+            previous_hdc,
+            previous_hglrc,
             marker1: PhantomData,
             marker2: PhantomData,
         })

--- a/glutin/src/context.rs
+++ b/glutin/src/context.rs
@@ -41,21 +41,10 @@ impl<T: ContextCurrentState> Context<T> {
     ///
     /// [`ContextWrapper::make_current`]:
     /// struct.ContextWrapper.html#method.make_current
-    pub unsafe fn make_current(
-        self,
-    ) -> Result<Context<PossiblyCurrent>, (Self, ContextError)> {
+    pub unsafe fn make_current(self) -> Result<Context<PossiblyCurrent>, (Self, ContextError)> {
         match self.context.make_current() {
-            Ok(()) => Ok(Context {
-                context: self.context,
-                phantom: PhantomData,
-            }),
-            Err(err) => Err((
-                Context {
-                    context: self.context,
-                    phantom: PhantomData,
-                },
-                err,
-            )),
+            Ok(()) => Ok(Context { context: self.context, phantom: PhantomData }),
+            Err(err) => Err((Context { context: self.context, phantom: PhantomData }, err)),
         }
     }
 
@@ -63,21 +52,10 @@ impl<T: ContextCurrentState> Context<T> {
     ///
     /// [`ContextWrapper::make_not_current`]:
     /// struct.ContextWrapper.html#method.make_not_current
-    pub unsafe fn make_not_current(
-        self,
-    ) -> Result<Context<NotCurrent>, (Self, ContextError)> {
+    pub unsafe fn make_not_current(self) -> Result<Context<NotCurrent>, (Self, ContextError)> {
         match self.context.make_not_current() {
-            Ok(()) => Ok(Context {
-                context: self.context,
-                phantom: PhantomData,
-            }),
-            Err(err) => Err((
-                Context {
-                    context: self.context,
-                    phantom: PhantomData,
-                },
-                err,
-            )),
+            Ok(()) => Ok(Context { context: self.context, phantom: PhantomData }),
+            Err(err) => Err((Context { context: self.context, phantom: PhantomData }, err)),
         }
     }
 
@@ -86,10 +64,7 @@ impl<T: ContextCurrentState> Context<T> {
     /// [`ContextWrapper::treat_as_not_current`]:
     /// struct.ContextWrapper.html#method.treat_as_not_current
     pub unsafe fn treat_as_not_current(self) -> Context<NotCurrent> {
-        Context {
-            context: self.context,
-            phantom: PhantomData,
-        }
+        Context { context: self.context, phantom: PhantomData }
     }
 
     /// See [`ContextWrapper::treat_as_current`].
@@ -97,10 +72,7 @@ impl<T: ContextCurrentState> Context<T> {
     /// [`ContextWrapper::treat_as_current`]:
     /// struct.ContextWrapper.html#method.treat_as_current
     pub unsafe fn treat_as_current(self) -> Context<PossiblyCurrent> {
-        Context {
-            context: self.context,
-            phantom: PhantomData,
-        }
+        Context { context: self.context, phantom: PhantomData }
     }
 
     /// See [`ContextWrapper::is_current`].
@@ -179,12 +151,8 @@ impl<'a, T: ContextCurrentState> ContextBuilder<'a, T> {
     ) -> Result<Context<NotCurrent>, CreationError> {
         let ContextBuilder { pf_reqs, gl_attr } = self;
         let gl_attr = gl_attr.map_sharing(|ctx| &ctx.context);
-        platform_impl::Context::new_headless(el, &pf_reqs, &gl_attr, size).map(
-            |context| Context {
-                context,
-                phantom: PhantomData,
-            },
-        )
+        platform_impl::Context::new_headless(el, &pf_reqs, &gl_attr, size)
+            .map(|context| Context { context, phantom: PhantomData })
     }
 }
 

--- a/glutin/src/lib.rs
+++ b/glutin/src/lib.rs
@@ -194,10 +194,7 @@ impl<'a, T: ContextCurrentState> ContextBuilder<'a, T> {
         self,
         other: &'a Context<T2>,
     ) -> ContextBuilder<'a, T2> {
-        ContextBuilder {
-            gl_attr: self.gl_attr.set_sharing(Some(other)),
-            pf_reqs: self.pf_reqs,
-        }
+        ContextBuilder { gl_attr: self.gl_attr.set_sharing(Some(other)), pf_reqs: self.pf_reqs }
     }
 
     /// Sets the multisampling level to request. A value of `0` indicates that
@@ -286,10 +283,7 @@ impl<'a, T: ContextCurrentState> ContextBuilder<'a, T> {
     ///   * Windows using EGL or WGL
     ///   * Android using EGL
     #[inline]
-    pub fn with_hardware_acceleration(
-        mut self,
-        acceleration: Option<bool>,
-    ) -> Self {
+    pub fn with_hardware_acceleration(mut self, acceleration: Option<bool>) -> Self {
         self.pf_reqs.hardware_accelerated = acceleration;
         self
     }
@@ -325,17 +319,13 @@ impl CreationError {
                 errs.push(Box::new(err));
                 CreationError::CreationErrors(errs)
             }
-            _ => CreationError::CreationErrors(vec![
-                Box::new(err),
-                Box::new(self),
-            ]),
+            _ => CreationError::CreationErrors(vec![Box::new(err), Box::new(self)]),
         }
     }
 
     fn to_string(&self) -> &str {
         match *self {
-            CreationError::OsError(ref text)
-            | CreationError::NotSupported(ref text) => &text,
+            CreationError::OsError(ref text) | CreationError::NotSupported(ref text) => &text,
             CreationError::NoBackendAvailable(_) => "No backend is available",
             CreationError::RobustnessNotSupported => {
                 "You requested robustness, but it is not supported."
@@ -347,19 +337,14 @@ impl CreationError {
                 "Couldn't find any pixel format that matches the criteria."
             }
             CreationError::PlatformSpecific(ref text) => &text,
-            CreationError::Window(ref err) => {
-                std::error::Error::description(err)
-            }
+            CreationError::Window(ref err) => std::error::Error::description(err),
             CreationError::CreationErrors(_) => "Received multiple errors.",
         }
     }
 }
 
 impl std::fmt::Display for CreationError {
-    fn fmt(
-        &self,
-        formatter: &mut std::fmt::Formatter,
-    ) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
         formatter.write_str(self.to_string())?;
 
         if let CreationError::CreationErrors(ref es) = *self {
@@ -421,10 +406,7 @@ impl ContextError {
 }
 
 impl std::fmt::Display for ContextError {
-    fn fmt(
-        &self,
-        formatter: &mut std::fmt::Formatter,
-    ) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
         formatter.write_str(self.to_string())
     }
 }
@@ -489,12 +471,8 @@ impl GlRequest {
     /// Extract the desktop GL version, if any.
     pub fn to_gl_version(&self) -> Option<(u8, u8)> {
         match self {
-            &GlRequest::Specific(Api::OpenGl, opengl_version) => {
-                Some(opengl_version)
-            }
-            &GlRequest::GlThenGles { opengl_version, .. } => {
-                Some(opengl_version)
-            }
+            &GlRequest::Specific(Api::OpenGl, opengl_version) => Some(opengl_version),
+            &GlRequest::GlThenGles { opengl_version, .. } => Some(opengl_version),
             _ => None,
         }
     }

--- a/glutin/src/platform/mod.rs
+++ b/glutin/src/platform/mod.rs
@@ -7,7 +7,6 @@
 //!  - `macos`
 //!  - `unix`
 //!  - `windows`
-//!
 
 /// Platform-specific methods for android.
 pub mod android;
@@ -19,7 +18,8 @@ pub mod macos;
 pub mod unix;
 /// Platform-specific methods for Windows.
 pub mod windows;
-/// Platform-specific methods for event loops independent from the application lifetime.
+/// Platform-specific methods for event loops independent from the application
+/// lifetime.
 pub mod run_return {
     #![cfg(any(
         target_os = "windows",

--- a/glutin/src/platform_impl/emscripten/mod.rs
+++ b/glutin/src/platform_impl/emscripten/mod.rs
@@ -1,8 +1,7 @@
 #![cfg(target_os = "emscripten")]
 
 use crate::{
-    Api, ContextError, CreationError, GlAttributes, GlRequest, PixelFormat,
-    PixelFormatRequirements,
+    Api, ContextError, CreationError, GlAttributes, GlRequest, PixelFormat, PixelFormatRequirements,
 };
 
 use glutin_emscripten_sys as ffi;
@@ -16,10 +15,7 @@ use std::ffi::CString;
 #[derive(Debug)]
 pub enum Context {
     Window(ffi::EMSCRIPTEN_WEBGL_CONTEXT_HANDLE),
-    WindowedContext(
-        winit::window::Window,
-        ffi::EMSCRIPTEN_WEBGL_CONTEXT_HANDLE,
-    ),
+    WindowedContext(winit::window::Window, ffi::EMSCRIPTEN_WEBGL_CONTEXT_HANDLE),
 }
 
 impl Context {
@@ -32,21 +28,19 @@ impl Context {
     ) -> Result<(winit::window::Window, Self), CreationError> {
         let win = wb.build(el)?;
 
-        let gl_attr = gl_attr.clone().map_sharing(|_| {
-            unimplemented!("Shared contexts are unimplemented in WebGL.")
-        });
+        let gl_attr = gl_attr
+            .clone()
+            .map_sharing(|_| unimplemented!("Shared contexts are unimplemented in WebGL."));
 
         // getting the default values of attributes
         let mut attributes = unsafe {
-            let mut attributes: ffi::EmscriptenWebGLContextAttributes =
-                std::mem::zeroed();
+            let mut attributes: ffi::EmscriptenWebGLContextAttributes = std::mem::zeroed();
             ffi::emscripten_webgl_init_context_attributes(&mut attributes);
             attributes
         };
 
         // setting the attributes
-        if let GlRequest::Specific(Api::WebGl, (major, minor)) = gl_attr.version
-        {
+        if let GlRequest::Specific(Api::WebGl, (major, minor)) = gl_attr.version {
             attributes.majorVersion = major as _;
             attributes.minorVersion = minor as _;
         }
@@ -54,10 +48,7 @@ impl Context {
         // creating the context
         let context = unsafe {
             // TODO: correct first parameter based on the window
-            let context = ffi::emscripten_webgl_create_context(
-                std::ptr::null(),
-                &attributes,
-            );
+            let context = ffi::emscripten_webgl_create_context(std::ptr::null(), &attributes);
             if context <= 0 {
                 return Err(CreationError::OsError(format!(
                     "Error while calling emscripten_webgl_create_context: {}",
@@ -91,9 +82,7 @@ impl Context {
 
     #[inline]
     pub fn is_current(&self) -> bool {
-        unsafe {
-            ffi::emscripten_webgl_get_current_context() == self.raw_handle()
-        }
+        unsafe { ffi::emscripten_webgl_get_current_context() == self.raw_handle() }
     }
 
     #[inline]
@@ -150,8 +139,7 @@ impl Context {
         unsafe {
             // FIXME: if `as_ptr()` is used, then wrong data is passed to
             // emscripten
-            ffi::emscripten_GetProcAddress(addr.into_raw() as *const _)
-                as *const _
+            ffi::emscripten_GetProcAddress(addr.into_raw() as *const _) as *const _
         }
     }
 
@@ -161,13 +149,8 @@ impl Context {
     }
 
     #[inline]
-    pub fn swap_buffers_with_damage(
-        &self,
-        rects: &[Rect],
-    ) -> Result<(), ContextError> {
-        Err(ContextError::OsError(
-            "buffer damage not suported".to_string(),
-        ))
+    pub fn swap_buffers_with_damage(&self, rects: &[Rect]) -> Result<(), ContextError> {
+        Err(ContextError::OsError("buffer damage not suported".to_string()))
     }
 
     #[inline]

--- a/glutin/src/platform_impl/macos/helpers.rs
+++ b/glutin/src/platform_impl/macos/helpers.rs
@@ -1,6 +1,5 @@
 use crate::{
-    CreationError, GlAttributes, GlProfile, GlRequest, PixelFormatRequirements,
-    ReleaseBehavior,
+    CreationError, GlAttributes, GlProfile, GlRequest, PixelFormatRequirements, ReleaseBehavior,
 };
 
 use cocoa::appkit::*;
@@ -53,13 +52,9 @@ pub fn get_gl_profile<T>(
         attributes[current_idx] = NSOpenGLPFAOpenGLProfile as u32;
         current_idx += 1;
 
-        for &profile in
-            &[NSOpenGLProfileVersion4_1Core, NSOpenGLProfileVersion3_2Core]
-        {
+        for &profile in &[NSOpenGLProfileVersion4_1Core, NSOpenGLProfileVersion3_2Core] {
             attributes[current_idx] = profile as u32;
-            let id = unsafe {
-                NSOpenGLPixelFormat::alloc(nil).initWithAttributes_(&attributes)
-            };
+            let id = unsafe { NSOpenGLPixelFormat::alloc(nil).initWithAttributes_(&attributes) };
             if id != nil {
                 unsafe { msg_send![id, release] }
                 return Ok(profile);

--- a/glutin/src/platform_impl/unix/mod.rs
+++ b/glutin/src/platform_impl/unix/mod.rs
@@ -7,9 +7,7 @@
 ))]
 
 #[cfg(not(any(feature = "x11", feature = "wayland")))]
-compile_error!(
-    "at least one of the 'x11' or 'wayland' features must be enabled"
-);
+compile_error!("at least one of the 'x11' or 'wayland' features must be enabled");
 
 mod wayland;
 mod x11;
@@ -18,8 +16,8 @@ mod x11;
 use self::x11::X11Context;
 use crate::api::osmesa;
 use crate::{
-    Api, ContextCurrentState, ContextError, CreationError, GlAttributes,
-    NotCurrent, PixelFormat, PixelFormatRequirements, Rect,
+    Api, ContextCurrentState, ContextError, CreationError, GlAttributes, NotCurrent, PixelFormat,
+    PixelFormatRequirements, Rect,
 };
 #[cfg(feature = "x11")]
 pub use x11::utils as x11_utils;
@@ -65,19 +63,14 @@ pub enum Context {
 }
 
 impl Context {
-    fn is_compatible(
-        c: &Option<&Context>,
-        ct: ContextType,
-    ) -> Result<(), CreationError> {
+    fn is_compatible(c: &Option<&Context>, ct: ContextType) -> Result<(), CreationError> {
         if let Some(c) = *c {
             match ct {
                 ContextType::OsMesa => match *c {
                     Context::OsMesa(_) => Ok(()),
                     _ => {
                         let msg = "Cannot share an OSMesa context with a non-OSMesa context";
-                        return Err(CreationError::PlatformSpecific(
-                            msg.into(),
-                        ));
+                        return Err(CreationError::PlatformSpecific(msg.into()));
                     }
                 },
                 #[cfg(feature = "x11")]
@@ -85,9 +78,7 @@ impl Context {
                     Context::X11(_) => Ok(()),
                     _ => {
                         let msg = "Cannot share an X11 context with a non-X11 context";
-                        return Err(CreationError::PlatformSpecific(
-                            msg.into(),
-                        ));
+                        return Err(CreationError::PlatformSpecific(msg.into()));
                     }
                 },
                 #[cfg(feature = "wayland")]
@@ -95,9 +86,7 @@ impl Context {
                     Context::Wayland(_) => Ok(()),
                     _ => {
                         let msg = "Cannot share a Wayland context with a non-Wayland context";
-                        return Err(CreationError::PlatformSpecific(
-                            msg.into(),
-                        ));
+                        return Err(CreationError::PlatformSpecific(msg.into()));
                     }
                 },
             }
@@ -160,10 +149,8 @@ impl Context {
                 Context::Wayland(ref ctx) => ctx,
                 _ => unreachable!(),
             });
-            return wayland::Context::new_headless(
-                &el, pf_reqs, &gl_attr, size,
-            )
-            .map(|ctx| Context::Wayland(ctx));
+            return wayland::Context::new_headless(&el, pf_reqs, &gl_attr, size)
+                .map(|ctx| Context::Wayland(ctx));
         }
         #[cfg(feature = "x11")]
         if el.is_x11() {
@@ -282,10 +269,7 @@ impl Context {
     }
 
     #[inline]
-    pub fn swap_buffers_with_damage(
-        &self,
-        rects: &[Rect],
-    ) -> Result<(), ContextError> {
+    pub fn swap_buffers_with_damage(&self, rects: &[Rect]) -> Result<(), ContextError> {
         match *self {
             #[cfg(feature = "x11")]
             Context::X11(ref ctx) => ctx.swap_buffers_with_damage(rects),
@@ -301,9 +285,7 @@ impl Context {
             #[cfg(feature = "x11")]
             Context::X11(ref ctx) => ctx.swap_buffers_with_damage_supported(),
             #[cfg(feature = "wayland")]
-            Context::Wayland(ref ctx) => {
-                ctx.swap_buffers_with_damage_supported()
-            }
+            Context::Wayland(ref ctx) => ctx.swap_buffers_with_damage_supported(),
             _ => unreachable!(),
         }
     }
@@ -354,9 +336,7 @@ pub trait HeadlessContextExt {
         Self: Sized;
 }
 
-impl<'a, T: ContextCurrentState> HeadlessContextExt
-    for crate::ContextBuilder<'a, T>
-{
+impl<'a, T: ContextCurrentState> HeadlessContextExt for crate::ContextBuilder<'a, T> {
     #[inline]
     fn build_osmesa(
         self,
@@ -374,10 +354,7 @@ impl<'a, T: ContextCurrentState> HeadlessContextExt
         });
         osmesa::OsMesaContext::new(&pf_reqs, &gl_attr, size)
             .map(|context| Context::OsMesa(context))
-            .map(|context| crate::Context {
-                context,
-                phantom: PhantomData,
-            })
+            .map(|context| crate::Context { context, phantom: PhantomData })
     }
 
     #[inline]
@@ -390,12 +367,8 @@ impl<'a, T: ContextCurrentState> HeadlessContextExt
     {
         let crate::ContextBuilder { pf_reqs, gl_attr } = self;
         let gl_attr = gl_attr.map_sharing(|ctx| &ctx.context);
-        Context::new_headless_impl(el, &pf_reqs, &gl_attr, None).map(
-            |context| crate::Context {
-                context,
-                phantom: PhantomData,
-            },
-        )
+        Context::new_headless_impl(el, &pf_reqs, &gl_attr, None)
+            .map(|context| crate::Context { context, phantom: PhantomData })
     }
 }
 
@@ -436,9 +409,7 @@ pub trait RawContextExt {
         Self: Sized;
 }
 
-impl<'a, T: ContextCurrentState> RawContextExt
-    for crate::ContextBuilder<'a, T>
-{
+impl<'a, T: ContextCurrentState> RawContextExt for crate::ContextBuilder<'a, T> {
     #[inline]
     #[cfg(feature = "wayland")]
     unsafe fn build_raw_wayland_context(
@@ -458,23 +429,10 @@ impl<'a, T: ContextCurrentState> RawContextExt
             Context::Wayland(ref ctx) => ctx,
             _ => unreachable!(),
         });
-        wayland::Context::new_raw_context(
-            display_ptr,
-            surface,
-            width,
-            height,
-            &pf_reqs,
-            &gl_attr,
-        )
-        .map(|context| Context::Wayland(context))
-        .map(|context| crate::Context {
-            context,
-            phantom: PhantomData,
-        })
-        .map(|context| crate::RawContext {
-            context,
-            window: (),
-        })
+        wayland::Context::new_raw_context(display_ptr, surface, width, height, &pf_reqs, &gl_attr)
+            .map(|context| Context::Wayland(context))
+            .map(|context| crate::Context { context, phantom: PhantomData })
+            .map(|context| crate::RawContext { context, window: () })
     }
 
     #[inline]
@@ -496,13 +454,7 @@ impl<'a, T: ContextCurrentState> RawContextExt
         });
         x11::Context::new_raw_context(xconn, xwin, &pf_reqs, &gl_attr)
             .map(|context| Context::X11(context))
-            .map(|context| crate::Context {
-                context,
-                phantom: PhantomData,
-            })
-            .map(|context| crate::RawContext {
-                context,
-                window: (),
-            })
+            .map(|context| crate::Context { context, phantom: PhantomData })
+            .map(|context| crate::RawContext { context, window: () })
     }
 }

--- a/glutin/src/platform_impl/unix/wayland.rs
+++ b/glutin/src/platform_impl/unix/wayland.rs
@@ -1,11 +1,8 @@
 #![cfg(feature = "wayland")]
 
-use crate::api::egl::{
-    Context as EglContext, NativeDisplay, SurfaceType as EglSurfaceType,
-};
+use crate::api::egl::{Context as EglContext, NativeDisplay, SurfaceType as EglSurfaceType};
 use crate::{
-    ContextError, CreationError, GlAttributes, PixelFormat,
-    PixelFormatRequirements, Rect,
+    ContextError, CreationError, GlAttributes, PixelFormat, PixelFormatRequirements, Rect,
 };
 
 use crate::platform::unix::{EventLoopWindowTargetExtUnix, WindowExtUnix};
@@ -57,8 +54,7 @@ impl Context {
     ) -> Result<Self, CreationError> {
         let gl_attr = gl_attr.clone().map_sharing(|c| &**c);
         let display_ptr = el.wayland_display().unwrap() as *const _;
-        let native_display =
-            NativeDisplay::Wayland(Some(display_ptr as *const _));
+        let native_display = NativeDisplay::Wayland(Some(display_ptr as *const _));
         if let Some(size) = size {
             let context = EglContext::new(
                 pf_reqs,
@@ -102,20 +98,11 @@ impl Context {
         let surface = match surface {
             Some(s) => s,
             None => {
-                return Err(CreationError::NotSupported(
-                    "Wayland not found".to_string(),
-                ));
+                return Err(CreationError::NotSupported("Wayland not found".to_string()));
             }
         };
 
-        let context = Self::new_raw_context(
-            display_ptr,
-            surface,
-            width,
-            height,
-            pf_reqs,
-            gl_attr,
-        )?;
+        let context = Self::new_raw_context(display_ptr, surface, width, height, pf_reqs, gl_attr)?;
         Ok((win, context))
     }
 
@@ -129,27 +116,17 @@ impl Context {
         gl_attr: &GlAttributes<&Context>,
     ) -> Result<Self, CreationError> {
         let egl_surface = unsafe {
-            wayland_egl::WlEglSurface::new_from_raw(
-                surface as *mut _,
-                width as i32,
-                height as i32,
-            )
+            wayland_egl::WlEglSurface::new_from_raw(surface as *mut _, width as i32, height as i32)
         };
         let context = {
             let gl_attr = gl_attr.clone().map_sharing(|c| &**c);
-            let native_display =
-                NativeDisplay::Wayland(Some(display_ptr as *const _));
-            EglContext::new(
-                pf_reqs,
-                &gl_attr,
-                native_display,
-                EglSurfaceType::Window,
-                |c, _| Ok(c[0]),
-            )
+            let native_display = NativeDisplay::Wayland(Some(display_ptr as *const _));
+            EglContext::new(pf_reqs, &gl_attr, native_display, EglSurfaceType::Window, |c, _| {
+                Ok(c[0])
+            })
             .and_then(|p| p.finish(egl_surface.ptr() as *const _))?
         };
-        let context =
-            Context::Windowed(context, EglSurface(Arc::new(egl_surface)));
+        let context = Context::Windowed(context, EglSurface(Arc::new(egl_surface)));
         Ok(context)
     }
 
@@ -186,9 +163,7 @@ impl Context {
     #[inline]
     pub fn resize(&self, width: u32, height: u32) {
         match self {
-            Context::Windowed(_, surface) => {
-                surface.0.resize(width as i32, height as i32, 0, 0)
-            }
+            Context::Windowed(_, surface) => surface.0.resize(width as i32, height as i32, 0, 0),
             _ => unreachable!(),
         }
     }
@@ -204,10 +179,7 @@ impl Context {
     }
 
     #[inline]
-    pub fn swap_buffers_with_damage(
-        &self,
-        rects: &[Rect],
-    ) -> Result<(), ContextError> {
+    pub fn swap_buffers_with_damage(&self, rects: &[Rect]) -> Result<(), ContextError> {
         (**self).swap_buffers_with_damage(rects)
     }
 

--- a/glutin/src/platform_impl/unix/x11/utils.rs
+++ b/glutin/src/platform_impl/unix/x11/utils.rs
@@ -3,10 +3,7 @@ use glutin_glx_sys as ffi;
 
 use std::sync::Arc;
 
-pub fn get_visual_info_from_xid(
-    xconn: &Arc<XConnection>,
-    xid: ffi::VisualID,
-) -> ffi::XVisualInfo {
+pub fn get_visual_info_from_xid(xconn: &Arc<XConnection>, xid: ffi::VisualID) -> ffi::XVisualInfo {
     assert_ne!(xid, 0);
     let mut template: ffi::XVisualInfo = unsafe { std::mem::zeroed() };
     template.visualid = xid;
@@ -20,9 +17,7 @@ pub fn get_visual_info_from_xid(
             &mut num_visuals,
         )
     };
-    xconn
-        .check_errors()
-        .expect("Failed to call `XGetVisualInfo`");
+    xconn.check_errors().expect("Failed to call `XGetVisualInfo`");
     assert!(!vi.is_null());
     assert!(num_visuals == 1);
 

--- a/glutin/src/platform_impl/windows/mod.rs
+++ b/glutin/src/platform_impl/windows/mod.rs
@@ -1,13 +1,11 @@
 #![cfg(target_os = "windows")]
 
 use crate::{
-    Api, ContextCurrentState, ContextError, CreationError, GlAttributes,
-    GlRequest, NotCurrent, PixelFormat, PixelFormatRequirements, Rect,
+    Api, ContextCurrentState, ContextError, CreationError, GlAttributes, GlRequest, NotCurrent,
+    PixelFormat, PixelFormatRequirements, Rect,
 };
 
-use crate::api::egl::{
-    Context as EglContext, NativeDisplay, SurfaceType as EglSurfaceType, EGL,
-};
+use crate::api::egl::{Context as EglContext, NativeDisplay, SurfaceType as EglSurfaceType, EGL};
 use crate::api::wgl::Context as WglContext;
 use crate::platform::windows::WindowExtWindows;
 
@@ -72,26 +70,22 @@ impl Context {
                     (Some(&Context::HiddenWindowWgl(_, _)), _)
                     | (Some(&Context::Wgl(_)), _)
                     | (None, None) => {
-                        let gl_attr_wgl =
-                            gl_attr.clone().map_sharing(|ctx| match *ctx {
-                                Context::HiddenWindowWgl(_, ref c)
-                                | Context::Wgl(ref c) => c.get_hglrc(),
-                                _ => unreachable!(),
-                            });
-                        unsafe {
-                            WglContext::new(&pf_reqs, &gl_attr_wgl, hwnd)
-                                .map(Context::Wgl)
-                        }
+                        let gl_attr_wgl = gl_attr.clone().map_sharing(|ctx| match *ctx {
+                            Context::HiddenWindowWgl(_, ref c) | Context::Wgl(ref c) => {
+                                c.get_hglrc()
+                            }
+                            _ => unreachable!(),
+                        });
+                        unsafe { WglContext::new(&pf_reqs, &gl_attr_wgl, hwnd).map(Context::Wgl) }
                     }
                     // We must use EGL.
                     (Some(_), Some(_)) => {
-                        let gl_attr_egl =
-                            gl_attr.clone().map_sharing(|ctx| match *ctx {
-                                Context::Egl(ref c)
-                                | Context::EglPbuffer(ref c)
-                                | Context::HiddenWindowEgl(_, ref c) => c,
-                                _ => unreachable!(),
-                            });
+                        let gl_attr_egl = gl_attr.clone().map_sharing(|ctx| match *ctx {
+                            Context::Egl(ref c)
+                            | Context::EglPbuffer(ref c)
+                            | Context::HiddenWindowEgl(_, ref c) => c,
+                            _ => unreachable!(),
+                        });
 
                         EglContext::new(
                             &pf_reqs,
@@ -105,10 +99,8 @@ impl Context {
                     }
                     // Try EGL, fallback to WGL.
                     (None, Some(_)) => {
-                        let gl_attr_egl =
-                            gl_attr.clone().map_sharing(|_| unreachable!());
-                        let gl_attr_wgl =
-                            gl_attr.clone().map_sharing(|_| unreachable!());
+                        let gl_attr_egl = gl_attr.clone().map_sharing(|_| unreachable!());
+                        let gl_attr_wgl = gl_attr.clone().map_sharing(|_| unreachable!());
 
                         if let Ok(c) = EglContext::new(
                             &pf_reqs,
@@ -122,8 +114,7 @@ impl Context {
                             Ok(Context::Egl(c))
                         } else {
                             unsafe {
-                                WglContext::new(&pf_reqs, &gl_attr_wgl, hwnd)
-                                    .map(Context::Wgl)
+                                WglContext::new(&pf_reqs, &gl_attr_wgl, hwnd).map(Context::Wgl)
                             }
                         }
                     }
@@ -131,16 +122,11 @@ impl Context {
                 }
             }
             _ => {
-                let gl_attr_wgl =
-                    gl_attr.clone().map_sharing(|ctx| match *ctx {
-                        Context::HiddenWindowWgl(_, ref c)
-                        | Context::Wgl(ref c) => c.get_hglrc(),
-                        _ => panic!(),
-                    });
-                unsafe {
-                    WglContext::new(&pf_reqs, &gl_attr_wgl, hwnd)
-                        .map(Context::Wgl)
-                }
+                let gl_attr_wgl = gl_attr.clone().map_sharing(|ctx| match *ctx {
+                    Context::HiddenWindowWgl(_, ref c) | Context::Wgl(ref c) => c.get_hglrc(),
+                    _ => panic!(),
+                });
+                unsafe { WglContext::new(&pf_reqs, &gl_attr_wgl, hwnd).map(Context::Wgl) }
             }
         }
     }
@@ -159,13 +145,12 @@ impl Context {
             | (Some(&Context::Egl(_)), Some(_))
             | (Some(&Context::HiddenWindowEgl(_, _)), Some(_))
             | (Some(&Context::EglPbuffer(_)), Some(_)) => {
-                let gl_attr_egl =
-                    gl_attr.clone().map_sharing(|ctx| match *ctx {
-                        Context::Egl(ref c)
-                        | Context::EglPbuffer(ref c)
-                        | Context::HiddenWindowEgl(_, ref c) => c,
-                        _ => unreachable!(),
-                    });
+                let gl_attr_egl = gl_attr.clone().map_sharing(|ctx| match *ctx {
+                    Context::Egl(ref c)
+                    | Context::EglPbuffer(ref c)
+                    | Context::HiddenWindowEgl(_, ref c) => c,
+                    _ => unreachable!(),
+                });
 
                 let native_display = NativeDisplay::Other(None);
                 let context = EglContext::new(
@@ -185,15 +170,11 @@ impl Context {
             _ => (),
         }
 
-        let wb = WindowBuilder::new()
-            .with_visible(false)
-            .with_inner_size(size);
-        Self::new_windowed(wb, &el, pf_reqs, gl_attr).map(|(win, context)| {
-            match context {
-                Context::Egl(context) => Context::HiddenWindowEgl(win, context),
-                Context::Wgl(context) => Context::HiddenWindowWgl(win, context),
-                _ => unreachable!(),
-            }
+        let wb = WindowBuilder::new().with_visible(false).with_inner_size(size);
+        Self::new_windowed(wb, &el, pf_reqs, gl_attr).map(|(win, context)| match context {
+            Context::Egl(context) => Context::HiddenWindowEgl(win, context),
+            Context::Wgl(context) => Context::HiddenWindowWgl(win, context),
+            _ => unreachable!(),
         })
     }
 
@@ -205,9 +186,7 @@ impl Context {
     #[inline]
     pub unsafe fn make_current(&self) -> Result<(), ContextError> {
         match *self {
-            Context::Wgl(ref c) | Context::HiddenWindowWgl(_, ref c) => {
-                c.make_current()
-            }
+            Context::Wgl(ref c) | Context::HiddenWindowWgl(_, ref c) => c.make_current(),
             Context::Egl(ref c)
             | Context::HiddenWindowEgl(_, ref c)
             | Context::EglPbuffer(ref c) => c.make_current(),
@@ -217,9 +196,7 @@ impl Context {
     #[inline]
     pub unsafe fn make_not_current(&self) -> Result<(), ContextError> {
         match *self {
-            Context::Wgl(ref c) | Context::HiddenWindowWgl(_, ref c) => {
-                c.make_not_current()
-            }
+            Context::Wgl(ref c) | Context::HiddenWindowWgl(_, ref c) => c.make_not_current(),
             Context::Egl(ref c)
             | Context::HiddenWindowEgl(_, ref c)
             | Context::EglPbuffer(ref c) => c.make_not_current(),
@@ -229,9 +206,7 @@ impl Context {
     #[inline]
     pub fn is_current(&self) -> bool {
         match *self {
-            Context::Wgl(ref c) | Context::HiddenWindowWgl(_, ref c) => {
-                c.is_current()
-            }
+            Context::Wgl(ref c) | Context::HiddenWindowWgl(_, ref c) => c.is_current(),
             Context::Egl(ref c)
             | Context::HiddenWindowEgl(_, ref c)
             | Context::EglPbuffer(ref c) => c.is_current(),
@@ -241,9 +216,7 @@ impl Context {
     #[inline]
     pub fn get_proc_address(&self, addr: &str) -> *const core::ffi::c_void {
         match *self {
-            Context::Wgl(ref c) | Context::HiddenWindowWgl(_, ref c) => {
-                c.get_proc_address(addr)
-            }
+            Context::Wgl(ref c) | Context::HiddenWindowWgl(_, ref c) => c.get_proc_address(addr),
             Context::Egl(ref c)
             | Context::HiddenWindowEgl(_, ref c)
             | Context::EglPbuffer(ref c) => c.get_proc_address(addr),
@@ -260,13 +233,8 @@ impl Context {
     }
 
     #[inline]
-    pub fn swap_buffers_with_damage(
-        &self,
-        rects: &[Rect],
-    ) -> Result<(), ContextError> {
-        Err(ContextError::OsError(
-            "buffer damage not suported".to_string(),
-        ))
+    pub fn swap_buffers_with_damage(&self, rects: &[Rect]) -> Result<(), ContextError> {
+        Err(ContextError::OsError("buffer damage not suported".to_string()))
     }
 
     #[inline]
@@ -277,9 +245,7 @@ impl Context {
     #[inline]
     pub fn get_api(&self) -> Api {
         match *self {
-            Context::Wgl(ref c) | Context::HiddenWindowWgl(_, ref c) => {
-                c.get_api()
-            }
+            Context::Wgl(ref c) | Context::HiddenWindowWgl(_, ref c) => c.get_api(),
             Context::Egl(ref c)
             | Context::HiddenWindowEgl(_, ref c)
             | Context::EglPbuffer(ref c) => c.get_api(),
@@ -332,9 +298,7 @@ pub trait RawContextExt {
         Self: Sized;
 }
 
-impl<'a, T: ContextCurrentState> RawContextExt
-    for crate::ContextBuilder<'a, T>
-{
+impl<'a, T: ContextCurrentState> RawContextExt for crate::ContextBuilder<'a, T> {
     #[inline]
     unsafe fn build_raw_context(
         self,
@@ -346,13 +310,7 @@ impl<'a, T: ContextCurrentState> RawContextExt
         let crate::ContextBuilder { pf_reqs, gl_attr } = self;
         let gl_attr = gl_attr.map_sharing(|ctx| &ctx.context);
         Context::new_raw_context(hwnd as *mut _, &pf_reqs, &gl_attr)
-            .map(|context| crate::Context {
-                context,
-                phantom: PhantomData,
-            })
-            .map(|context| crate::RawContext {
-                context,
-                window: (),
-            })
+            .map(|context| crate::Context { context, phantom: PhantomData })
+            .map(|context| crate::RawContext { context, window: () })
     }
 }

--- a/glutin/src/windowed.rs
+++ b/glutin/src/windowed.rs
@@ -112,13 +112,7 @@ impl<T: ContextCurrentState> WindowedContext<T> {
     /// [`Window`]: struct.Window.html
     /// [`Context`]: struct.Context.html
     pub unsafe fn split(self) -> (RawContext<T>, Window) {
-        (
-            RawContext {
-                context: self.context,
-                window: (),
-            },
-            self.window,
-        )
+        (RawContext { context: self.context, window: () }, self.window)
     }
 }
 
@@ -146,10 +140,7 @@ impl<W> ContextWrapper<PossiblyCurrent, W> {
     /// next time the screen is refreshed. However drivers can choose to
     /// override your vsync settings, which means that you can't know in
     /// advance whether `swap_buffers` will block or not.
-    pub fn swap_buffers_with_damage(
-        &self,
-        rects: &[Rect],
-    ) -> Result<(), ContextError> {
+    pub fn swap_buffers_with_damage(&self, rects: &[Rect]) -> Result<(), ContextError> {
         self.context.context.swap_buffers_with_damage(rects)
     }
 
@@ -249,9 +240,7 @@ impl<T: ContextCurrentState, W> ContextWrapper<T, W> {
         let window = self.window;
         match self.context.make_current() {
             Ok(context) => Ok(ContextWrapper { window, context }),
-            Err((context, err)) => {
-                Err((ContextWrapper { window, context }, err))
-            }
+            Err((context, err)) => Err((ContextWrapper { window, context }, err)),
         }
     }
 
@@ -267,9 +256,7 @@ impl<T: ContextCurrentState, W> ContextWrapper<T, W> {
         let window = self.window;
         match self.context.make_not_current() {
             Ok(context) => Ok(ContextWrapper { window, context }),
-            Err((context, err)) => {
-                Err((ContextWrapper { window, context }, err))
-            }
+            Err((context, err)) => Err((ContextWrapper { window, context }, err)),
         }
     }
 
@@ -285,10 +272,7 @@ impl<T: ContextCurrentState, W> ContextWrapper<T, W> {
     /// [`make_not_current`]: struct.ContextWrapper.html#method.make_not_current
     /// [`make_current`]: struct.ContextWrapper.html#method.make_current
     pub unsafe fn treat_as_not_current(self) -> ContextWrapper<NotCurrent, W> {
-        ContextWrapper {
-            context: self.context.treat_as_not_current(),
-            window: self.window,
-        }
+        ContextWrapper { context: self.context.treat_as_not_current(), window: self.window }
     }
 
     /// Treats this context as current, even if it is not current. We do no
@@ -305,10 +289,7 @@ impl<T: ContextCurrentState, W> ContextWrapper<T, W> {
     /// [`NotCurrent`]: enum.NotCurrent.html
     /// [`Context`]: struct.Context.html
     pub unsafe fn treat_as_current(self) -> ContextWrapper<PossiblyCurrent, W> {
-        ContextWrapper {
-            context: self.context.treat_as_current(),
-            window: self.window,
-        }
+        ContextWrapper { context: self.context.treat_as_current(), window: self.window }
     }
 
     /// Returns true if this context is the current one in this thread.
@@ -357,14 +338,8 @@ impl<'a, T: ContextCurrentState> ContextBuilder<'a, T> {
     ) -> Result<WindowedContext<NotCurrent>, CreationError> {
         let ContextBuilder { pf_reqs, gl_attr } = self;
         let gl_attr = gl_attr.map_sharing(|ctx| &ctx.context);
-        platform_impl::Context::new_windowed(wb, el, &pf_reqs, &gl_attr).map(
-            |(window, context)| WindowedContext {
-                window,
-                context: Context {
-                    context,
-                    phantom: PhantomData,
-                },
-            },
-        )
+        platform_impl::Context::new_windowed(wb, el, &pf_reqs, &gl_attr).map(|(window, context)| {
+            WindowedContext { window, context: Context { context, phantom: PhantomData } }
+        })
     }
 }

--- a/glutin_emscripten_sys/src/lib.rs
+++ b/glutin_emscripten_sys/src/lib.rs
@@ -54,8 +54,7 @@ extern "C" {
         context: EMSCRIPTEN_WEBGL_CONTEXT_HANDLE,
     ) -> EMSCRIPTEN_RESULT;
 
-    pub fn emscripten_webgl_get_current_context(
-    ) -> EMSCRIPTEN_WEBGL_CONTEXT_HANDLE;
+    pub fn emscripten_webgl_get_current_context() -> EMSCRIPTEN_WEBGL_CONTEXT_HANDLE;
 
     pub fn emscripten_webgl_destroy_context(
         context: EMSCRIPTEN_WEBGL_CONTEXT_HANDLE,
@@ -79,15 +78,11 @@ extern "C" {
         callback: em_webgl_context_callback,
     ) -> EMSCRIPTEN_RESULT;
 
-    pub fn emscripten_is_webgl_context_lost(
-        target: *const raw::c_char,
-    ) -> EM_BOOL;
+    pub fn emscripten_is_webgl_context_lost(target: *const raw::c_char) -> EM_BOOL;
 
     // note: this function is not documented but is used by the ports of glfw,
     // SDL and EGL
-    pub fn emscripten_GetProcAddress(
-        name: *const raw::c_char,
-    ) -> *const raw::c_void;
+    pub fn emscripten_GetProcAddress(name: *const raw::c_char) -> *const raw::c_void;
 
     pub fn emscripten_request_fullscreen(
         target: *const raw::c_char,

--- a/glutin_examples/examples/damage.rs
+++ b/glutin_examples/examples/damage.rs
@@ -14,29 +14,13 @@ struct Color {
 
 impl Color {
     fn new() -> Color {
-        Color {
-            red: 1.0,
-            green: 0.5,
-            blue: 0.0,
-        }
+        Color { red: 1.0, green: 0.5, blue: 0.0 }
     }
     fn next(&self) -> Color {
         Color {
-            red: if self.red >= 1.0 {
-                0.0
-            } else {
-                self.red + 0.01
-            },
-            green: if self.green >= 1.0 {
-                0.0
-            } else {
-                self.green + 0.01
-            },
-            blue: if self.blue >= 1.0 {
-                0.0
-            } else {
-                self.blue + 0.01
-            },
+            red: if self.red >= 1.0 { 0.0 } else { self.red + 0.01 },
+            green: if self.green >= 1.0 { 0.0 } else { self.green + 0.01 },
+            blue: if self.blue >= 1.0 { 0.0 } else { self.blue + 0.01 },
         }
     }
 }
@@ -45,8 +29,7 @@ fn main() {
     let el = EventLoop::new();
     let wb = WindowBuilder::new().with_title("A fantastic window!");
 
-    let windowed_context =
-        ContextBuilder::new().build_windowed(wb, &el).unwrap();
+    let windowed_context = ContextBuilder::new().build_windowed(wb, &el).unwrap();
 
     let windowed_context = unsafe { windowed_context.make_current().unwrap() };
 
@@ -54,10 +37,7 @@ fn main() {
         panic!("Damage not supported!");
     }
 
-    println!(
-        "Pixel format of the window's GL context: {:?}",
-        windowed_context.get_pixel_format()
-    );
+    println!("Pixel format of the window's GL context: {:?}", windowed_context.get_pixel_format());
 
     let gl = support::load(&windowed_context.context());
 
@@ -73,12 +53,8 @@ fn main() {
         match event {
             Event::LoopDestroyed => return,
             Event::WindowEvent { event, .. } => match event {
-                WindowEvent::Resized(physical_size) => {
-                    windowed_context.resize(physical_size)
-                }
-                WindowEvent::CloseRequested => {
-                    *control_flow = ControlFlow::Exit
-                }
+                WindowEvent::Resized(physical_size) => windowed_context.resize(physical_size),
+                WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
                 WindowEvent::CursorMoved { .. } => {
                     // Select a new color to render, draw and swap buffers.
                     //

--- a/glutin_examples/examples/fullscreen.rs
+++ b/glutin_examples/examples/fullscreen.rs
@@ -1,8 +1,6 @@
 mod support;
 
-use glutin::event::{
-    ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent,
-};
+use glutin::event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent};
 use glutin::event_loop::{ControlFlow, EventLoop};
 use glutin::monitor::{MonitorHandle, VideoMode};
 use glutin::window::{Fullscreen, WindowBuilder};
@@ -11,9 +9,7 @@ use std::io::{stdin, stdout, Write};
 fn main() {
     let el = EventLoop::new();
 
-    print!(
-        "Please choose the fullscreen mode: (1) exclusive, (2) borderless: "
-    );
+    print!("Please choose the fullscreen mode: (1) exclusive, (2) borderless: ");
     stdout().flush().unwrap();
 
     let mut num = String::new();
@@ -21,9 +17,7 @@ fn main() {
     let num = num.trim().parse().ok().expect("Please enter a number");
 
     let fullscreen = Some(match num {
-        1 => Fullscreen::Exclusive(prompt_for_video_mode(&prompt_for_monitor(
-            &el,
-        ))),
+        1 => Fullscreen::Exclusive(prompt_for_video_mode(&prompt_for_monitor(&el))),
         2 => Fullscreen::Borderless(Some(prompt_for_monitor(&el))),
         _ => panic!("Please enter a valid number"),
     });
@@ -33,12 +27,8 @@ fn main() {
     let mut is_maximized = false;
     let mut decorations = true;
 
-    let wb = WindowBuilder::new()
-        .with_title("Hello world!")
-        .with_fullscreen(fullscreen.clone());
-    let windowed_context = glutin::ContextBuilder::new()
-        .build_windowed(wb, &el)
-        .unwrap();
+    let wb = WindowBuilder::new().with_title("Hello world!").with_fullscreen(fullscreen.clone());
+    let windowed_context = glutin::ContextBuilder::new().build_windowed(wb, &el).unwrap();
 
     let windowed_context = unsafe { windowed_context.make_current().unwrap() };
 
@@ -49,38 +39,24 @@ fn main() {
 
         match event {
             Event::WindowEvent { event, .. } => match event {
-                WindowEvent::CloseRequested => {
-                    *control_flow = ControlFlow::Exit
-                }
+                WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
                 WindowEvent::Resized(physical_size) => {
                     windowed_context.resize(physical_size);
                 }
                 WindowEvent::KeyboardInput {
-                    input:
-                        KeyboardInput {
-                            virtual_keycode: Some(virtual_code),
-                            state,
-                            ..
-                        },
+                    input: KeyboardInput { virtual_keycode: Some(virtual_code), state, .. },
                     ..
                 } => match (virtual_code, state) {
-                    (VirtualKeyCode::Escape, _) => {
-                        *control_flow = ControlFlow::Exit
-                    }
+                    (VirtualKeyCode::Escape, _) => *control_flow = ControlFlow::Exit,
                     (VirtualKeyCode::F, ElementState::Pressed) => {
                         if windowed_context.window().fullscreen().is_some() {
                             windowed_context.window().set_fullscreen(None);
                         } else {
-                            windowed_context
-                                .window()
-                                .set_fullscreen(fullscreen.clone());
+                            windowed_context.window().set_fullscreen(fullscreen.clone());
                         }
                     }
                     (VirtualKeyCode::S, ElementState::Pressed) => {
-                        println!(
-                            "window.fullscreen {:?}",
-                            windowed_context.window().fullscreen()
-                        );
+                        println!("window.fullscreen {:?}", windowed_context.window().fullscreen());
                     }
                     (VirtualKeyCode::M, ElementState::Pressed) => {
                         is_maximized = !is_maximized;
@@ -115,10 +91,7 @@ fn prompt_for_monitor(el: &EventLoop<()>) -> MonitorHandle {
     let mut num = String::new();
     stdin().read_line(&mut num).unwrap();
     let num = num.trim().parse().ok().expect("Please enter a number");
-    let monitor = el
-        .available_monitors()
-        .nth(num)
-        .expect("Please enter a valid ID");
+    let monitor = el.available_monitors().nth(num).expect("Please enter a valid ID");
 
     println!("Using {:?}", monitor.name());
 
@@ -136,10 +109,7 @@ fn prompt_for_video_mode(monitor: &MonitorHandle) -> VideoMode {
     let mut num = String::new();
     stdin().read_line(&mut num).unwrap();
     let num = num.trim().parse().ok().expect("Please enter a number");
-    let video_mode = monitor
-        .video_modes()
-        .nth(num)
-        .expect("Please enter a valid ID");
+    let video_mode = monitor.video_modes().nth(num).expect("Please enter a valid ID");
 
     println!("Using {}", video_mode);
 

--- a/glutin_examples/examples/headless.rs
+++ b/glutin_examples/examples/headless.rs
@@ -3,8 +3,7 @@ mod support;
 use glutin::dpi::PhysicalSize;
 use glutin::event_loop::EventLoop;
 use glutin::{
-    Context, ContextBuilder, ContextCurrentState, CreationError, GlProfile,
-    GlRequest, NotCurrent,
+    Context, ContextBuilder, ContextCurrentState, CreationError, GlProfile, GlRequest, NotCurrent,
 };
 use std::path::Path;
 use support::gl;
@@ -78,9 +77,7 @@ fn build_context<T1: ContextCurrentState>(
 }
 
 fn main() {
-    let cb = ContextBuilder::new()
-        .with_gl_profile(GlProfile::Core)
-        .with_gl(GlRequest::Latest);
+    let cb = ContextBuilder::new().with_gl_profile(GlProfile::Core).with_gl(GlRequest::Latest);
     let size = PhysicalSize::new(768., 480.);
 
     let (headless_context, _el) = build_context(cb).unwrap();
@@ -102,12 +99,7 @@ fn main() {
         // to have a different code path.
         gl.gl.GenRenderbuffers(1, &mut render_buf);
         gl.gl.BindRenderbuffer(gl::RENDERBUFFER, render_buf);
-        gl.gl.RenderbufferStorage(
-            gl::RENDERBUFFER,
-            gl::RGB8,
-            size.width as _,
-            size.height as _,
-        );
+        gl.gl.RenderbufferStorage(gl::RENDERBUFFER, gl::RGB8, size.width as _, size.height as _);
         gl.gl.GenFramebuffers(1, &mut fb);
         gl.gl.BindFramebuffer(gl::FRAMEBUFFER, fb);
         gl.gl.FramebufferRenderbuffer(

--- a/glutin_examples/examples/multiwindow.rs
+++ b/glutin_examples/examples/multiwindow.rs
@@ -14,10 +14,8 @@ fn main() {
     for index in 0..3 {
         let title = format!("Charming Window #{}", index + 1);
         let wb = WindowBuilder::new().with_title(title);
-        let windowed_context =
-            ContextBuilder::new().build_windowed(wb, &el).unwrap();
-        let windowed_context =
-            unsafe { windowed_context.make_current().unwrap() };
+        let windowed_context = ContextBuilder::new().build_windowed(wb, &el).unwrap();
+        let windowed_context = unsafe { windowed_context.make_current().unwrap() };
         let gl = support::load(&windowed_context.context());
         let window_id = windowed_context.window().id();
         let context_id = ct.insert(ContextCurrentWrapper::PossiblyCurrent(
@@ -32,18 +30,14 @@ fn main() {
             Event::LoopDestroyed => return,
             Event::WindowEvent { event, window_id } => match event {
                 WindowEvent::Resized(physical_size) => {
-                    let windowed_context =
-                        ct.get_current(windows[&window_id].0).unwrap();
+                    let windowed_context = ct.get_current(windows[&window_id].0).unwrap();
                     let windowed_context = windowed_context.windowed();
                     windowed_context.resize(physical_size);
                 }
                 WindowEvent::CloseRequested => {
                     if let Some((cid, _, _)) = windows.remove(&window_id) {
                         ct.remove(cid);
-                        println!(
-                            "Window with ID {:?} has been closed",
-                            window_id
-                        );
+                        println!("Window with ID {:?} has been closed", window_id);
                     }
                 }
                 _ => (),

--- a/glutin_examples/examples/raw_context.rs
+++ b/glutin_examples/examples/raw_context.rs
@@ -48,17 +48,11 @@ mod this_example {
                     let size = win.inner_size();
                     let (width, height): (u32, u32) = size.into();
 
-                    let display_ptr =
-                        win.wayland_display().unwrap() as *const _;
+                    let display_ptr = win.wayland_display().unwrap() as *const _;
                     let surface = win.wayland_surface().unwrap();
 
                     let raw_context = ContextBuilder::new()
-                        .build_raw_wayland_context(
-                            display_ptr,
-                            surface,
-                            width,
-                            height,
-                        )
+                        .build_raw_wayland_context(display_ptr, surface, width, height)
                         .unwrap();
 
                     (raw_context, el)
@@ -85,9 +79,8 @@ File a PR if you are interested in implementing the latter.
                     let win = wb.build(&el).unwrap();
                     let xconn = el.xlib_xconnection().unwrap();
                     let xwindow = win.xlib_window().unwrap();
-                    let raw_context = ContextBuilder::new()
-                        .build_raw_x11_context(xconn, xwindow)
-                        .unwrap();
+                    let raw_context =
+                        ContextBuilder::new().build_raw_x11_context(xconn, xwindow).unwrap();
 
                     (raw_context, el)
                 }
@@ -96,13 +89,10 @@ File a PR if you are interested in implementing the latter.
             #[cfg(target_os = "windows")]
             unsafe {
                 let win = wb.build(&el).unwrap();
-                use glutin::platform::windows::{
-                    RawContextExt, WindowExtWindows,
-                };
+                use glutin::platform::windows::{RawContextExt, WindowExtWindows};
 
                 let hwnd = win.hwnd();
-                let raw_context =
-                    ContextBuilder::new().build_raw_context(hwnd).unwrap();
+                let raw_context = ContextBuilder::new().build_raw_context(hwnd).unwrap();
 
                 (raw_context, el)
             }
@@ -110,10 +100,7 @@ File a PR if you are interested in implementing the latter.
 
         let raw_context = unsafe { raw_context.make_current().unwrap() };
 
-        println!(
-            "Pixel format of the window's GL context: {:?}",
-            raw_context.get_pixel_format()
-        );
+        println!("Pixel format of the window's GL context: {:?}", raw_context.get_pixel_format());
 
         let gl = support::load(&*raw_context);
 
@@ -128,20 +115,12 @@ File a PR if you are interested in implementing the latter.
                     return;
                 }
                 Event::WindowEvent { event, .. } => match event {
-                    WindowEvent::Resized(physical_size) => {
-                        raw_context.resize(physical_size)
-                    }
-                    WindowEvent::CloseRequested => {
-                        *control_flow = ControlFlow::Exit
-                    }
+                    WindowEvent::Resized(physical_size) => raw_context.resize(physical_size),
+                    WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
                     _ => (),
                 },
                 Event::RedrawRequested(_) => {
-                    gl.draw_frame(if transparency {
-                        [0.0; 4]
-                    } else {
-                        [1.0, 0.5, 0.7, 1.0]
-                    });
+                    gl.draw_frame(if transparency { [0.0; 4] } else { [1.0, 0.5, 0.7, 1.0] });
                     raw_context.swap_buffers().unwrap();
                 }
                 _ => (),

--- a/glutin_examples/examples/sharing.rs
+++ b/glutin_examples/examples/sharing.rs
@@ -7,20 +7,12 @@ use glutin::window::WindowBuilder;
 use glutin::ContextBuilder;
 use support::{gl, ContextCurrentWrapper, ContextTracker, ContextWrapper};
 
-fn make_renderbuf(
-    gl: &support::Gl,
-    size: PhysicalSize<u32>,
-) -> gl::types::GLuint {
+fn make_renderbuf(gl: &support::Gl, size: PhysicalSize<u32>) -> gl::types::GLuint {
     let mut render_buf = 0;
     unsafe {
         gl.gl.GenRenderbuffers(1, &mut render_buf);
         gl.gl.BindRenderbuffer(gl::RENDERBUFFER, render_buf);
-        gl.gl.RenderbufferStorage(
-            gl::RENDERBUFFER,
-            gl::RGB8,
-            size.width as _,
-            size.height as _,
-        );
+        gl.gl.RenderbufferStorage(gl::RENDERBUFFER, gl::RGB8, size.width as _, size.height as _);
     }
 
     render_buf
@@ -32,24 +24,17 @@ fn main() {
 
     let mut ct = ContextTracker::default();
 
-    let headless_context = ContextBuilder::new()
-        .build_headless(&el, PhysicalSize::new(1, 1))
-        .unwrap();
+    let headless_context =
+        ContextBuilder::new().build_headless(&el, PhysicalSize::new(1, 1)).unwrap();
 
-    let wb = WindowBuilder::new()
-        .with_title("A fantastic window!")
-        .with_inner_size(size);
-    let windowed_context = ContextBuilder::new()
-        .with_shared_lists(&headless_context)
-        .build_windowed(wb, &el)
-        .unwrap();
+    let wb = WindowBuilder::new().with_title("A fantastic window!").with_inner_size(size);
+    let windowed_context =
+        ContextBuilder::new().with_shared_lists(&headless_context).build_windowed(wb, &el).unwrap();
 
-    let headless_id = ct.insert(ContextCurrentWrapper::NotCurrent(
-        ContextWrapper::Headless(headless_context),
-    ));
-    let windowed_id = ct.insert(ContextCurrentWrapper::NotCurrent(
-        ContextWrapper::Windowed(windowed_context),
-    ));
+    let headless_id =
+        ct.insert(ContextCurrentWrapper::NotCurrent(ContextWrapper::Headless(headless_context)));
+    let windowed_id =
+        ct.insert(ContextCurrentWrapper::NotCurrent(ContextWrapper::Windowed(windowed_context)));
 
     let windowed_context = ct.get_current(windowed_id).unwrap();
     println!(
@@ -127,26 +112,14 @@ fn main() {
                             size.width as _,
                             size.height as _,
                         );
-                        glw.gl.Viewport(
-                            0,
-                            0,
-                            size.width as _,
-                            size.height as _,
-                        );
+                        glw.gl.Viewport(0, 0, size.width as _, size.height as _);
                         std::mem::drop(windowed_context);
 
                         let _ = ct.get_current(headless_id).unwrap();
-                        glc.gl.Viewport(
-                            0,
-                            0,
-                            size.width as _,
-                            size.height as _,
-                        );
+                        glc.gl.Viewport(0, 0, size.width as _, size.height as _);
                     }
                 }
-                WindowEvent::CloseRequested => {
-                    *control_flow = ControlFlow::Exit
-                }
+                WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
                 _ => (),
             },
             Event::RedrawRequested(_) => {

--- a/glutin_examples/examples/support/mod.rs
+++ b/glutin_examples/examples/support/mod.rs
@@ -12,13 +12,10 @@ pub struct Gl {
 }
 
 pub fn load(gl_context: &glutin::Context<PossiblyCurrent>) -> Gl {
-    let gl =
-        gl::Gl::load_with(|ptr| gl_context.get_proc_address(ptr) as *const _);
+    let gl = gl::Gl::load_with(|ptr| gl_context.get_proc_address(ptr) as *const _);
 
     let version = unsafe {
-        let data = CStr::from_ptr(gl.GetString(gl::VERSION) as *const _)
-            .to_bytes()
-            .to_vec();
+        let data = CStr::from_ptr(gl.GetString(gl::VERSION) as *const _).to_bytes().to_vec();
         String::from_utf8(data).unwrap()
     };
 
@@ -26,21 +23,11 @@ pub fn load(gl_context: &glutin::Context<PossiblyCurrent>) -> Gl {
 
     unsafe {
         let vs = gl.CreateShader(gl::VERTEX_SHADER);
-        gl.ShaderSource(
-            vs,
-            1,
-            [VS_SRC.as_ptr() as *const _].as_ptr(),
-            std::ptr::null(),
-        );
+        gl.ShaderSource(vs, 1, [VS_SRC.as_ptr() as *const _].as_ptr(), std::ptr::null());
         gl.CompileShader(vs);
 
         let fs = gl.CreateShader(gl::FRAGMENT_SHADER);
-        gl.ShaderSource(
-            fs,
-            1,
-            [FS_SRC.as_ptr() as *const _].as_ptr(),
-            std::ptr::null(),
-        );
+        gl.ShaderSource(fs, 1, [FS_SRC.as_ptr() as *const _].as_ptr(), std::ptr::null());
         gl.CompileShader(fs);
 
         let program = gl.CreateProgram();
@@ -54,8 +41,7 @@ pub fn load(gl_context: &glutin::Context<PossiblyCurrent>) -> Gl {
         gl.BindBuffer(gl::ARRAY_BUFFER, vb);
         gl.BufferData(
             gl::ARRAY_BUFFER,
-            (VERTEX_DATA.len() * std::mem::size_of::<f32>())
-                as gl::types::GLsizeiptr,
+            (VERTEX_DATA.len() * std::mem::size_of::<f32>()) as gl::types::GLsizeiptr,
             VERTEX_DATA.as_ptr() as *const _,
             gl::STATIC_DRAW,
         );
@@ -66,10 +52,8 @@ pub fn load(gl_context: &glutin::Context<PossiblyCurrent>) -> Gl {
             gl.BindVertexArray(vao);
         }
 
-        let pos_attrib =
-            gl.GetAttribLocation(program, b"position\0".as_ptr() as *const _);
-        let color_attrib =
-            gl.GetAttribLocation(program, b"color\0".as_ptr() as *const _);
+        let pos_attrib = gl.GetAttribLocation(program, b"position\0".as_ptr() as *const _);
+        let color_attrib = gl.GetAttribLocation(program, b"color\0".as_ptr() as *const _);
         gl.VertexAttribPointer(
             pos_attrib as gl::types::GLuint,
             2,
@@ -90,7 +74,7 @@ pub fn load(gl_context: &glutin::Context<PossiblyCurrent>) -> Gl {
         gl.EnableVertexAttribArray(color_attrib as gl::types::GLuint);
     }
 
-    Gl { gl: gl }
+    Gl { gl }
 }
 
 impl Gl {
@@ -136,15 +120,13 @@ void main() {
 }
 \0";
 
-pub use self::context_tracker::{
-    ContextCurrentWrapper, ContextId, ContextTracker, ContextWrapper,
-};
+pub use self::context_tracker::{ContextCurrentWrapper, ContextId, ContextTracker, ContextWrapper};
 
 #[allow(dead_code)] // Not used by all examples
 mod context_tracker {
     use glutin::{
-        self, Context, ContextCurrentState, ContextError, NotCurrent,
-        PossiblyCurrent, WindowedContext,
+        self, Context, ContextCurrentState, ContextError, NotCurrent, PossiblyCurrent,
+        WindowedContext,
     };
     use takeable_option::Takeable;
 
@@ -174,29 +156,20 @@ mod context_tracker {
             fw: FW,
         ) -> Result<ContextWrapper<T2>, (Self, ContextError)>
         where
-            FH: FnOnce(
-                Context<T>,
-            )
-                -> Result<Context<T2>, (Context<T>, ContextError)>,
+            FH: FnOnce(Context<T>) -> Result<Context<T2>, (Context<T>, ContextError)>,
             FW: FnOnce(
                 WindowedContext<T>,
-            ) -> Result<
-                WindowedContext<T2>,
-                (WindowedContext<T>, ContextError),
-            >,
+            )
+                -> Result<WindowedContext<T2>, (WindowedContext<T>, ContextError)>,
         {
             match self {
                 ContextWrapper::Headless(ctx) => match fh(ctx) {
                     Ok(ctx) => Ok(ContextWrapper::Headless(ctx)),
-                    Err((ctx, err)) => {
-                        Err((ContextWrapper::Headless(ctx), err))
-                    }
+                    Err((ctx, err)) => Err((ContextWrapper::Headless(ctx), err)),
                 },
                 ContextWrapper::Windowed(ctx) => match fw(ctx) {
                     Ok(ctx) => Ok(ContextWrapper::Windowed(ctx)),
-                    Err((ctx, err)) => {
-                        Err((ContextWrapper::Windowed(ctx), err))
-                    }
+                    Err((ctx, err)) => Err((ContextWrapper::Windowed(ctx), err)),
                 },
             }
         }
@@ -221,9 +194,7 @@ mod context_tracker {
                 ret @ ContextCurrentWrapper::NotCurrent(_) => Ok(ret),
                 ContextCurrentWrapper::PossiblyCurrent(ctx) => match f(ctx) {
                     Ok(ctx) => Ok(ContextCurrentWrapper::NotCurrent(ctx)),
-                    Err((ctx, err)) => {
-                        Err((ContextCurrentWrapper::PossiblyCurrent(ctx), err))
-                    }
+                    Err((ctx, err)) => Err((ContextCurrentWrapper::PossiblyCurrent(ctx), err)),
                 },
             }
         }
@@ -241,9 +212,7 @@ mod context_tracker {
                 ret @ ContextCurrentWrapper::PossiblyCurrent(_) => Ok(ret),
                 ContextCurrentWrapper::NotCurrent(ctx) => match f(ctx) {
                     Ok(ctx) => Ok(ContextCurrentWrapper::PossiblyCurrent(ctx)),
-                    Err((ctx, err)) => {
-                        Err((ContextCurrentWrapper::NotCurrent(ctx), err))
-                    }
+                    Err((ctx, err)) => Err((ContextCurrentWrapper::NotCurrent(ctx), err)),
                 },
             }
         }
@@ -288,10 +257,7 @@ mod context_tracker {
                 self.current.take();
             }
 
-            let this_index = self
-                .others
-                .binary_search_by(|(sid, _)| sid.cmp(&id))
-                .unwrap();
+            let this_index = self.others.binary_search_by(|(sid, _)| sid.cmp(&id)).unwrap();
             Takeable::take(&mut self.others.remove(this_index).1)
         }
 
@@ -299,15 +265,10 @@ mod context_tracker {
         where
             F: FnOnce(
                 ContextCurrentWrapper,
-            ) -> Result<
-                ContextCurrentWrapper,
-                (ContextCurrentWrapper, ContextError),
-            >,
+            )
+                -> Result<ContextCurrentWrapper, (ContextCurrentWrapper, ContextError)>,
         {
-            let this_index = self
-                .others
-                .binary_search_by(|(sid, _)| sid.cmp(&id))
-                .unwrap();
+            let this_index = self.others.binary_search_by(|(sid, _)| sid.cmp(&id)).unwrap();
 
             let this_context = Takeable::take(&mut self.others[this_index].1);
 
@@ -326,22 +287,15 @@ mod context_tracker {
         pub fn get_current(
             &mut self,
             id: ContextId,
-        ) -> Result<&mut ContextWrapper<PossiblyCurrent>, ContextError>
-        {
+        ) -> Result<&mut ContextWrapper<PossiblyCurrent>, ContextError> {
             unsafe {
-                let this_index = self
-                    .others
-                    .binary_search_by(|(sid, _)| sid.cmp(&id))
-                    .unwrap();
+                let this_index = self.others.binary_search_by(|(sid, _)| sid.cmp(&id)).unwrap();
                 if Some(id) != self.current {
                     let old_current = self.current.take();
 
                     if let Err(err) = self.modify(id, |ctx| {
                         ctx.map_not(|ctx| {
-                            ctx.map(
-                                |ctx| ctx.make_current(),
-                                |ctx| ctx.make_current(),
-                            )
+                            ctx.map(|ctx| ctx.make_current(), |ctx| ctx.make_current())
                         })
                     }) {
                         // Oh noes, something went wrong
@@ -355,19 +309,22 @@ mod context_tracker {
                                     )
                                 })
                             }) {
-                                panic!("Could not `make_current` nor `make_not_current`, {:?}, {:?}", err, err2);
+                                panic!(
+                                    "Could not `make_current` nor `make_not_current`, {:?}, {:?}",
+                                    err, err2
+                                );
                             }
                         }
 
                         if let Err(err2) = self.modify(id, |ctx| {
                             ctx.map_possibly(|ctx| {
-                                ctx.map(
-                                    |ctx| ctx.make_not_current(),
-                                    |ctx| ctx.make_not_current(),
-                                )
+                                ctx.map(|ctx| ctx.make_not_current(), |ctx| ctx.make_not_current())
                             })
                         }) {
-                            panic!("Could not `make_current` nor `make_not_current`, {:?}, {:?}", err, err2);
+                            panic!(
+                                "Could not `make_current` nor `make_not_current`, {:?}, {:?}",
+                                err, err2
+                            );
                         }
 
                         return Err(err);
@@ -389,9 +346,7 @@ mod context_tracker {
                 }
 
                 match *self.others[this_index].1 {
-                    ContextCurrentWrapper::PossiblyCurrent(ref mut ctx) => {
-                        Ok(ctx)
-                    }
+                    ContextCurrentWrapper::PossiblyCurrent(ref mut ctx) => Ok(ctx),
                     ContextCurrentWrapper::NotCurrent(_) => panic!(),
                 }
             }

--- a/glutin_examples/examples/transparent.rs
+++ b/glutin_examples/examples/transparent.rs
@@ -12,15 +12,11 @@ fn main() {
         .with_decorations(false)
         .with_transparent(true);
 
-    let windowed_context =
-        ContextBuilder::new().build_windowed(wb, &el).unwrap();
+    let windowed_context = ContextBuilder::new().build_windowed(wb, &el).unwrap();
 
     let windowed_context = unsafe { windowed_context.make_current().unwrap() };
 
-    println!(
-        "Pixel format of the window's GL context: {:?}",
-        windowed_context.get_pixel_format()
-    );
+    println!("Pixel format of the window's GL context: {:?}", windowed_context.get_pixel_format());
 
     let gl = support::load(&windowed_context.context());
 
@@ -31,12 +27,8 @@ fn main() {
         match event {
             Event::LoopDestroyed => return,
             Event::WindowEvent { event, .. } => match event {
-                WindowEvent::Resized(physical_size) => {
-                    windowed_context.resize(physical_size)
-                }
-                WindowEvent::CloseRequested => {
-                    *control_flow = ControlFlow::Exit
-                }
+                WindowEvent::Resized(physical_size) => windowed_context.resize(physical_size),
+                WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
                 _ => (),
             },
             Event::RedrawRequested(_) => {

--- a/glutin_examples/examples/window.rs
+++ b/glutin_examples/examples/window.rs
@@ -9,15 +9,11 @@ fn main() {
     let el = EventLoop::new();
     let wb = WindowBuilder::new().with_title("A fantastic window!");
 
-    let windowed_context =
-        ContextBuilder::new().build_windowed(wb, &el).unwrap();
+    let windowed_context = ContextBuilder::new().build_windowed(wb, &el).unwrap();
 
     let windowed_context = unsafe { windowed_context.make_current().unwrap() };
 
-    println!(
-        "Pixel format of the window's GL context: {:?}",
-        windowed_context.get_pixel_format()
-    );
+    println!("Pixel format of the window's GL context: {:?}", windowed_context.get_pixel_format());
 
     let gl = support::load(&windowed_context.context());
 
@@ -28,12 +24,8 @@ fn main() {
         match event {
             Event::LoopDestroyed => return,
             Event::WindowEvent { event, .. } => match event {
-                WindowEvent::Resized(physical_size) => {
-                    windowed_context.resize(physical_size)
-                }
-                WindowEvent::CloseRequested => {
-                    *control_flow = ControlFlow::Exit
-                }
+                WindowEvent::Resized(physical_size) => windowed_context.resize(physical_size),
+                WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
                 _ => (),
             },
             Event::RedrawRequested(_) => {

--- a/glutin_examples/ios-example/rust/src/lib.rs
+++ b/glutin_examples/ios-example/rust/src/lib.rs
@@ -12,15 +12,11 @@ fn main() {
         .with_decorations(false)
         .with_transparent(true);
 
-    let windowed_context =
-        ContextBuilder::new().build_windowed(wb, &el).unwrap();
+    let windowed_context = ContextBuilder::new().build_windowed(wb, &el).unwrap();
 
     let windowed_context = unsafe { windowed_context.make_current().unwrap() };
 
-    println!(
-        "Pixel format of the window's GL context: {:?}",
-        windowed_context.get_pixel_format()
-    );
+    println!("Pixel format of the window's GL context: {:?}", windowed_context.get_pixel_format());
     let gl = support::load(&windowed_context.context());
     let mut inc: f32 = 0.0;
 
@@ -31,9 +27,7 @@ fn main() {
         match event {
             Event::LoopDestroyed => return,
             Event::WindowEvent { event, .. } => match event {
-                WindowEvent::Resized(physical_size) => {
-                    windowed_context.resize(physical_size)
-                }
+                WindowEvent::Resized(physical_size) => windowed_context.resize(physical_size),
                 WindowEvent::Touch(_touch) => {
                     const INCREMENTER: f32 = 0.05;
                     inc += INCREMENTER;
@@ -45,9 +39,7 @@ fn main() {
                     ]);
                     windowed_context.swap_buffers().unwrap();
                 }
-                WindowEvent::CloseRequested => {
-                    *control_flow = ControlFlow::Exit
-                }
+                WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
                 _ => (),
             },
             Event::RedrawRequested(_) => {

--- a/glutin_gles2_sys/src/lib.rs
+++ b/glutin_gles2_sys/src/lib.rs
@@ -90,12 +90,6 @@ pub const RTLD_LAZY: raw::c_int = 0x001;
 pub const RTLD_GLOBAL: raw::c_int = 0x100;
 
 extern "C" {
-    pub fn dlopen(
-        filename: *const raw::c_char,
-        flag: raw::c_int,
-    ) -> *mut raw::c_void;
-    pub fn dlsym(
-        handle: *mut raw::c_void,
-        symbol: *const raw::c_char,
-    ) -> *mut raw::c_void;
+    pub fn dlopen(filename: *const raw::c_char, flag: raw::c_int) -> *mut raw::c_void;
+    pub fn dlsym(handle: *mut raw::c_void, symbol: *const raw::c_char) -> *mut raw::c_void;
 }

--- a/glutin_glx_sys/build.rs
+++ b/glutin_glx_sys/build.rs
@@ -20,8 +20,7 @@ fn main() {
             .write_bindings(gl_generator::StructGenerator, &mut file)
             .unwrap();
 
-        let mut file =
-            File::create(&dest.join("glx_extra_bindings.rs")).unwrap();
+        let mut file = File::create(&dest.join("glx_extra_bindings.rs")).unwrap();
         Registry::new(
             Api::Glx,
             (1, 4),

--- a/glutin_wgl_sys/build.rs
+++ b/glutin_wgl_sys/build.rs
@@ -15,8 +15,7 @@ fn main() {
             .write_bindings(gl_generator::StaticGenerator, &mut file)
             .unwrap();
 
-        let mut file =
-            File::create(&dest.join("wgl_extra_bindings.rs")).unwrap();
+        let mut file = File::create(&dest.join("wgl_extra_bindings.rs")).unwrap();
         Registry::new(
             Api::Wgl,
             (1, 0),

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
-wrap_comments = true
-max_width = 80
-normalize_comments = true
+use_small_heuristics = "Max"
+use_field_init_shorthand = true
+newline_style = "Unix"
+edition = "2018"


### PR DESCRIPTION
This changes the way rustfmt runs, since right now it uses nightly
versions and it's not properly checked on CI, while we can use nightly
on CI, the stable rustfmt should work fine.

Also the 'small' heuristics was changed to 'Max' to make code more
compact.
