### PR TITLE
Fix ios glutin example viewport size

### DIFF
--- a/glutin_examples/ios-example/GlutinExample/Info.plist
+++ b/glutin_examples/ios-example/GlutinExample/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UILaunchScreen</key>
+	<dict>
+		<key>UIImageName</key>
+		<string></string>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
Adding launch screen image fixes the issue. Basically without it viewport does not match actual screen size (there are black edges to on the top and bottom of the screen). Here is an example: https://stackoverflow.com/questions/32641240/ios-9-xcode-7-application-appears-with-black-bars-on-top-and-bottom

- [x] Tested on all platforms changed
- [x] ~~Compilation warnings were addressed~~
- [x] ~~`cargo fmt` has been run on this branch~~
- [x] ~~`cargo doc` builds successfully~~
- [x] ~~Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users~~
- [x] ~~Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior~~
- [x] Created or updated an example program if it would help users understand this functionality
