### PR TITLE
Add Android example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ cargo run --example window
 Glutin is an OpenGL context creation library and doesn't directly provide
 OpenGL bindings for you.
 
-For examples, please look [here.](https://github.com/rust-windowing/glutin/tree/master/glutin_examples)
+For examples, please look [here](https://github.com/rust-windowing/glutin/tree/master/glutin_examples).
 
 Note that glutin aims at being a low-level brick in your rendering
 infrastructure. You are encouraged to write another layer of abstraction
@@ -52,6 +52,10 @@ The minimum rust version target by glutin is `1.60.0`.
 
 ### Android
 
-To compile the examples for android, you have to use the `cargo apk` utility.
+Be sure to handle Android's lifecycle correctly when using a `winit` window by only creating a GL surface after `winit` raises `Event::Resumed`, and destroy it again upon receiving `Event::Suspended`. See this in action in the [`android.rs` example](./glutin_examples/examples/android.rs).
 
-See [`cargo-apk` in the `android-ndk-rs` repository](https://github.com/rust-windowing/android-ndk-rs/tree/master/cargo-apk) for instructions.
+To compile and run the Android example on your device, install [`cargo-apk`](https://crates.io/crates/cargo-apk) and start the app using:
+
+```console
+$ cargo apk r -p glutin_examples --example android
+```

--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -25,11 +25,11 @@ libloading = { version = "0.7.3", optional = true }
 once_cell = "1.13"
 raw-window-handle = "0.5.0"
 
-[target.'cfg(target_os = "windows")'.dependencies]
+[target.'cfg(windows)'.dependencies]
 glutin_egl_sys = { version = "0.2.0", path = "../glutin_egl_sys", optional = true }
 glutin_wgl_sys = { version = "0.2.0", path = "../glutin_wgl_sys", optional = true }
 
-[target.'cfg(target_os = "windows")'.dependencies.windows-sys]
+[target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.36"
 features = [
     "Win32_Foundation",

--- a/glutin/src/api/egl/display.rs
+++ b/glutin/src/api/egl/display.rs
@@ -45,7 +45,7 @@ impl Display {
     /// `raw_display` must point to a valid system display. Using zero or
     /// `[std::ptr::null]` for the display will result in using
     /// `EGL_DEFAULT_DISPLAY`, which is not recommended or will
-    /// work on a platfrom with a concept of native display, like Wayland.
+    /// work on a platform with a concept of native display, like Wayland.
     pub unsafe fn from_raw(raw_display: RawDisplayHandle) -> Result<Self> {
         let egl = match EGL.as_ref() {
             Some(egl) => egl,

--- a/glutin_egl_sys/Cargo.toml
+++ b/glutin_egl_sys/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 [build-dependencies]
 gl_generator = "0.14"
 
-[target.'cfg(target_os = "windows")'.dependencies.windows-sys]
+[target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.36"
 features = [
     "Win32_Foundation",

--- a/glutin_egl_sys/src/lib.rs
+++ b/glutin_egl_sys/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg(any(
-    target_os = "windows",
+    windows,
     target_os = "linux",
     target_os = "android",
     target_os = "dragonfly",
@@ -43,7 +43,7 @@ pub type EGLenum = raw::c_uint;
 pub type EGLNativeDisplayType = *const raw::c_void;
 pub type EGLNativePixmapType = *const raw::c_void; // FIXME: egl_native_pixmap_t instead
 
-#[cfg(target_os = "windows")]
+#[cfg(windows)]
 pub type EGLNativeWindowType = windows_sys::Win32::Foundation::HWND;
 #[cfg(target_os = "linux")]
 pub type EGLNativeWindowType = *const raw::c_void;

--- a/glutin_examples/Cargo.toml
+++ b/glutin_examples/Cargo.toml
@@ -23,6 +23,13 @@ glutin = { path = "../glutin", default-features = false }
 winit = { version = "0.27.2", default-features = false }
 raw-window-handle = "0.5.0"
 
+[target.'cfg(target_os = "android")'.dependencies]
+ndk-glue = "0.7" # Keep in sync with winit dependency
+
 [build-dependencies]
 gl_generator = "0.14"
 cfg_aliases = "0.1.1"
+
+[[example]]
+name = "android"
+crate-type = ["cdylib"]

--- a/glutin_examples/examples/android.rs
+++ b/glutin_examples/examples/android.rs
@@ -1,0 +1,6 @@
+#![cfg(target_os = "android")]
+
+#[ndk_glue::main(backtrace = "on")]
+fn main() {
+    glutin_examples::main()
+}

--- a/glutin_wgl_sys/src/lib.rs
+++ b/glutin_wgl_sys/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg(any(target_os = "windows"))]
+#![cfg(target_os = "windows")]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::missing_safety_doc)]
 #![allow(clippy::manual_non_exhaustive)]

--- a/glutin_wgl_sys/src/lib.rs
+++ b/glutin_wgl_sys/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg(target_os = "windows")]
+#![cfg(windows)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::missing_safety_doc)]
 #![allow(clippy::manual_non_exhaustive)]


### PR DESCRIPTION
As mentioned in #1398/#1411 we should have an example that showcases how to deal with the Android activity lifecycle.  Ultimately this turns into a helper function on `ContextWrapper` that has access to the internal surface for recreation, as did the broken implementation prior to #1411.  At the same time I hope to replace `new_windowed()` with an implementation soon™ that takes a `RawWindowHandle`, making the code more generic, `winit`-agnostic, and allows users to use Android `Surface`s for specific views in their Java/Kotlin/Flutter apps without needing a fullscreen `NativeActivity`.

This PR is based on top of #1412 so that my editor doesn't go bonkers on all the lint warnings/errors :)
