### PR TITLE
Ignore vsync safely on unsupported platforms.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Ignore vsync safely on unsupported platforms (e.g: llvmpipe software render).
+
 # Version 0.28.0 (2021-12-02)
 
 - On Windows, fixed a panic for headless contexts because of active drag-and-drop (OleInitialize failed! Result was: `RPC_E_CHANGED_MODE`)

--- a/glutin/src/api/egl/mod.rs
+++ b/glutin/src/api/egl/mod.rs
@@ -364,7 +364,7 @@ fn get_native_display(native_display: &NativeDisplay) -> *const raw::c_void {
                 ffi::egl::DEFAULT_DISPLAY as *mut _,
                 std::ptr::null(),
             )
-        }
+        },
 
         NativeDisplay::Device(display)
             if has_dp_extension("EGL_EXT_platform_device")
@@ -375,7 +375,7 @@ fn get_native_display(native_display: &NativeDisplay) -> *const raw::c_void {
                 display as *mut _,
                 std::ptr::null(),
             )
-        }
+        },
 
         NativeDisplay::X11(Some(display))
         | NativeDisplay::Gbm(Some(display))

--- a/glutin/src/api/glx/mod.rs
+++ b/glutin/src/api/glx/mod.rs
@@ -364,7 +364,13 @@ impl<'a> ContextPrototype<'a> {
     }
 
     pub fn finish(self, window: ffi::Window) -> Result<Context, CreationError> {
-        let glx = GLX.as_ref().unwrap();
+        let glx = match GLX.as_ref() {
+            Some(glx) => glx,
+            _ => {
+                return Err(CreationError::OsError("Can't get GLX as reference.".into()));
+            }
+        };
+
         let (extra_functions, context) = self.create_context()?;
 
         // vsync
@@ -410,9 +416,7 @@ impl<'a> ContextPrototype<'a> {
                 extra_functions.SwapIntervalSGI(swap_mode);
             }
         } else if self.opengl.vsync {
-            return Err(CreationError::OsError(
-                "Couldn't find any available vsync extension".to_string(),
-            ));
+            eprintln!("Couldn't find any available vsync extension on this platform.")
         }
 
         Ok(Context {

--- a/glutin/src/platform_impl/unix/x11.rs
+++ b/glutin/src/platform_impl/unix/x11.rs
@@ -41,10 +41,18 @@ pub enum X11Context {
     Egl(EglContext),
 }
 
-#[derive(Debug)]
 pub struct ContextInner {
     xconn: Arc<XConnection>,
     context: X11Context,
+}
+
+impl std::fmt::Debug for ContextInner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ContextInner")
+            .field("xconn", &self.xconn)
+            .field("context", &self.context)
+            .finish()
+    }
 }
 
 enum Prototype<'a> {


### PR DESCRIPTION
- [✅] Tested on all platforms changed
- [✅] Compilation warnings were addressed
- [✅] `cargo fmt` has been run on this branch
- [✅] `cargo doc` builds successfully
- [✅] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users

improvement of this PR: https://github.com/rust-windowing/glutin/pull/1387
thanks to: @ch-sy