### PR TITLE
Add support for GBM surface-less context.

### DIFF
--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -18,6 +18,7 @@ serde = ["winit/serde"]
 x11 = ["winit/x11", "glutin_glx_sys"]
 wayland = ["winit/wayland", "winit/wayland-dlopen", "wayland-client", "wayland-egl"]
 wayland-dlopen = ["winit/wayland-dlopen"]
+gbm = ["gbm-sys", "libc"]
 default = ["x11", "wayland", "wayland-dlopen"]
 
 [dependencies]
@@ -66,3 +67,7 @@ glutin_egl_sys = { version = "0.1.5", path = "../glutin_egl_sys" }
 glutin_glx_sys = { version = "0.1.7", path = "../glutin_glx_sys", optional = true }
 parking_lot = "0.11"
 log = "0.4"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+gbm-sys = { version = "0.2", optional = true }
+libc = { version = "0.2", optional = true }

--- a/glutin/src/api/egl/mod.rs
+++ b/glutin/src/api/egl/mod.rs
@@ -1110,39 +1110,41 @@ where
         return Err(CreationError::OsError("eglChooseConfig failed".to_string()));
     }
 
-    // We're interested in those configs which allow our desired VSync.
-    let desired_swap_interval = if opengl.vsync { 1 } else { 0 };
+    if surface_type != SurfaceType::Surfaceless {
+        // We're interested in those configs which allow our desired VSync.
+        let desired_swap_interval = if opengl.vsync { 1 } else { 0 };
 
-    let config_ids = config_ids
-        .into_iter()
-        .filter(|&config| {
-            let mut min_swap_interval = 0;
-            let res = egl.GetConfigAttrib(
-                display,
-                config,
-                ffi::egl::MIN_SWAP_INTERVAL as ffi::egl::types::EGLint,
-                &mut min_swap_interval,
-            );
+        config_ids = config_ids
+            .into_iter()
+            .filter(|&config| {
+                let mut min_swap_interval = 0;
+                let res = egl.GetConfigAttrib(
+                    display,
+                    config,
+                    ffi::egl::MIN_SWAP_INTERVAL as ffi::egl::types::EGLint,
+                    &mut min_swap_interval,
+                );
 
-            if desired_swap_interval < min_swap_interval {
-                return false;
-            }
+                if desired_swap_interval < min_swap_interval {
+                    return false;
+                }
 
-            let mut max_swap_interval = 0;
-            let res = egl.GetConfigAttrib(
-                display,
-                config,
-                ffi::egl::MAX_SWAP_INTERVAL as ffi::egl::types::EGLint,
-                &mut max_swap_interval,
-            );
+                let mut max_swap_interval = 0;
+                let res = egl.GetConfigAttrib(
+                    display,
+                    config,
+                    ffi::egl::MAX_SWAP_INTERVAL as ffi::egl::types::EGLint,
+                    &mut max_swap_interval,
+                );
 
-            if desired_swap_interval > max_swap_interval {
-                return false;
-            }
+                if desired_swap_interval > max_swap_interval {
+                    return false;
+                }
 
-            true
-        })
-        .collect::<Vec<_>>();
+                true
+            })
+            .collect::<Vec<_>>();
+    }
 
     if config_ids.is_empty() {
         return Err(CreationError::NoAvailablePixelFormat);

--- a/glutin/src/platform_impl/unix/gbm.rs
+++ b/glutin/src/platform_impl/unix/gbm.rs
@@ -1,0 +1,117 @@
+use crate::api::egl::{Context as EglContext, NativeDisplay, SurfaceType as EglSurfaceType};
+use crate::{ContextError, CreationError, GlAttributes, PixelFormatRequirements};
+
+use glutin_egl_sys as ffi;
+
+use std::ffi::CString;
+use std::mem::ManuallyDrop;
+use std::ops::Deref;
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::io::RawFd;
+use std::path::Path;
+
+#[derive(Debug)]
+pub struct Context {
+    dri_device_fd: RawFd,
+    gbm_device: *mut gbm_sys::gbm_device,
+    context: ManuallyDrop<EglContext>,
+}
+
+impl Deref for Context {
+    type Target = EglContext;
+
+    fn deref(&self) -> &Self::Target {
+        &self.context
+    }
+}
+
+impl Context {
+    #[inline]
+    pub fn new_surfaceless(
+        pf_reqs: &PixelFormatRequirements,
+        gl_attr: &GlAttributes<&Context>,
+        dri_device_path: &Path,
+    ) -> Result<Self, CreationError> {
+        // Open DRI device.
+        let path = CString::new(dri_device_path.as_os_str().as_bytes()).unwrap();
+        let dri_device_fd = unsafe { libc::open(path.as_ptr(), libc::O_RDWR) };
+        if dri_device_fd == -1 {
+            return Err(CreationError::OsError(std::io::Error::last_os_error().to_string()));
+        }
+
+        // Create GBM device from DRI device.
+        let gbm_device = unsafe { gbm_sys::gbm_create_device(dri_device_fd) };
+        if gbm_device.is_null() {
+            unsafe { libc::close(dri_device_fd) };
+            return Err(CreationError::OsError("GBM device creation failed".to_string()));
+        }
+
+        // Create EGL context.
+        let gl_attr = gl_attr.clone().map_sharing(|c| &**c);
+        let native_display = NativeDisplay::Gbm(Some(gbm_device as *const _));
+        let context = match EglContext::new(
+            pf_reqs,
+            &gl_attr,
+            native_display,
+            EglSurfaceType::Surfaceless,
+            |c, _| Ok(c[0]),
+        )
+        .and_then(|p| p.finish_surfaceless())
+        {
+            Ok(context) => context,
+            Err(err) => {
+                unsafe { gbm_sys::gbm_device_destroy(gbm_device) };
+                unsafe { libc::close(dri_device_fd) };
+                return Err(err);
+            }
+        };
+
+        Ok(Self { dri_device_fd, gbm_device, context: ManuallyDrop::new(context) })
+    }
+
+    #[inline]
+    pub unsafe fn make_current(&self) -> Result<(), ContextError> {
+        (**self).make_current()
+    }
+
+    #[inline]
+    pub unsafe fn make_not_current(&self) -> Result<(), ContextError> {
+        (**self).make_not_current()
+    }
+
+    #[inline]
+    pub fn is_current(&self) -> bool {
+        (**self).is_current()
+    }
+
+    #[inline]
+    pub fn get_api(&self) -> crate::Api {
+        (**self).get_api()
+    }
+
+    #[inline]
+    pub unsafe fn raw_handle(&self) -> ffi::EGLContext {
+        (**self).raw_handle()
+    }
+
+    #[inline]
+    pub fn get_proc_address(&self, addr: &str) -> *const core::ffi::c_void {
+        (**self).get_proc_address(addr)
+    }
+}
+
+impl Drop for Context {
+    fn drop(&mut self) {
+        // Drop EGL context.
+        unsafe { ManuallyDrop::drop(&mut self.context) };
+
+        // Destroy GBM device.
+        unsafe { gbm_sys::gbm_device_destroy(self.gbm_device) };
+
+        // Close DRI device.
+        unsafe { libc::close(self.dri_device_fd) };
+    }
+}
+
+unsafe impl Send for Context {}
+unsafe impl Sync for Context {}

--- a/glutin_examples/Cargo.toml
+++ b/glutin_examples/Cargo.toml
@@ -10,6 +10,9 @@ build = "build.rs"
 edition = "2018"
 publish = false
 
+[features]
+gbm = ["glutin/gbm"]
+
 [dependencies]
 glutin = { path = "../glutin" }
 takeable-option = "0.4"


### PR DESCRIPTION
This introduces support for a hardware accelerated surface-less EGL
context backed by GBM on Linux.

This allows the `headless` example to run without X11 and Wayland,
but with hardware acceleration.

Tested on Ubuntu 22.04 x64 (Intel GPU) and arm64 (RPi 4 with vc4-kms-v3d).

Fixes #1372.