### PR TITLE
Update winit to 0.25 and cocoa to 0.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Updated winit dependency to 0.25.0. See [winit's CHANGELOG](https://github.com/rust-windowing/winit/releases/tag/v0.25.0) for more info.
+
 # Version 0.26.0 (2020-12-10)
 
 - Updated winit dependency to 0.24.0. See [winit's CHANGELOG](https://github.com/rust-windowing/winit/releases/tag/v0.24.0) for more info.

--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -21,7 +21,7 @@ default = ["x11", "wayland"]
 
 [dependencies]
 lazy_static = "1.3"
-winit = { version = "0.24.0", default-features = false }
+winit = { version = "0.25", default-features = false }
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_glue = "0.2"
@@ -37,7 +37,7 @@ glutin_gles2_sys = { version = "0.1.4", path = "../glutin_gles2_sys" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cgl = "0.3"
-cocoa = "0.23"
+cocoa = "0.24"
 core-foundation = "0.9"
 
 [target.'cfg(target_os = "windows")'.dependencies.winapi]

--- a/glutin_examples/Cargo.toml
+++ b/glutin_examples/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 
 [dependencies]
 glutin = { path = "../glutin" }
-winit = "0.24.0"
+winit = "0.25"
 takeable-option = "0.4"
 image = "0.21"
 

--- a/glutin_examples/Cargo.toml
+++ b/glutin_examples/Cargo.toml
@@ -12,7 +12,6 @@ publish = false
 
 [dependencies]
 glutin = { path = "../glutin" }
-winit = "0.25"
 takeable-option = "0.4"
 image = "0.21"
 


### PR DESCRIPTION
Updates _winit_ to the latest version: https://github.com/rust-windowing/winit/releases/tag/v0.25.0 I also updated _cocoa_ to match the version used in _winit_ (closes #1346).

It would be great to see a new glutin release to go with this.

- ~Tested on all platforms changed~ I've tested Linux examples.
- ~Compilation warnings were addressed~ There are loads and are not related.
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- ~Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior~
- ~Created or updated an example program if it would help users understand this functionality~
