### PR TITLE
Fixes android symbol loader not having `is_loaded` (build error)

### DIFF
--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -22,7 +22,7 @@ default = ["x11", "wayland", "wayland-dlopen"]
 
 [dependencies]
 lazy_static = "1.3"
-winit = { version = "0.26", default-features = false }
+winit = { version = "0.26", default-features = false, path="../../winit" }
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_glue = "0.2"

--- a/glutin/src/api/android/mod.rs
+++ b/glutin/src/api/android/mod.rs
@@ -143,6 +143,11 @@ impl Context {
     pub fn resize(&self, _: u32, _: u32) {}
 
     #[inline]
+    pub fn buffer_age(&self) -> u32 {
+        self.0.egl_context.buffer_age()
+    }
+
+    #[inline]
     pub fn is_current(&self) -> bool {
         self.0.egl_context.is_current()
     }

--- a/glutin/src/api/android/mod.rs
+++ b/glutin/src/api/android/mod.rs
@@ -4,7 +4,7 @@ use crate::api::egl::{Context as EglContext, NativeDisplay, SurfaceType as EglSu
 use crate::CreationError::{self, OsError};
 use crate::{Api, ContextError, GlAttributes, PixelFormat, PixelFormatRequirements, Rect};
 
-use crate::platform::android::EventLoopExtAndroid;
+use crate::platform::android::EventLoopWindowTargetExtAndroid;
 use glutin_egl_sys as ffi;
 use parking_lot::Mutex;
 use winit;

--- a/glutin/src/api/egl/mod.rs
+++ b/glutin/src/api/egl/mod.rs
@@ -617,7 +617,11 @@ impl Context {
     #[cfg(not(target_os = "windows"))]
     pub fn swap_buffers_with_damage(&self, rects: &[Rect]) -> Result<(), ContextError> {
         let egl = EGL.as_ref().unwrap();
-        
+
+        if !self.swap_buffers_with_damage_supported() {
+            return Err(ContextError::FunctionUnavailable);
+        }
+
         let surface = self.surface.as_ref().unwrap().lock();
         if *surface == ffi::egl::NO_SURFACE {
             return Err(ContextError::ContextLost);
@@ -654,7 +658,7 @@ impl Context {
     }
 
     #[inline]
-    #[cfg(all(not(target_os = "windows"), not(target_os = "android")))]
+    #[cfg(not(any(target_os = "windows", target_os = "android")))]
     pub fn swap_buffers_with_damage_supported(&self) -> bool {
         let egl = EGL.as_ref().unwrap();
         egl.SwapBuffersWithDamageKHR.is_loaded()

--- a/glutin/src/api/egl/mod.rs
+++ b/glutin/src/api/egl/mod.rs
@@ -617,11 +617,7 @@ impl Context {
     #[cfg(not(target_os = "windows"))]
     pub fn swap_buffers_with_damage(&self, rects: &[Rect]) -> Result<(), ContextError> {
         let egl = EGL.as_ref().unwrap();
-
-        if !egl.SwapBuffersWithDamageKHR.is_loaded() {
-            return Err(ContextError::FunctionUnavailable);
-        }
-
+        
         let surface = self.surface.as_ref().unwrap().lock();
         if *surface == ffi::egl::NO_SURFACE {
             return Err(ContextError::ContextLost);
@@ -658,10 +654,16 @@ impl Context {
     }
 
     #[inline]
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(all(not(target_os = "windows"), not(target_os = "android")))]
     pub fn swap_buffers_with_damage_supported(&self) -> bool {
         let egl = EGL.as_ref().unwrap();
         egl.SwapBuffersWithDamageKHR.is_loaded()
+    }
+
+    #[inline]
+    #[cfg(target_os = "android")]
+    pub fn swap_buffers_with_damage_supported(&self) -> bool {
+        true
     }
 
     #[inline]


### PR DESCRIPTION
Fixes https://github.com/rust-windowing/glutin/issues/1307

- [ ] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [ ] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
