### PR TITLE
api/android: Implement missing `buffer_age()` function

### DIFF
--- a/glutin/src/api/android/mod.rs
+++ b/glutin/src/api/android/mod.rs
@@ -153,6 +153,11 @@ impl Context {
     }
 
     #[inline]
+    pub fn buffer_age(&self) -> u32 {
+        self.0.egl_context.buffer_age()
+    }
+
+    #[inline]
     pub fn swap_buffers(&self) -> Result<(), ContextError> {
         if let Some(ref stopped) = self.0.stopped {
             let stopped = stopped.lock();


### PR DESCRIPTION
This function, introduced in 988b070 ("Add `buffer_age` method on `WindowedContext`") was implemented for every platform and the EGL API/backend, but not implemented on the Android platform.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users (piggy-backing on the one added in the mentioned commit)
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality

---

Note that I'll be adding Android to the CI soon to prevent such mishaps, as soon as we've fleshed out the remaining mishaps.

In addition I couldn't help notice that `android` currently lives under `api/` where the APIs (EGL/GLX/osmesa/wgl etc) live, while all the platforms are under `platform_impl/` (Android is just an ugly reexport there). Can I move it over from `api/` to `platform_impl/`?