### PR TITLE
Fix possible panic on Windows for headless contexts because of active drag and drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fixed possible panic (OleInitialize failed! Result was: `RPC_E_CHANGED_MODE`) for headless contexts on Windows because of active drag-and-drop
+
 # Version 0.27.0 (2021-06-01)
 
 - Updated winit dependency to 0.25.0. See [winit's CHANGELOG](https://github.com/rust-windowing/winit/releases/tag/v0.25.0) for more info.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- Fixed possible panic (OleInitialize failed! Result was: `RPC_E_CHANGED_MODE`) for headless contexts on Windows because of active drag-and-drop
+- On Windows, fixed a panic for headless contexts because of active drag-and-drop (OleInitialize failed! Result was: `RPC_E_CHANGED_MODE`)
 
 # Version 0.27.0 (2021-06-01)
 

--- a/glutin/src/platform_impl/windows/mod.rs
+++ b/glutin/src/platform_impl/windows/mod.rs
@@ -14,6 +14,7 @@ use winapi::shared::windef::{HGLRC, HWND};
 use winit;
 use winit::dpi;
 use winit::event_loop::EventLoopWindowTarget;
+use winit::platform::windows::WindowBuilderExtWindows;
 use winit::window::{Window, WindowBuilder};
 
 use std::marker::PhantomData;
@@ -170,7 +171,10 @@ impl Context {
             _ => (),
         }
 
-        let wb = WindowBuilder::new().with_visible(false).with_inner_size(size);
+        let wb = WindowBuilder::new()
+            .with_visible(false)
+            .with_inner_size(size)
+            .with_drag_and_drop(false);
         Self::new_windowed(wb, &el, pf_reqs, gl_attr).map(|(win, context)| match context {
             Context::Egl(context) => Context::HiddenWindowEgl(win, context),
             Context::Wgl(context) => Context::HiddenWindowWgl(win, context),


### PR DESCRIPTION
Integrating a headless context into a legacy Windows application was not working for me because of this error:

> thread 'unnamed' panicked at 'OleInitialize failed! Result was: `RPC_E_CHANGED_MODE`. Make sure other crates are not using multithreaded COM library on the same thread or disable drag and drop support.',…\.cargo\registry\src\github.com-1ecc6299db9ec823\winit-0.24.0\src\platform_impl\windows\window.rs:85:25

I guess a headless context usually doesn't need drag-and-drop support, so it should be safe to disable this default winit behavior?

Looking forward to your thoughts!

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
