### PR TITLE
Fix broken link in documentation

### DIFF
--- a/glutin/src/lib.rs
+++ b/glutin/src/lib.rs
@@ -30,7 +30,7 @@
 //! You can also produce headless [`Context`]s via the
 //! [`ContextBuilder::build_headless`] function.
 //!
-//! [`Window`]: struct.Window.html
+//! [`Window`]: window/struct.Window.html
 //! [`Context`]: struct.Context.html
 //! [`WindowedContext<T>`]: type.WindowedContext.html
 //! [`RawContext<T>`]: type.RawContext.html


### PR DESCRIPTION
The link to the `Window` struct on the [glutin index page is
broken][0]. It looks for the struct in the top-level module but
it's defined in the `window` module.

This change prefixes the link with the window module name.

- [ ] Tested on all platforms changed
- [ ] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality

[0]: https://docs.rs/glutin/0.26.0/glutin/