### PR TITLE
Fix `clippy::inherent_to_string_shadow_display` on `CreationError`

### DIFF
--- a/glutin/src/lib.rs
+++ b/glutin/src/lib.rs
@@ -337,7 +337,11 @@ impl std::fmt::Display for CreationError {
                 return write!(f, "{}", err);
             }
             CreationError::CreationErrors(ref es) => {
-                return write!(f, "Received multiple errors: `{:?}`", es);
+                writeln!(f, "Received multiple errors:")?;
+                for e in es {
+                    writeln!(f, "\t{}", e)?;
+                }
+                return Ok(());
             }
         })
     }

--- a/glutin/src/lib.rs
+++ b/glutin/src/lib.rs
@@ -313,42 +313,33 @@ impl CreationError {
             _ => CreationError::CreationErrors(vec![Box::new(err), Box::new(self)]),
         }
     }
-
-    fn to_string(&self) -> String {
-        match self {
-            CreationError::OsError(text) | CreationError::NotSupported(text) => text.clone(),
-            CreationError::NoBackendAvailable(_) => "No backend is available".to_string(),
-            CreationError::RobustnessNotSupported => {
-                "You requested robustness, but it is not supported.".to_string()
-            }
-            CreationError::OpenGlVersionNotSupported => {
-                "The requested OpenGL version is not supported.".to_string()
-            }
-            CreationError::NoAvailablePixelFormat => {
-                "Couldn't find any pixel format that matches the criteria.".to_string()
-            }
-            CreationError::PlatformSpecific(text) => text.clone(),
-            CreationError::Window(err) => err.to_string(),
-            CreationError::CreationErrors(_) => "Received multiple errors.".to_string(),
-        }
-    }
 }
 
 impl std::fmt::Display for CreationError {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-        formatter.write_str(&self.to_string())?;
-
-        if let CreationError::CreationErrors(ref es) = *self {
-            use std::fmt::Debug;
-            write!(formatter, " Errors: `")?;
-            es.fmt(formatter)?;
-            write!(formatter, "`")?;
-        }
-
-        if let Some(err) = std::error::Error::source(self) {
-            write!(formatter, ": {}", err)?;
-        }
-        Ok(())
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        f.write_str(match self {
+            CreationError::OsError(text)
+            | CreationError::NotSupported(text)
+            | CreationError::PlatformSpecific(text) => text,
+            CreationError::NoBackendAvailable(err) => {
+                return write!(f, "No backend is available: {}", err);
+            }
+            CreationError::RobustnessNotSupported => {
+                "You requested robustness, but it is not supported."
+            }
+            CreationError::OpenGlVersionNotSupported => {
+                "The requested OpenGL version is not supported."
+            }
+            CreationError::NoAvailablePixelFormat => {
+                "Couldn't find any pixel format that matches the criteria."
+            }
+            CreationError::Window(err) => {
+                return write!(f, "{}", err);
+            }
+            CreationError::CreationErrors(ref es) => {
+                return write!(f, "Received multiple errors: `{:?}`", es);
+            }
+        })
     }
 }
 


### PR DESCRIPTION
Clippy throws:

    error: type `CreationError` implements inherent method `to_string(&self) -> String` which shadows the implementation of `Display`
       --> glutin/src/lib.rs:317:5
        |
    317 | /     fn to_string(&self) -> String {
    318 | |         match self {
    319 | |             CreationError::OsError(text) | CreationError::NotSupported(text) => text.clone(),
    320 | |             CreationError::NoBackendAvailable(_) => "No backend is available".to_string(),
    ...   |
    333 | |         }
    334 | |     }
        | |_____^
        |
        = note: `#[deny(clippy::inherent_to_string_shadow_display)]` on by default
        = help: remove the inherent method from type `CreationError`
        = help: for further information visit
        https://rust-lang.github.io/rust-clippy/master/index.html#inherent_to_string_shadow_display

To solve this, the contents of the function - which were only consumed by the `impl Display for CreationError` anyway - have been moved into that implementation.  The function has been revised to only format a nested error if the enum variant has one.  Regardless the default implementation for `source()` returns `None` and doesn't forward to the deprecated `fn cause()` implementation, which we should probably update too.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users (internal change not relevant to users)
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
