### PR TITLE
ci: Disallow warnings in rustdoc and test private items

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
       OPTIONS: ${{ matrix.platform.options }}
       FEATURES: ${{ format(',{0}', matrix.platform.features ) }}
       WEB: ${{ matrix.platform.web }}
+      RUSTDOCFLAGS: -Dwarnings
 
     runs-on: ${{ matrix.platform.os }}
     steps:
@@ -81,7 +82,7 @@ jobs:
     - name: Check documentation
       shell: bash
       if: matrix.platform.target != 'wasm32-unknown-unknown'
-      run: cd glutin && cargo doc --no-deps --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES
+      run: cd glutin && cargo doc --no-deps --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES --document-private-items
 
     - name: Build glutin
       shell: bash


### PR DESCRIPTION
To jibe with the PR template, make sure `cargo doc` runs cleanly without
any warnings.

In case someone wishes to add docs on private items, make sure those
adhere to the same standards.
