### PR TITLE
Fix error on systems without vsync support (#1262)

### DIFF
--- a/glutin/src/api/glx/mod.rs
+++ b/glutin/src/api/glx/mod.rs
@@ -409,7 +409,7 @@ impl<'a> ContextPrototype<'a> {
             unsafe {
                 extra_functions.SwapIntervalSGI(swap_mode);
             }
-        } else {
+        } else if self.opengl.vsync {
             return Err(CreationError::OsError(
                 "Couldn't find any available vsync extension".to_string(),
             ));


### PR DESCRIPTION
If vsync was not requested and it is not supported on the system, then this feature can safely be ignored. This makes the program runnable on systems without vsync support like the Raspberry Pi Zero. 

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
