### PR TITLE
Return Err instead of panic on surfaceless GLX contexts on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix crash when creating OpenGLES context without explicit version
 - Add `buffer_age` method on `WindowedContext`
+- Return an `Err` instead of panicking when surfaceless GLX context creation fails on Linux
 
 # Version 0.28.0 (2021-12-02)
 

--- a/glutin/src/platform_impl/unix/x11.rs
+++ b/glutin/src/platform_impl/unix/x11.rs
@@ -264,7 +264,11 @@ impl Context {
                 // Prototype::Glx(ctx) =>
                 // X11Context::Glx(ctx.finish_surfaceless(xwin)?),
                 Prototype::Egl(ctx) => X11Context::Egl(ctx.finish_surfaceless()?),
-                _ => unimplemented!(),
+                _ => {
+                    return Err(CreationError::NotSupported(
+                        "Surfaceless GLX context not implemented".to_string(),
+                    ))
+                }
             };
 
             let context = Context::Surfaceless(ContextInner { context });


### PR DESCRIPTION
Returns an `Err` instead of panicking in this specific case when surfaceless context creation fails on Linux. This allows my program to gracefully fall back to an OsMesa context when it fails.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality