### PR TITLE
Run clippy in the CI with warnings disallowed; address most warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,8 @@ on:
       - '.github/workflows/ci.yml'
 
 jobs:
-  Check_Formatting:
+  check-formatting:
+    name: Check formatting
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
@@ -25,7 +26,8 @@ jobs:
     - name: Check Formatting
       run: cargo +stable fmt --all -- --check
 
-  Tests:
+  tests:
+    name: Tests
     strategy:
       fail-fast: false
       matrix:
@@ -70,6 +72,7 @@ jobs:
       with:
         rust-version: ${{ matrix.rust_version }}${{ matrix.platform.host }}
         targets: ${{ matrix.platform.target }}
+        components: clippy
 
     - name: Install GCC Multilib
       if: (matrix.platform.os == 'ubuntu-latest') && contains(matrix.platform.target, 'i686')
@@ -83,6 +86,11 @@ jobs:
       shell: bash
       if: matrix.platform.target != 'wasm32-unknown-unknown'
       run: cd glutin && cargo doc --no-deps --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES --document-private-items
+
+    - name: Lint with clippy
+      shell: bash
+      if: matrix.rust_version != 'nightly'
+      run: cargo clippy --workspace --all-targets --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES -- -Dwarnings
 
     - name: Build glutin
       shell: bash
@@ -103,7 +111,6 @@ jobs:
       shell: bash
       if: (!contains(matrix.platform.target, 'ios') && !contains(matrix.platform.target, 'wasm32'))
       run: cd glutin && cargo $WEB test --verbose --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES
-
 
     - name: Build with serde enabled
       shell: bash

--- a/glutin/src/api/dlloader.rs
+++ b/glutin/src/api/dlloader.rs
@@ -42,11 +42,8 @@ impl<T: SymTrait> SymWrapper<T> {
             #[cfg(not(target_os = "windows"))]
             let lib = unsafe { Library::new(path) };
 
-            if lib.is_ok() {
-                return Ok(SymWrapper {
-                    inner: T::load_with(lib.as_ref().unwrap()),
-                    _lib: Arc::new(lib.unwrap()),
-                });
+            if let Ok(lib) = lib {
+                return Ok(SymWrapper { inner: T::load_with(&lib), _lib: Arc::new(lib) });
             }
         }
 

--- a/glutin/src/api/egl/make_current_guard.rs
+++ b/glutin/src/api/egl/make_current_guard.rs
@@ -9,7 +9,7 @@ pub struct MakeCurrentGuard {
     possibly_invalid: Option<MakeCurrentGuardInner>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 struct MakeCurrentGuardInner {
     old_draw_surface: ffi::egl::types::EGLSurface,
     old_read_surface: ffi::egl::types::EGLSurface,

--- a/glutin/src/api/egl/mod.rs
+++ b/glutin/src/api/egl/mod.rs
@@ -235,7 +235,7 @@ fn get_native_display(native_display: &NativeDisplay) -> *const raw::c_void {
             vec![]
         } else {
             let p = CStr::from_ptr(p);
-            let list = String::from_utf8(p.to_bytes().to_vec()).unwrap_or_else(|_| String::new());
+            let list = String::from_utf8(p.to_bytes().to_vec()).unwrap_or_default();
             list.split(' ').map(|e| e.to_string()).collect::<Vec<_>>()
         }
     };
@@ -397,7 +397,7 @@ impl Context {
         let extensions = if egl_version >= (1, 2) {
             let p =
                 unsafe { CStr::from_ptr(egl.QueryString(display, ffi::egl::EXTENSIONS as i32)) };
-            let list = String::from_utf8(p.to_bytes().to_vec()).unwrap_or_else(|_| String::new());
+            let list = String::from_utf8(p.to_bytes().to_vec()).unwrap_or_default();
             list.split(' ').map(|e| e.to_string()).collect::<Vec<_>>()
         } else {
             vec![]

--- a/glutin/src/api/egl/mod.rs
+++ b/glutin/src/api/egl/mod.rs
@@ -7,101 +7,18 @@
     target_os = "netbsd",
     target_os = "openbsd",
 ))]
-#![allow(unused_variables)]
 
-mod egl {
-    use super::ffi;
-    use crate::api::dlloader::{SymTrait, SymWrapper};
-    use libloading;
-    use std::sync::{Arc, Mutex};
-
-    #[cfg(unix)]
-    use libloading::os::unix as libloading_os;
-    #[cfg(windows)]
-    use libloading::os::windows as libloading_os;
-
-    #[derive(Clone)]
-    pub struct Egl(pub SymWrapper<ffi::egl::Egl>);
-
-    /// Because `*const raw::c_void` doesn't implement `Sync`.
-    unsafe impl Sync for Egl {}
-
-    type EglGetProcAddressType = libloading_os::Symbol<
-        unsafe extern "C" fn(*const std::os::raw::c_void) -> *const std::os::raw::c_void,
-    >;
-
-    lazy_static! {
-        static ref EGL_GET_PROC_ADDRESS: Arc<Mutex<Option<EglGetProcAddressType>>> =
-            Arc::new(Mutex::new(None));
-    }
-
-    impl SymTrait for ffi::egl::Egl {
-        fn load_with(lib: &libloading::Library) -> Self {
-            let f = move |s: &'static str| -> *const std::os::raw::c_void {
-                // Check if the symbol is available in the library directly. If
-                // it is, just return it.
-                match unsafe {
-                    lib.get(std::ffi::CString::new(s.as_bytes()).unwrap().as_bytes_with_nul())
-                } {
-                    Ok(sym) => return *sym,
-                    Err(_) => (),
-                };
-
-                let mut egl_get_proc_address = (*EGL_GET_PROC_ADDRESS).lock().unwrap();
-                if egl_get_proc_address.is_none() {
-                    unsafe {
-                        let sym: libloading::Symbol<
-                            unsafe extern "C" fn(
-                                *const std::os::raw::c_void,
-                            )
-                                -> *const std::os::raw::c_void,
-                        > = lib.get(b"eglGetProcAddress").unwrap();
-                        *egl_get_proc_address = Some(sym.into_raw());
-                    }
-                }
-
-                // The symbol was not available in the library, so ask
-                // eglGetProcAddress for it. Note that eglGetProcAddress was
-                // only able to look up extension functions prior to EGL 1.5,
-                // hence this two-part dance.
-                unsafe {
-                    (egl_get_proc_address.as_ref().unwrap())(
-                        std::ffi::CString::new(s.as_bytes()).unwrap().as_bytes_with_nul().as_ptr()
-                            as *const std::os::raw::c_void,
-                    )
-                }
-            };
-
-            Self::load_with(f)
-        }
-    }
-
-    impl Egl {
-        pub fn new() -> Result<Self, ()> {
-            #[cfg(target_os = "windows")]
-            let paths = vec!["libEGL.dll", "atioglxx.dll"];
-
-            #[cfg(not(target_os = "windows"))]
-            let paths = vec!["libEGL.so.1", "libEGL.so"];
-
-            SymWrapper::new(paths).map(Egl)
-        }
-    }
-}
-
-mod make_current_guard;
-
-pub use self::egl::Egl;
-use self::make_current_guard::MakeCurrentGuard;
-#[cfg(not(target_os = "windows"))]
-use crate::Rect;
-use crate::{
-    Api, ContextError, CreationError, GlAttributes, GlRequest, PixelFormat,
-    PixelFormatRequirements, ReleaseBehavior, Robustness,
-};
+use std::ffi::{CStr, CString};
+use std::ops::{Deref, DerefMut};
+use std::os::raw;
+use std::sync::{Arc, Mutex};
 
 use glutin_egl_sys as ffi;
-use parking_lot::Mutex;
+use libloading;
+#[cfg(unix)]
+use libloading::os::unix as libloading_os;
+#[cfg(windows)]
+use libloading::os::windows as libloading_os;
 #[cfg(any(
     target_os = "android",
     target_os = "windows",
@@ -113,9 +30,83 @@ use parking_lot::Mutex;
 ))]
 use winit::dpi;
 
-use std::ffi::{CStr, CString};
-use std::ops::{Deref, DerefMut};
-use std::os::raw;
+use self::make_current_guard::MakeCurrentGuard;
+use crate::api::dlloader::{SymTrait, SymWrapper};
+#[cfg(not(target_os = "windows"))]
+use crate::Rect;
+use crate::{
+    Api, ContextError, CreationError, GlAttributes, GlRequest, PixelFormat,
+    PixelFormatRequirements, ReleaseBehavior, Robustness,
+};
+
+#[derive(Clone)]
+pub struct Egl(pub SymWrapper<ffi::egl::Egl>);
+
+/// Because `*const raw::c_void` doesn't implement `Sync`.
+unsafe impl Sync for Egl {}
+
+type EglGetProcAddressType = libloading_os::Symbol<
+    unsafe extern "C" fn(*const std::os::raw::c_void) -> *const std::os::raw::c_void,
+>;
+
+lazy_static! {
+    static ref EGL_GET_PROC_ADDRESS: Arc<Mutex<Option<EglGetProcAddressType>>> =
+        Arc::new(Mutex::new(None));
+}
+
+impl SymTrait for ffi::egl::Egl {
+    fn load_with(lib: &libloading::Library) -> Self {
+        let f = move |s: &'static str| -> *const std::os::raw::c_void {
+            // Check if the symbol is available in the library directly. If
+            // it is, just return it.
+            if let Ok(sym) = unsafe {
+                lib.get(std::ffi::CString::new(s.as_bytes()).unwrap().as_bytes_with_nul())
+            } {
+                return *sym;
+            }
+
+            let mut egl_get_proc_address = (*EGL_GET_PROC_ADDRESS).lock().unwrap();
+            if egl_get_proc_address.is_none() {
+                unsafe {
+                    let sym: libloading::Symbol<
+                        unsafe extern "C" fn(
+                            *const std::os::raw::c_void,
+                        )
+                            -> *const std::os::raw::c_void,
+                    > = lib.get(b"eglGetProcAddress").unwrap();
+                    *egl_get_proc_address = Some(sym.into_raw());
+                }
+            }
+
+            // The symbol was not available in the library, so ask
+            // eglGetProcAddress for it. Note that eglGetProcAddress was
+            // only able to look up extension functions prior to EGL 1.5,
+            // hence this two-part dance.
+            unsafe {
+                (egl_get_proc_address.as_ref().unwrap())(
+                    std::ffi::CString::new(s.as_bytes()).unwrap().as_bytes_with_nul().as_ptr()
+                        as *const std::os::raw::c_void,
+                )
+            }
+        };
+
+        Self::load_with(f)
+    }
+}
+
+impl Egl {
+    pub fn new() -> Result<Self, ()> {
+        #[cfg(target_os = "windows")]
+        let paths = vec!["libEGL.dll", "atioglxx.dll"];
+
+        #[cfg(not(target_os = "windows"))]
+        let paths = vec!["libEGL.so.1", "libEGL.so"];
+
+        SymWrapper::new(paths).map(Egl)
+    }
+}
+
+mod make_current_guard;
 
 impl Deref for Egl {
     type Target = ffi::egl::Egl;
@@ -158,7 +149,7 @@ pub enum NativeDisplay {
 pub struct Context {
     display: ffi::egl::types::EGLDisplay,
     context: ffi::egl::types::EGLContext,
-    surface: Option<Mutex<ffi::egl::types::EGLSurface>>,
+    surface: Option<parking_lot::Mutex<ffi::egl::types::EGLSurface>>,
     api: Api,
     pixel_format: PixelFormat,
 }
@@ -249,7 +240,7 @@ fn get_native_display(native_display: &NativeDisplay) -> *const raw::c_void {
         }
     };
 
-    let has_dp_extension = |e: &str| dp_extensions.iter().any(|s| &s == &e);
+    let has_dp_extension = |e: &str| dp_extensions.iter().any(|s| s == e);
 
     match *native_display {
         // Note: Some EGL implementations are missing the
@@ -364,7 +355,7 @@ fn get_native_display(native_display: &NativeDisplay) -> *const raw::c_void {
 }
 
 #[allow(dead_code)] // Not all platforms use all
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SurfaceType {
     PBuffer,
     Window,
@@ -376,8 +367,8 @@ impl Context {
     ///
     /// This function initializes some things and chooses the pixel format.
     ///
-    /// To finish the process, you must call `.finish(window)` on the
-    /// `ContextPrototype`.
+    /// To finish the process, you must call [`ContextPrototype::finish()`].
+    #[allow(clippy::new_ret_no_self)]
     pub fn new<'a, F>(
         pf_reqs: &PixelFormatRequirements,
         opengl: &'a GlAttributes<&'a Context>,
@@ -635,7 +626,7 @@ impl Drop for Context {
             guard.if_any_same_then_invalidate(surface, surface, self.context);
 
             let gl_finish_fn = self.get_proc_address("glFinish");
-            assert!(gl_finish_fn != std::ptr::null());
+            assert!(!gl_finish_fn.is_null());
             let gl_finish_fn = std::mem::transmute::<_, extern "system" fn()>(gl_finish_fn);
             gl_finish_fn();
 
@@ -783,7 +774,7 @@ impl<'a> ContextPrototype<'a> {
     pub fn finish_surfaceless(self) -> Result<Context, CreationError> {
         // FIXME: Also check for the GL_OES_surfaceless_context *CONTEXT*
         // extension
-        if !self.extensions.iter().any(|s| &s == &"EGL_KHR_surfaceless_context") {
+        if !self.extensions.iter().any(|s| s == "EGL_KHR_surfaceless_context") {
             Err(CreationError::NotSupported("EGL surfaceless not supported".to_string()))
         } else {
             self.finish_impl(None)
@@ -803,11 +794,6 @@ impl<'a> ContextPrototype<'a> {
         let size: (u32, u32) = size.into();
 
         let egl = EGL.as_ref().unwrap();
-        let tex_fmt = if self.pixel_format.alpha_bits > 0 {
-            ffi::egl::TEXTURE_RGBA
-        } else {
-            ffi::egl::TEXTURE_RGB
-        };
         let attrs = &[
             ffi::egl::WIDTH as raw::c_int,
             size.0 as raw::c_int,
@@ -936,7 +922,7 @@ impl<'a> ContextPrototype<'a> {
         Ok(Context {
             display: self.display,
             context,
-            surface: surface.map(Mutex::new),
+            surface: surface.map(parking_lot::Mutex::new),
             api: self.api,
             pixel_format: self.pixel_format,
         })
@@ -1113,7 +1099,7 @@ where
         .into_iter()
         .filter(|&config| {
             let mut min_swap_interval = 0;
-            let res = egl.GetConfigAttrib(
+            let _res = egl.GetConfigAttrib(
                 display,
                 config,
                 ffi::egl::MIN_SWAP_INTERVAL as ffi::egl::types::EGLint,
@@ -1125,7 +1111,7 @@ where
             }
 
             let mut max_swap_interval = 0;
-            let res = egl.GetConfigAttrib(
+            let _res = egl.GetConfigAttrib(
                 display,
                 config,
                 ffi::egl::MAX_SWAP_INTERVAL as ffi::egl::types::EGLint,
@@ -1201,7 +1187,7 @@ unsafe fn create_context(
     let mut context_attributes = Vec::with_capacity(10);
     let mut flags = 0;
 
-    if egl_version >= &(1, 5) || extensions.iter().any(|s| &s == &"EGL_KHR_create_context") {
+    if egl_version >= &(1, 5) || extensions.iter().any(|s| s == "EGL_KHR_create_context") {
         context_attributes.push(ffi::egl::CONTEXT_MAJOR_VERSION as i32);
         context_attributes.push(version.0 as i32);
         context_attributes.push(ffi::egl::CONTEXT_MINOR_VERSION as i32);
@@ -1209,13 +1195,13 @@ unsafe fn create_context(
 
         // handling robustness
         let supports_robustness = egl_version >= &(1, 5)
-            || extensions.iter().any(|s| &s == &"EGL_EXT_create_context_robustness");
+            || extensions.iter().any(|s| s == "EGL_EXT_create_context_robustness");
 
         match gl_robustness {
             Robustness::NotRobust => (),
 
             Robustness::NoError => {
-                if extensions.iter().any(|s| &s == &"EGL_KHR_create_context_no_error") {
+                if extensions.iter().any(|s| s == "EGL_KHR_create_context_no_error") {
                     context_attributes.push(ffi::egl::CONTEXT_OPENGL_NO_ERROR_KHR as raw::c_int);
                     context_attributes.push(1);
                 }
@@ -1265,6 +1251,13 @@ unsafe fn create_context(
         if gl_debug && egl_version >= &(1, 5) {
             context_attributes.push(ffi::egl::CONTEXT_OPENGL_DEBUG as i32);
             context_attributes.push(ffi::egl::TRUE as i32);
+
+            // TODO: using this flag sometimes generates an error
+            //       there was a change in the specs that added this flag, so it
+            // may not be       supported everywhere ; however it is
+            // not possible to know whether it is       supported or
+            // not flags = flags |
+            // ffi::egl::CONTEXT_OPENGL_DEBUG_BIT_KHR as i32;
         }
 
         // In at least some configurations, the Android emulator’s GL

--- a/glutin/src/api/glx/make_current_guard.rs
+++ b/glutin/src/api/glx/make_current_guard.rs
@@ -66,10 +66,7 @@ impl Drop for MakeCurrentGuard {
             None => (0, std::ptr::null()),
         };
 
-        let display = match self.old_display {
-            old_display if old_display == std::ptr::null_mut() => self.display,
-            old_display => old_display,
-        };
+        let display = if self.old_display.is_null() { self.display } else { self.old_display };
 
         let res = unsafe { glx.MakeCurrent(display as *mut _, drawable, context) };
 

--- a/glutin/src/api/ios/mod.rs
+++ b/glutin/src/api/ios/mod.rs
@@ -155,7 +155,7 @@ pub struct Context {
 
 fn validate_version(version: u8) -> Result<ffi::NSUInteger, CreationError> {
     let version = version as ffi::NSUInteger;
-    if version >= ffi::kEAGLRenderingAPIOpenGLES1 && version <= ffi::kEAGLRenderingAPIOpenGLES3 {
+    if (ffi::kEAGLRenderingAPIOpenGLES1..=ffi::kEAGLRenderingAPIOpenGLES3).contains(&version) {
         Ok(version)
     } else {
         Err(CreationError::OsError(format!(
@@ -384,13 +384,13 @@ impl Context {
     pub fn get_proc_address(&self, proc_name: &str) -> *const core::ffi::c_void {
         let proc_name_c = CString::new(proc_name).expect("proc name contained interior nul byte");
         let path = b"/System/Library/Frameworks/OpenGLES.framework/OpenGLES\0";
-        let addr = unsafe {
+
+        // debug!("proc {} -> {:?}", proc_name, addr);
+        unsafe {
             let lib =
                 ffi::dlopen(path.as_ptr() as *const raw::c_char, ffi::RTLD_LAZY | ffi::RTLD_GLOBAL);
             ffi::dlsym(lib, proc_name_c.as_ptr()) as *const _
-        };
-        // debug!("proc {} -> {:?}", proc_name, addr);
-        addr
+        }
     }
 
     #[inline]

--- a/glutin/src/api/ios/mod.rs
+++ b/glutin/src/api/ios/mod.rs
@@ -385,7 +385,6 @@ impl Context {
         let proc_name_c = CString::new(proc_name).expect("proc name contained interior nul byte");
         let path = b"/System/Library/Frameworks/OpenGLES.framework/OpenGLES\0";
 
-        // debug!("proc {} -> {:?}", proc_name, addr);
         unsafe {
             let lib =
                 ffi::dlopen(path.as_ptr() as *const raw::c_char, ffi::RTLD_LAZY | ffi::RTLD_GLOBAL);

--- a/glutin/src/api/osmesa/mod.rs
+++ b/glutin/src/api/osmesa/mod.rs
@@ -80,7 +80,7 @@ impl OsMesaContext {
 
         match opengl.robustness {
             Robustness::RobustNoResetNotification | Robustness::RobustLoseContextOnReset => {
-                return Err(CreationError::RobustnessNotSupported.into());
+                return Err(CreationError::RobustnessNotSupported);
             }
             _ => (),
         }

--- a/glutin/src/lib.rs
+++ b/glutin/src/lib.rs
@@ -67,6 +67,7 @@
 )]
 #![deny(missing_debug_implementations)]
 #![allow(clippy::missing_safety_doc, clippy::too_many_arguments)]
+#![cfg_attr(feature = "cargo-clippy", deny(warnings))]
 
 #[cfg(any(
     target_os = "windows",

--- a/glutin/src/lib.rs
+++ b/glutin/src/lib.rs
@@ -65,10 +65,8 @@
 [`RawContextExt`]: os/unix/trait.RawContextExt.html
 "
 )]
-#![deny(
-    missing_debug_implementations,
-    //missing_docs,
-)]
+#![deny(missing_debug_implementations)]
+#![allow(clippy::missing_safety_doc, clippy::too_many_arguments)]
 
 #[cfg(any(
     target_os = "windows",
@@ -117,13 +115,16 @@ pub struct ContextBuilder<'a, T: ContextCurrentState> {
     pub pf_reqs: PixelFormatRequirements,
 }
 
+impl Default for ContextBuilder<'_, NotCurrent> {
+    fn default() -> Self {
+        Self { gl_attr: Default::default(), pf_reqs: Default::default() }
+    }
+}
+
 impl<'a> ContextBuilder<'a, NotCurrent> {
     /// Initializes a new `ContextBuilder` with default values.
     pub fn new() -> Self {
-        ContextBuilder {
-            pf_reqs: std::default::Default::default(),
-            gl_attr: std::default::Default::default(),
-        }
+        Default::default()
     }
 }
 
@@ -440,10 +441,10 @@ pub enum GlRequest {
 
 impl GlRequest {
     /// Extract the desktop GL version, if any.
-    pub fn to_gl_version(&self) -> Option<(u8, u8)> {
+    pub fn to_gl_version(self) -> Option<(u8, u8)> {
         match self {
-            &GlRequest::Specific(Api::OpenGl, opengl_version) => Some(opengl_version),
-            &GlRequest::GlThenGles { opengl_version, .. } => Some(opengl_version),
+            GlRequest::Specific(Api::OpenGl, opengl_version) => Some(opengl_version),
+            GlRequest::GlThenGles { opengl_version, .. } => Some(opengl_version),
             _ => None,
         }
     }
@@ -584,8 +585,9 @@ pub struct PixelFormatRequirements {
     /// The behavior when changing the current context. Default is `Flush`.
     pub release_behavior: ReleaseBehavior,
 
-    /// X11 only: set internally to insure a certain visual xid is used when
+    /// X11 only: set internally to ensure a certain visual xid is used when
     /// choosing the fbconfig.
+    #[allow(dead_code)]
     pub(crate) x11_visual_xid: Option<std::os::raw::c_ulong>,
 }
 

--- a/glutin/src/platform_impl/android/mod.rs
+++ b/glutin/src/platform_impl/android/mod.rs
@@ -48,7 +48,7 @@ impl Context {
             .and_then(|p| p.finish(nwin))?;
         let ctx = Arc::new(AndroidContext { egl_context, stopped: Some(Mutex::new(false)) });
 
-        let context = Context(ctx.clone());
+        let context = Context(ctx);
 
         Ok((win, context))
     }

--- a/glutin/src/platform_impl/macos/helpers.rs
+++ b/glutin/src/platform_impl/macos/helpers.rs
@@ -1,3 +1,5 @@
+use std::cmp::Ordering;
+
 use crate::{
     CreationError, GlAttributes, GlProfile, GlRequest, PixelFormatRequirements, ReleaseBehavior,
 };
@@ -21,16 +23,16 @@ pub fn get_gl_profile<T>(
         }
     } else if let Some(v) = version {
         // second, process exact requested version, if any
-        if v < (3, 2) {
-            if opengl.profile.is_none() && v <= (2, 1) {
-                Ok(NSOpenGLProfileVersionLegacy)
-            } else {
-                Err(CreationError::OpenGlVersionNotSupported)
+        match v.cmp(&(3, 2)) {
+            Ordering::Less => {
+                if opengl.profile.is_none() && v <= (2, 1) {
+                    Ok(NSOpenGLProfileVersionLegacy)
+                } else {
+                    Err(CreationError::OpenGlVersionNotSupported)
+                }
             }
-        } else if v == (3, 2) {
-            Ok(NSOpenGLProfileVersion3_2Core)
-        } else {
-            Ok(NSOpenGLProfileVersion4_1Core)
+            Ordering::Equal => Ok(NSOpenGLProfileVersion3_2Core),
+            Ordering::Greater => Ok(NSOpenGLProfileVersion4_1Core),
         }
     } else if let GlRequest::Latest = opengl.version {
         // now, find the latest supported version automatically;

--- a/glutin/src/platform_impl/macos/mod.rs
+++ b/glutin/src/platform_impl/macos/mod.rs
@@ -126,11 +126,11 @@ impl Context {
             );
 
             if transparent {
-                let mut opacity = 0;
+                let opacity = 0;
                 CGLSetParameter(
                     gl_context.CGLContextObj() as *mut _,
                     kCGLCPSurfaceOpacity,
-                    &mut opacity,
+                    &opacity,
                 );
             }
 
@@ -339,7 +339,7 @@ impl Drop for IdRef {
 
 impl Deref for IdRef {
     type Target = id;
-    fn deref<'a>(&'a self) -> &'a id {
+    fn deref(&self) -> &id {
         &self.0
     }
 }

--- a/glutin/src/platform_impl/macos/mod.rs
+++ b/glutin/src/platform_impl/macos/mod.rs
@@ -14,7 +14,7 @@ use core_foundation::string::CFString;
 use objc::runtime::{BOOL, NO};
 
 use crate::platform::macos::WindowExtMacOS;
-use winit;
+
 use winit::dpi;
 use winit::event_loop::EventLoopWindowTarget;
 use winit::window::{Window, WindowBuilder};

--- a/glutin/src/platform_impl/mod.rs
+++ b/glutin/src/platform_impl/mod.rs
@@ -1,8 +1,8 @@
-pub use self::platform_impl::*;
+pub use self::platform::*;
 
 #[cfg(target_os = "windows")]
 #[path = "windows/mod.rs"]
-mod platform_impl;
+mod platform;
 #[cfg(any(
     target_os = "linux",
     target_os = "dragonfly",
@@ -11,13 +11,13 @@ mod platform_impl;
     target_os = "openbsd",
 ))]
 #[path = "unix/mod.rs"]
-mod platform_impl;
+mod platform;
 #[cfg(target_os = "macos")]
 #[path = "macos/mod.rs"]
-mod platform_impl;
+mod platform;
 #[cfg(target_os = "android")]
 #[path = "android/mod.rs"]
-mod platform_impl;
+mod platform;
 #[cfg(target_os = "ios")]
 #[path = "ios/mod.rs"]
-mod platform_impl;
+mod platform;

--- a/glutin/src/platform_impl/unix/mod.rs
+++ b/glutin/src/platform_impl/unix/mod.rs
@@ -70,7 +70,7 @@ impl Context {
                     Context::OsMesa(_) => Ok(()),
                     _ => {
                         let msg = "Cannot share an OSMesa context with a non-OSMesa context";
-                        return Err(CreationError::PlatformSpecific(msg.into()));
+                        Err(CreationError::PlatformSpecific(msg.into()))
                     }
                 },
                 #[cfg(feature = "x11")]
@@ -78,7 +78,7 @@ impl Context {
                     Context::X11(_) => Ok(()),
                     _ => {
                         let msg = "Cannot share an X11 context with a non-X11 context";
-                        return Err(CreationError::PlatformSpecific(msg.into()));
+                        Err(CreationError::PlatformSpecific(msg.into()))
                     }
                 },
                 #[cfg(feature = "wayland")]
@@ -86,7 +86,7 @@ impl Context {
                     Context::Wayland(_) => Ok(()),
                     _ => {
                         let msg = "Cannot share a Wayland context with a non-Wayland context";
-                        return Err(CreationError::PlatformSpecific(msg.into()));
+                        Err(CreationError::PlatformSpecific(msg.into()))
                     }
                 },
             }
@@ -149,8 +149,8 @@ impl Context {
                 Context::Wayland(ref ctx) => ctx,
                 _ => unreachable!(),
             });
-            return wayland::Context::new_headless(&el, pf_reqs, &gl_attr, size)
-                .map(|ctx| Context::Wayland(ctx));
+            return wayland::Context::new_headless(el, pf_reqs, &gl_attr, size)
+                .map(Context::Wayland);
         }
         #[cfg(feature = "x11")]
         if el.is_x11() {
@@ -159,8 +159,7 @@ impl Context {
                 Context::X11(ref ctx) => ctx,
                 _ => unreachable!(),
             });
-            return x11::Context::new_headless(&el, pf_reqs, &gl_attr, size)
-                .map(|ctx| Context::X11(ctx));
+            return x11::Context::new_headless(el, pf_reqs, &gl_attr, size).map(Context::X11);
         }
         panic!("glutin was not compiled with support for this display server")
     }
@@ -364,7 +363,7 @@ impl<'a, T: ContextCurrentState> HeadlessContextExt for crate::ContextBuilder<'a
             _ => unreachable!(),
         });
         osmesa::OsMesaContext::new(&pf_reqs, &gl_attr, size)
-            .map(|context| Context::OsMesa(context))
+            .map(Context::OsMesa)
             .map(|context| crate::Context { context, phantom: PhantomData })
     }
 
@@ -441,7 +440,7 @@ impl<'a, T: ContextCurrentState> RawContextExt for crate::ContextBuilder<'a, T> 
             _ => unreachable!(),
         });
         wayland::Context::new_raw_context(display_ptr, surface, width, height, &pf_reqs, &gl_attr)
-            .map(|context| Context::Wayland(context))
+            .map(Context::Wayland)
             .map(|context| crate::Context { context, phantom: PhantomData })
             .map(|context| crate::RawContext { context, window: () })
     }
@@ -464,7 +463,7 @@ impl<'a, T: ContextCurrentState> RawContextExt for crate::ContextBuilder<'a, T> 
             _ => unreachable!(),
         });
         x11::Context::new_raw_context(xconn, xwin, &pf_reqs, &gl_attr)
-            .map(|context| Context::X11(context))
+            .map(Context::X11)
             .map(|context| crate::Context { context, phantom: PhantomData })
             .map(|context| crate::RawContext { context, window: () })
     }

--- a/glutin/src/platform_impl/unix/wayland.rs
+++ b/glutin/src/platform_impl/unix/wayland.rs
@@ -8,7 +8,7 @@ use crate::{
 use crate::platform::unix::{EventLoopWindowTargetExtUnix, WindowExtUnix};
 use glutin_egl_sys as ffi;
 pub use wayland_client::sys::client::wl_display;
-use winit;
+
 use winit::dpi;
 use winit::event_loop::EventLoopWindowTarget;
 use winit::window::{Window, WindowBuilder};
@@ -190,6 +190,6 @@ impl Context {
 
     #[inline]
     pub fn get_pixel_format(&self) -> PixelFormat {
-        (**self).get_pixel_format().clone()
+        (**self).get_pixel_format()
     }
 }

--- a/glutin/src/platform_impl/unix/x11.rs
+++ b/glutin/src/platform_impl/unix/x11.rs
@@ -134,10 +134,10 @@ where
 
             // Stick with the earlier.
             (Some(Err(Lacks::Transparency)), Err(Lacks::Transparency)) => (),
-            (Some(Err(_)), Err(Lacks::XID)) => (),
+            (Some(Err(_)), Err(Lacks::Xid)) => (),
 
             // Lacking transparency is better than lacking the xid.
-            (Some(Err(Lacks::XID)), Err(Lacks::Transparency)) => {
+            (Some(Err(Lacks::Xid)), Err(Lacks::Transparency)) => {
                 chosen_config_id = Some((config_id, visual_infos));
                 lacks_what = Some(this_lacks_what);
             }
@@ -149,7 +149,7 @@ where
         Some(Err(Lacks::Transparency)) => log::warn!(
             "Glutin could not a find fb config with an alpha mask. Transparency may be broken."
         ),
-        Some(Err(Lacks::XID)) => panic!(),
+        Some(Err(Lacks::Xid)) => panic!(),
         None => unreachable!(),
     }
 
@@ -375,14 +375,14 @@ impl Context {
                     // If the preferred choice works, don't spend time testing
                     // if the other works.
                     if prefer_egl {
-                        if let Some(_) = &*EGL {
+                        if EGL.is_some() {
                             return egl(builder_egl_u);
-                        } else if let Some(_) = &*GLX {
+                        } else if GLX.is_some() {
                             return glx(builder_glx_u);
                         }
-                    } else if let Some(_) = &*GLX {
+                    } else if GLX.is_some() {
                         return glx(builder_glx_u);
-                    } else if let Some(_) = &*EGL {
+                    } else if EGL.is_some() {
                         return egl(builder_egl_u);
                     }
 
@@ -391,10 +391,10 @@ impl Context {
                     ));
                 } else {
                     if prefer_egl {
-                        if let Some(_) = &*EGL {
+                        if EGL.is_some() {
                             return egl(builder_egl_u);
                         }
-                    } else if let Some(_) = &*GLX {
+                    } else if GLX.is_some() {
                         return glx(builder_glx_u);
                     }
 
@@ -404,7 +404,7 @@ impl Context {
                 }
             }
             GlRequest::Specific(Api::OpenGlEs, _) => {
-                if let Some(_) = *EGL {
+                if EGL.is_some() {
                     let builder = gl_attr.clone();
                     *builder_egl_u = Some(builder.map_sharing(|c| match c.context {
                         X11Context::Egl(ref c) => c,

--- a/glutin/src/platform_impl/unix/x11/utils.rs
+++ b/glutin/src/platform_impl/unix/x11/utils.rs
@@ -31,7 +31,7 @@ pub fn get_visual_info_from_xid(xconn: &Arc<XConnection>, xid: ffi::VisualID) ->
 #[derive(Clone, Copy, Debug)]
 pub enum Lacks {
     Transparency,
-    XID,
+    Xid,
 }
 
 /// Should always check for lack of xid before lack of transparency.
@@ -43,7 +43,7 @@ pub fn examine_visual_info(
 ) -> Result<(), Lacks> {
     if let Some(want_xid) = want_xid {
         if visual_infos.visualid != want_xid {
-            return Err(Lacks::XID);
+            return Err(Lacks::Xid);
         }
     }
 

--- a/glutin/src/platform_impl/unix/x11/utils.rs
+++ b/glutin/src/platform_impl/unix/x11/utils.rs
@@ -63,7 +63,7 @@ pub fn examine_visual_info(
         }
     }
 
-    return Ok(());
+    Ok(())
 }
 
 pub use super::select_config;

--- a/glutin_egl_sys/src/lib.rs
+++ b/glutin_egl_sys/src/lib.rs
@@ -7,7 +7,12 @@
     target_os = "netbsd",
     target_os = "openbsd"
 ))]
-#![allow(non_camel_case_types)]
+#![allow(
+    clippy::manual_non_exhaustive,
+    clippy::missing_safety_doc,
+    clippy::unnecessary_cast,
+    non_camel_case_types
+)]
 
 pub mod egl {
     pub type khronos_utime_nanoseconds_t = super::khronos_utime_nanoseconds_t;

--- a/glutin_egl_sys/src/lib.rs
+++ b/glutin_egl_sys/src/lib.rs
@@ -13,6 +13,7 @@
     clippy::unnecessary_cast,
     non_camel_case_types
 )]
+#![cfg_attr(feature = "cargo-clippy", deny(warnings))]
 
 pub mod egl {
     pub type khronos_utime_nanoseconds_t = super::khronos_utime_nanoseconds_t;

--- a/glutin_examples/examples/buffer_age.rs
+++ b/glutin_examples/examples/buffer_age.rs
@@ -15,14 +15,14 @@ fn main() {
 
     println!("Pixel format of the window's GL context: {:?}", windowed_context.get_pixel_format());
 
-    let gl = support::load(&windowed_context.context());
+    let gl = support::load(windowed_context.context());
 
     el.run(move |event, _, control_flow| {
         println!("{:?}", event);
         *control_flow = ControlFlow::Wait;
 
         match event {
-            Event::LoopDestroyed => return,
+            Event::LoopDestroyed => (),
             Event::WindowEvent { event, .. } => match event {
                 WindowEvent::Resized(physical_size) => windowed_context.resize(physical_size),
                 WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,

--- a/glutin_examples/examples/damage.rs
+++ b/glutin_examples/examples/damage.rs
@@ -39,7 +39,7 @@ fn main() {
 
     println!("Pixel format of the window's GL context: {:?}", windowed_context.get_pixel_format());
 
-    let gl = support::load(&windowed_context.context());
+    let gl = support::load(windowed_context.context());
 
     let mut color = Color::new();
 
@@ -51,7 +51,7 @@ fn main() {
         *control_flow = ControlFlow::Wait;
 
         match event {
-            Event::LoopDestroyed => return,
+            Event::LoopDestroyed => (),
             Event::WindowEvent { event, .. } => match event {
                 WindowEvent::Resized(physical_size) => windowed_context.resize(physical_size),
                 WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,

--- a/glutin_examples/examples/fullscreen.rs
+++ b/glutin_examples/examples/fullscreen.rs
@@ -14,7 +14,7 @@ fn main() {
 
     let mut num = String::new();
     stdin().read_line(&mut num).unwrap();
-    let num = num.trim().parse().ok().expect("Please enter a number");
+    let num = num.trim().parse().expect("Please enter a number");
 
     let fullscreen = Some(match num {
         1 => Fullscreen::Exclusive(prompt_for_video_mode(&prompt_for_monitor(&el))),
@@ -90,7 +90,7 @@ fn prompt_for_monitor(el: &EventLoop<()>) -> MonitorHandle {
 
     let mut num = String::new();
     stdin().read_line(&mut num).unwrap();
-    let num = num.trim().parse().ok().expect("Please enter a number");
+    let num = num.trim().parse().expect("Please enter a number");
     let monitor = el.available_monitors().nth(num).expect("Please enter a valid ID");
 
     println!("Using {:?}", monitor.name());
@@ -108,7 +108,7 @@ fn prompt_for_video_mode(monitor: &MonitorHandle) -> VideoMode {
 
     let mut num = String::new();
     stdin().read_line(&mut num).unwrap();
-    let num = num.trim().parse().ok().expect("Please enter a number");
+    let num = num.trim().parse().expect("Please enter a number");
     let video_mode = monitor.video_modes().nth(num).expect("Please enter a valid ID");
 
     println!("Using {}", video_mode);

--- a/glutin_examples/examples/fullscreen.rs
+++ b/glutin_examples/examples/fullscreen.rs
@@ -32,7 +32,7 @@ fn main() {
 
     let windowed_context = unsafe { windowed_context.make_current().unwrap() };
 
-    let gl = support::load(&windowed_context.context());
+    let gl = support::load(windowed_context.context());
 
     el.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;

--- a/glutin_examples/examples/headless.rs
+++ b/glutin_examples/examples/headless.rs
@@ -14,7 +14,7 @@ fn build_context_surfaceless<T1: ContextCurrentState>(
     el: &EventLoop<()>,
 ) -> Result<Context<NotCurrent>, CreationError> {
     use glutin::platform::unix::HeadlessContextExt;
-    cb.build_surfaceless(&el)
+    cb.build_surfaceless(el)
 }
 
 fn build_context_headless<T1: ContextCurrentState>(
@@ -22,7 +22,7 @@ fn build_context_headless<T1: ContextCurrentState>(
     el: &EventLoop<()>,
 ) -> Result<Context<NotCurrent>, CreationError> {
     let size_one = PhysicalSize::new(1, 1);
-    cb.build_headless(&el, size_one)
+    cb.build_headless(el, size_one)
 }
 
 #[cfg(target_os = "linux")]

--- a/glutin_examples/examples/multiwindow.rs
+++ b/glutin_examples/examples/multiwindow.rs
@@ -16,7 +16,7 @@ fn main() {
         let wb = WindowBuilder::new().with_title(title);
         let windowed_context = ContextBuilder::new().build_windowed(wb, &el).unwrap();
         let windowed_context = unsafe { windowed_context.make_current().unwrap() };
-        let gl = support::load(&windowed_context.context());
+        let gl = support::load(windowed_context.context());
         let window_id = windowed_context.window().id();
         let context_id = ct.insert(ContextCurrentWrapper::PossiblyCurrent(
             ContextWrapper::Windowed(windowed_context),

--- a/glutin_examples/examples/raw_context.rs
+++ b/glutin_examples/examples/raw_context.rs
@@ -112,7 +112,6 @@ File a PR if you are interested in implementing the latter.
             match event {
                 Event::LoopDestroyed => {
                     Takeable::take(&mut raw_context); // Make sure it drops first
-                    return;
                 }
                 Event::WindowEvent { event, .. } => match event {
                     WindowEvent::Resized(physical_size) => raw_context.resize(physical_size),

--- a/glutin_examples/examples/raw_context.rs
+++ b/glutin_examples/examples/raw_context.rs
@@ -25,7 +25,7 @@ mod this_example {
         let mut transparency = String::new();
         std::io::stdin().read_line(&mut transparency).unwrap();
         let transparency = transparency.trim().parse().unwrap_or_else(|_| {
-            println!("Unknown input, assumming true.");
+            println!("Unknown input, assuming true.");
             true
         });
 

--- a/glutin_examples/examples/sharing.rs
+++ b/glutin_examples/examples/sharing.rs
@@ -61,7 +61,6 @@ fn main() {
         glw.gl.BindFramebuffer(gl::DRAW_FRAMEBUFFER, 0);
         glw.gl.Viewport(0, 0, size.width as _, size.height as _);
     }
-    std::mem::drop(windowed_context);
 
     let headless_context = ct.get_current(headless_id).unwrap();
     let glc = support::load(headless_context.headless());
@@ -81,7 +80,6 @@ fn main() {
         );
         glc.gl.Viewport(0, 0, size.width as _, size.height as _);
     }
-    std::mem::drop(headless_context);
 
     el.run(move |event, _, control_flow| {
         println!("{:?}", event);
@@ -89,10 +87,9 @@ fn main() {
 
         match event {
             Event::LoopDestroyed => unsafe {
-                let windowed_context = ct.get_current(windowed_id).unwrap();
+                let _ = ct.get_current(windowed_id).unwrap();
                 glw.gl.DeleteFramebuffers(1, &window_fb);
                 glw.gl.DeleteRenderbuffers(1, &render_buf);
-                std::mem::drop(windowed_context);
                 let _ = ct.get_current(headless_id).unwrap();
                 glc.gl.DeleteFramebuffers(1, &context_fb);
             },
@@ -110,7 +107,6 @@ fn main() {
                             size.height as _,
                         );
                         glw.gl.Viewport(0, 0, size.width as _, size.height as _);
-                        std::mem::drop(windowed_context);
 
                         let _ = ct.get_current(headless_id).unwrap();
                         glc.gl.Viewport(0, 0, size.width as _, size.height as _);
@@ -120,9 +116,8 @@ fn main() {
                 _ => (),
             },
             Event::RedrawRequested(_) => {
-                let headless_context = ct.get_current(headless_id).unwrap();
+                let _ = ct.get_current(headless_id).unwrap();
                 glc.draw_frame([1.0, 0.5, 0.7, 1.0]);
-                std::mem::drop(headless_context);
 
                 let windowed_context = ct.get_current(windowed_id).unwrap();
                 unsafe {

--- a/glutin_examples/examples/sharing.rs
+++ b/glutin_examples/examples/sharing.rs
@@ -41,7 +41,7 @@ fn main() {
         "Pixel format of the window's GL context: {:?}",
         windowed_context.windowed().get_pixel_format()
     );
-    let glw = support::load(&windowed_context.windowed().context());
+    let glw = support::load(windowed_context.windowed().context());
 
     let render_buf = make_renderbuf(&glw, size);
 
@@ -64,7 +64,7 @@ fn main() {
     std::mem::drop(windowed_context);
 
     let headless_context = ct.get_current(headless_id).unwrap();
-    let glc = support::load(&headless_context.headless());
+    let glc = support::load(headless_context.headless());
 
     let mut context_fb = 0;
     unsafe {
@@ -88,17 +88,14 @@ fn main() {
         *control_flow = ControlFlow::Wait;
 
         match event {
-            Event::LoopDestroyed => {
-                unsafe {
-                    let windowed_context = ct.get_current(windowed_id).unwrap();
-                    glw.gl.DeleteFramebuffers(1, &window_fb);
-                    glw.gl.DeleteRenderbuffers(1, &render_buf);
-                    std::mem::drop(windowed_context);
-                    let _ = ct.get_current(headless_id).unwrap();
-                    glc.gl.DeleteFramebuffers(1, &context_fb);
-                }
-                return;
-            }
+            Event::LoopDestroyed => unsafe {
+                let windowed_context = ct.get_current(windowed_id).unwrap();
+                glw.gl.DeleteFramebuffers(1, &window_fb);
+                glw.gl.DeleteRenderbuffers(1, &render_buf);
+                std::mem::drop(windowed_context);
+                let _ = ct.get_current(headless_id).unwrap();
+                glc.gl.DeleteFramebuffers(1, &context_fb);
+            },
             Event::WindowEvent { event, .. } => match event {
                 WindowEvent::Resized(physical_size) => {
                     let windowed_context = ct.get_current(windowed_id).unwrap();

--- a/glutin_examples/examples/support/mod.rs
+++ b/glutin_examples/examples/support/mod.rs
@@ -3,6 +3,14 @@ use glutin::{self, PossiblyCurrent};
 use std::ffi::CStr;
 
 pub mod gl {
+    #![allow(
+        clippy::manual_non_exhaustive,
+        clippy::too_many_arguments,
+        clippy::unused_unit,
+        clippy::upper_case_acronyms,
+        non_camel_case_types
+    )]
+
     pub use self::Gles2 as Gl;
     include!(concat!(env!("OUT_DIR"), "/gl_bindings.rs"));
 }

--- a/glutin_examples/examples/support/mod.rs
+++ b/glutin_examples/examples/support/mod.rs
@@ -94,7 +94,7 @@ static VERTEX_DATA: [f32; 15] = [
      0.5, -0.5,  0.0,  0.0,  1.0,
 ];
 
-const VS_SRC: &'static [u8] = b"
+const VS_SRC: &[u8] = b"
 #version 100
 precision mediump float;
 
@@ -109,7 +109,7 @@ void main() {
 }
 \0";
 
-const FS_SRC: &'static [u8] = b"
+const FS_SRC: &[u8] = b"
 #version 100
 precision mediump float;
 

--- a/glutin_examples/examples/transparent.rs
+++ b/glutin_examples/examples/transparent.rs
@@ -18,14 +18,14 @@ fn main() {
 
     println!("Pixel format of the window's GL context: {:?}", windowed_context.get_pixel_format());
 
-    let gl = support::load(&windowed_context.context());
+    let gl = support::load(windowed_context.context());
 
     el.run(move |event, _, control_flow| {
         println!("{:?}", event);
         *control_flow = ControlFlow::Wait;
 
         match event {
-            Event::LoopDestroyed => return,
+            Event::LoopDestroyed => (),
             Event::WindowEvent { event, .. } => match event {
                 WindowEvent::Resized(physical_size) => windowed_context.resize(physical_size),
                 WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,

--- a/glutin_examples/examples/window.rs
+++ b/glutin_examples/examples/window.rs
@@ -15,14 +15,14 @@ fn main() {
 
     println!("Pixel format of the window's GL context: {:?}", windowed_context.get_pixel_format());
 
-    let gl = support::load(&windowed_context.context());
+    let gl = support::load(windowed_context.context());
 
     el.run(move |event, _, control_flow| {
         println!("{:?}", event);
         *control_flow = ControlFlow::Wait;
 
         match event {
-            Event::LoopDestroyed => return,
+            Event::LoopDestroyed => (),
             Event::WindowEvent { event, .. } => match event {
                 WindowEvent::Resized(physical_size) => windowed_context.resize(physical_size),
                 WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,

--- a/glutin_examples/ios-example/rust/src/lib.rs
+++ b/glutin_examples/ios-example/rust/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(feature = "cargo-clippy", deny(warnings))]
+
 use glutin::event::{Event, WindowEvent};
 use glutin::event_loop::{ControlFlow, EventLoop};
 use glutin::window::WindowBuilder;

--- a/glutin_examples/ios-example/rust/src/lib.rs
+++ b/glutin_examples/ios-example/rust/src/lib.rs
@@ -17,7 +17,7 @@ fn main() {
     let windowed_context = unsafe { windowed_context.make_current().unwrap() };
 
     println!("Pixel format of the window's GL context: {:?}", windowed_context.get_pixel_format());
-    let gl = support::load(&windowed_context.context());
+    let gl = support::load(windowed_context.context());
     let mut inc: f32 = 0.0;
 
     el.run(move |event, _, control_flow| {
@@ -25,7 +25,7 @@ fn main() {
         *control_flow = ControlFlow::Wait;
 
         match event {
-            Event::LoopDestroyed => return,
+            Event::LoopDestroyed => (),
             Event::WindowEvent { event, .. } => match event {
                 WindowEvent::Resized(physical_size) => windowed_context.resize(physical_size),
                 WindowEvent::Touch(_touch) => {

--- a/glutin_gles2_sys/src/lib.rs
+++ b/glutin_gles2_sys/src/lib.rs
@@ -7,6 +7,7 @@
     non_snake_case,
     non_upper_case_globals
 )]
+#![cfg_attr(feature = "cargo-clippy", deny(warnings))]
 
 pub mod gles {
     include!(concat!(env!("OUT_DIR"), "/gles2_bindings.rs"));

--- a/glutin_gles2_sys/src/lib.rs
+++ b/glutin_gles2_sys/src/lib.rs
@@ -1,5 +1,12 @@
 #![cfg(target_os = "ios")]
-#![allow(non_camel_case_types, non_snake_case, non_upper_case_globals)]
+#![allow(
+    clippy::missing_safety_doc,
+    clippy::too_many_arguments,
+    clippy::unused_unit,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals
+)]
 
 pub mod gles {
     include!(concat!(env!("OUT_DIR"), "/gles2_bindings.rs"));

--- a/glutin_glx_sys/src/lib.rs
+++ b/glutin_glx_sys/src/lib.rs
@@ -5,6 +5,12 @@
     target_os = "netbsd",
     target_os = "openbsd"
 ))]
+#![allow(
+    clippy::manual_non_exhaustive,
+    clippy::missing_safety_doc,
+    clippy::redundant_static_lifetimes,
+    clippy::unused_unit
+)]
 
 pub use self::glx::types::GLXContext;
 pub use x11_dl::xlib::*;

--- a/glutin_glx_sys/src/lib.rs
+++ b/glutin_glx_sys/src/lib.rs
@@ -11,6 +11,7 @@
     clippy::redundant_static_lifetimes,
     clippy::unused_unit
 )]
+#![cfg_attr(feature = "cargo-clippy", deny(warnings))]
 
 pub use self::glx::types::GLXContext;
 pub use x11_dl::xlib::*;

--- a/glutin_wgl_sys/src/lib.rs
+++ b/glutin_wgl_sys/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg(any(target_os = "windows"))]
 #![allow(clippy::manual_non_exhaustive, clippy::missing_safety_doc, clippy::too_many_arguments)]
+#![cfg_attr(feature = "cargo-clippy", deny(warnings))]
 
 /// WGL bindings
 pub mod wgl {

--- a/glutin_wgl_sys/src/lib.rs
+++ b/glutin_wgl_sys/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg(any(target_os = "windows"))]
+#![allow(clippy::manual_non_exhaustive, clippy::missing_safety_doc, clippy::too_many_arguments)]
 
 /// WGL bindings
 pub mod wgl {


### PR DESCRIPTION
Depends on #1413 + #1408.

This is a draft mainly to look at how `cargo clippy --fix` and myself have addressed warnings for most issues. There are still a few remaining, and clippy found some odd/fishy things we should look into.

- [ ] Tested on all platforms changed
  - [x] Android + EGL;
  - [x] Wayland + EGL;
  - [ ] Wayland + EGL on `sharing` example (doesn't run at all, but has nontrivial `clippy` warnings);
  - [ ] Windows.
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
