### PR TITLE
Fix sRGB support for WGL and EGL

### DIFF
--- a/glutin/src/api/egl/mod.rs
+++ b/glutin/src/api/egl/mod.rs
@@ -816,8 +816,20 @@ impl<'a> ContextPrototype<'a> {
     pub fn finish(self, nwin: ffi::EGLNativeWindowType) -> Result<Context, CreationError> {
         let egl = EGL.as_ref().unwrap();
         let surface = unsafe {
+            let colorspace = if self.pixel_format.srgb {
+                ffi::egl::GL_COLORSPACE_SRGB
+            } else {
+                ffi::egl::GL_COLORSPACE_LINEAR
+            };
+
+            let attrs = &[
+                ffi::egl::GL_COLORSPACE as raw::c_int,
+                colorspace as raw::c_int,
+                ffi::egl::NONE as raw::c_int,
+            ];
+
             let surface =
-                egl.CreateWindowSurface(self.display, self.config_id, nwin, std::ptr::null());
+                egl.CreateWindowSurface(self.display, self.config_id, nwin, attrs.as_ptr());
             if surface.is_null() {
                 return Err(CreationError::OsError("eglCreateWindowSurface failed".to_string()));
             }
@@ -1126,8 +1138,6 @@ where
             out.push(xid as raw::c_int);
         }
 
-        // FIXME: srgb is not taken into account
-
         match pf_reqs.release_behavior {
             ReleaseBehavior::Flush => (),
             ReleaseBehavior::None => {
@@ -1238,7 +1248,7 @@ where
             0 | 1 => None,
             a => Some(a as u16),
         },
-        srgb: false, // TODO: use EGL_KHR_gl_colorspace to know that
+        srgb: pf_reqs.srgb,
     };
 
     Ok((config_id, desc))

--- a/glutin/src/api/wgl/mod.rs
+++ b/glutin/src/api/wgl/mod.rs
@@ -616,7 +616,14 @@ unsafe fn choose_arb_pixel_format_id(
 
         // WGL_*_FRAMEBUFFER_SRGB might be assumed to be true if not listed;
         // so it's best to list it out and set its value as necessary.
-        if extensions.split(' ').find(|&i| i == "WGL_ARB_framebuffer_sRGB").is_some() {
+        if extensions.split(' ').find(|&i| i == "WGL_EXT_colorspace").is_some() {
+            out.push(gl::wgl_extra::COLORSPACE_EXT as raw::c_int);
+            if pf_reqs.srgb {
+                out.push(gl::wgl_extra::COLORSPACE_SRGB_EXT as raw::c_int);
+            } else {
+                out.push(gl::wgl_extra::COLORSPACE_LINEAR_EXT as raw::c_int);
+            }
+        } else if extensions.split(' ').find(|&i| i == "WGL_ARB_framebuffer_sRGB").is_some() {
             out.push(gl::wgl_extra::FRAMEBUFFER_SRGB_CAPABLE_ARB as raw::c_int);
             out.push(pf_reqs.srgb as raw::c_int);
         } else if extensions.split(' ').find(|&i| i == "WGL_EXT_framebuffer_sRGB").is_some() {
@@ -704,6 +711,8 @@ unsafe fn choose_arb_pixel_format(
         srgb: if extensions.split(' ').find(|&i| i == "WGL_ARB_framebuffer_sRGB").is_some() {
             get_info(gl::wgl_extra::FRAMEBUFFER_SRGB_CAPABLE_ARB) != 0
         } else if extensions.split(' ').find(|&i| i == "WGL_EXT_framebuffer_sRGB").is_some() {
+            get_info(gl::wgl_extra::FRAMEBUFFER_SRGB_CAPABLE_EXT) != 0
+        } else if extensions.split(' ').find(|&i| i == "WGL_EXT_colorspace").is_some() {
             get_info(gl::wgl_extra::FRAMEBUFFER_SRGB_CAPABLE_EXT) != 0
         } else {
             false

--- a/glutin_egl_sys/build.rs
+++ b/glutin_egl_sys/build.rs
@@ -38,6 +38,7 @@ fn main() {
                 "EGL_EXT_platform_wayland",
                 "EGL_EXT_platform_device",
                 "EGL_KHR_swap_buffers_with_damage",
+                "EGL_KHR_gl_colorspace",
             ],
         );
 

--- a/glutin_wgl_sys/build.rs
+++ b/glutin_wgl_sys/build.rs
@@ -35,6 +35,7 @@ fn main() {
                 "WGL_EXT_extensions_string",
                 "WGL_EXT_framebuffer_sRGB",
                 "WGL_EXT_swap_control",
+                "WGL_EXT_colorspace",
             ],
         )
         .write_bindings(gl_generator::StructGenerator, &mut file)


### PR DESCRIPTION
This PR fixes sRGB support for the `wgl` and `egl` backends (which I encountered while trying sRGB with OpenGL ES).

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [ ] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
