### PR TITLE
Replace deprecated `Error::cause()` implementation with `Error::source()`

### DIFF
--- a/glutin/src/lib.rs
+++ b/glutin/src/lib.rs
@@ -353,10 +353,10 @@ impl std::fmt::Display for CreationError {
 }
 
 impl std::error::Error for CreationError {
-    fn cause(&self) -> Option<&dyn std::error::Error> {
-        match *self {
-            CreationError::NoBackendAvailable(ref err) => Some(&**err),
-            CreationError::Window(ref err) => Some(err),
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            CreationError::NoBackendAvailable(err) => Some(&**err),
+            CreationError::Window(err) => Some(err),
             _ => None,
         }
     }


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
