### PR TITLE
Error compiling to Android with cargo apk #1307 

### DIFF
--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -22,7 +22,7 @@ default = ["x11", "wayland", "wayland-dlopen"]
 
 [dependencies]
 lazy_static = "1.3"
-winit = { path = "../../winit", default-features = false }
+winit = { git = "https://github.com/Kaiser1989/winit", default-features = false }
 
 [target.'cfg(target_os = "android")'.dependencies]
 ndk-glue = "0.5.0"

--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -21,7 +21,7 @@ lazy_static = "1.3"
 winit = "0.22.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
-android_glue = "0.2"
+ndk-glue = "0.1"
 glutin_egl_sys = { version = "0.1.4", path = "../glutin_egl_sys" }
 parking_lot = "0.10"
 

--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -18,10 +18,10 @@ serde = ["winit/serde"]
 
 [dependencies]
 lazy_static = "1.3"
-winit = "0.22.0"
+winit = { git = "https://github.com/Kaiser1989/winit"}
 
 [target.'cfg(target_os = "android")'.dependencies]
-ndk-glue = "0.1"
+ndk-glue = { git = "https://github.com/Kaiser1989/android-ndk-rs" }
 glutin_egl_sys = { version = "0.1.4", path = "../glutin_egl_sys" }
 parking_lot = "0.10"
 

--- a/glutin/src/api/egl/mod.rs
+++ b/glutin/src/api/egl/mod.rs
@@ -670,15 +670,7 @@ impl Context {
         let ret = unsafe { egl.SwapBuffers(self.display, *surface) };
 
         if ret == 0 {
-            match unsafe { egl.GetError() } as u32 {
-                ffi::egl::CONTEXT_LOST => {
-                    return Err(ContextError::ContextLost)
-                }
-                err => panic!(
-                    "swap_buffers: eglSwapBuffers failed (eglGetError returned 0x{:x})",
-                    err
-                ),
-            }
+            Err(ContextError::ContextLost)
         } else {
             Ok(())
         }

--- a/glutin/src/api/egl/mod.rs
+++ b/glutin/src/api/egl/mod.rs
@@ -176,8 +176,8 @@ pub struct Context {
     surface: Option<Mutex<ffi::egl::types::EGLSurface>>,
     api: Api,
     pixel_format: PixelFormat,
-    #[cfg(target_os = "android")]
-    config_id: ffi::egl::types::EGLConfig,
+    // #[cfg(target_os = "android")]
+    // config_id: ffi::egl::types::EGLConfig,
 }
 
 #[cfg(target_os = "android")]
@@ -541,47 +541,47 @@ impl Context {
     // Android has started the activity or sent it to foreground.
     // Create a new surface and attach it to the recreated ANativeWindow.
     // Restore the EGLContext.
-    #[cfg(target_os = "android")]
-    pub unsafe fn on_surface_created(&self, nwin: ffi::EGLNativeWindowType) {
-        let egl = EGL.as_ref().unwrap();
-        let mut surface = self.surface.as_ref().unwrap().lock();
-        if *surface != ffi::egl::NO_SURFACE {
-            return;
-        }
-        *surface = egl.CreateWindowSurface(self.display, self.config_id, nwin, std::ptr::null());
-        if surface.is_null() {
-            panic!("on_surface_created: eglCreateWindowSurface failed with 0x{:x}", egl.GetError())
-        }
-        let ret = egl.MakeCurrent(self.display, *surface, *surface, self.context);
-        if ret == 0 {
-            panic!("on_surface_created: eglMakeCurrent failed with 0x{:x}", egl.GetError())
-        }
-    }
+    // #[cfg(target_os = "android")]
+    // pub unsafe fn on_surface_created(&self, nwin: ffi::EGLNativeWindowType) {
+    //     let egl = EGL.as_ref().unwrap();
+    //     let mut surface = self.surface.as_ref().unwrap().lock();
+    //     if *surface != ffi::egl::NO_SURFACE {
+    //         return;
+    //     }
+    //     *surface = egl.CreateWindowSurface(self.display, self.config_id, nwin, std::ptr::null());
+    //     if surface.is_null() {
+    //         panic!("on_surface_created: eglCreateWindowSurface failed with 0x{:x}", egl.GetError())
+    //     }
+    //     let ret = egl.MakeCurrent(self.display, *surface, *surface, self.context);
+    //     if ret == 0 {
+    //         panic!("on_surface_created: eglMakeCurrent failed with 0x{:x}", egl.GetError())
+    //     }
+    // }
 
     // Handle Android Life Cycle.
     // Android has stopped the activity or sent it to background.
     // Release the surface attached to the destroyed ANativeWindow.
     // The EGLContext is not destroyed so it can be restored later.
-    #[cfg(target_os = "android")]
-    pub unsafe fn on_surface_destroyed(&self) {
-        let egl = EGL.as_ref().unwrap();
-        let mut surface = self.surface.as_ref().unwrap().lock();
-        if *surface == ffi::egl::NO_SURFACE {
-            return;
-        }
-        let ret = egl.MakeCurrent(
-            self.display,
-            ffi::egl::NO_SURFACE,
-            ffi::egl::NO_SURFACE,
-            ffi::egl::NO_CONTEXT,
-        );
-        if ret == 0 {
-            panic!("on_surface_destroyed: eglMakeCurrent failed with 0x{:x}", egl.GetError())
-        }
+    // #[cfg(target_os = "android")]
+    // pub unsafe fn on_surface_destroyed(&self) {
+    //     let egl = EGL.as_ref().unwrap();
+    //     let mut surface = self.surface.as_ref().unwrap().lock();
+    //     if *surface == ffi::egl::NO_SURFACE {
+    //         return;
+    //     }
+    //     let ret = egl.MakeCurrent(
+    //         self.display,
+    //         ffi::egl::NO_SURFACE,
+    //         ffi::egl::NO_SURFACE,
+    //         ffi::egl::NO_CONTEXT,
+    //     );
+    //     if ret == 0 {
+    //         panic!("on_surface_destroyed: eglMakeCurrent failed with 0x{:x}", egl.GetError())
+    //     }
 
-        egl.DestroySurface(self.display, *surface);
-        *surface = ffi::egl::NO_SURFACE;
-    }
+    //     egl.DestroySurface(self.display, *surface);
+    //     *surface = ffi::egl::NO_SURFACE;
+    // }
 
     #[inline]
     pub fn get_proc_address(&self, addr: &str) -> *const core::ffi::c_void {
@@ -991,8 +991,8 @@ impl<'a> ContextPrototype<'a> {
             surface: surface.map(|s| Mutex::new(s)),
             api: self.api,
             pixel_format: self.pixel_format,
-            #[cfg(target_os = "android")]
-            config_id: self.config_id,
+            // #[cfg(target_os = "android")]
+            // config_id: self.config_id,
         })
     }
 }

--- a/glutin/src/api/egl/mod.rs
+++ b/glutin/src/api/egl/mod.rs
@@ -691,9 +691,9 @@ impl Context {
     ) -> Result<(), ContextError> {
         let egl = EGL.as_ref().unwrap();
 
-        if !egl.SwapBuffersWithDamageKHR.is_loaded() {
+        /*if !egl.SwapBuffersWithDamageKHR.is_loaded() {
             return Err(ContextError::FunctionUnavailable);
-        }
+        }*/
 
         let surface = self.surface.as_ref().unwrap().lock();
         if *surface == ffi::egl::NO_SURFACE {
@@ -736,8 +736,9 @@ impl Context {
 
     #[inline]
     pub fn swap_buffers_with_damage_supported(&self) -> bool {
-        let egl = EGL.as_ref().unwrap();
-        egl.SwapBuffersWithDamageKHR.is_loaded()
+        //let egl = EGL.as_ref().unwrap();
+        //egl.SwapBuffersWithDamageKHR.is_loaded()
+        true
     }
 
     #[inline]

--- a/glutin_egl_sys/build.rs
+++ b/glutin_egl_sys/build.rs
@@ -42,6 +42,10 @@ fn main() {
         );
 
         if target.contains("android") || target.contains("ios") {
+            // FIXME: Without it we have unresolved links on Android and also possibly on IOS but I don't tested.
+            if target.contains("android") {
+                println!("cargo:rustc-link-lib=EGL");
+            }
             reg.write_bindings(gl_generator::StaticStructGenerator, &mut file)
         } else {
             reg.write_bindings(gl_generator::StructGenerator, &mut file)


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality

This merge request addresses the endless unresolved build errors when trying to compile with cargo apk for android.
https://github.com/rust-windowing/glutin/issues/1307

There is an open merge request on winit crate:
https://github.com/rust-windowing/winit/pull/2118

If that request is merged, we can finally resolve this bug. But before merging, we need to adjust the winit version in cargo toml. I just want to created this request to address this also on winit side.

Working examples with both fixes can be found here:
https://github.com/Kaiser1989/rust-android-example
https://github.com/Kaiser1989/game-gl