### PR TITLE
Switch from `ndk-glue` to `raw-window-handle` crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Return an `Err` instead of panicking when surfaceless GLX context creation fails on Linux.
 - Fix compilation on Android:
   - Switch from `StaticStructGenerator` to `StructGenerator` to dynamically load symbols.
-  - Replace `android_glue` dependency with `ndk-glue`, and remove broken lifecycle event handling.
+  - Replace `android_glue` dependency with `raw-window-handle`, and remove broken lifecycle event handling.
   - Glutin can now be used on Android, however, the application must ensure it only creates the `Context` following a winit `Event::Resumed` event, and destroys the `Context` in response to a `Event::Suspended` event.
 
 # Version 0.28.0 (2021-12-02)

--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -27,8 +27,8 @@ winit = { version = "0.26", default-features = false }
 [target.'cfg(target_os = "android")'.dependencies]
 glutin_egl_sys = { version = "0.1.5", path = "../glutin_egl_sys" }
 libloading = "0.7"
-ndk-glue = "0.5" # Keep in sync with winit
 parking_lot = "0.11"
+raw-window-handle = "0.4"
 
 [target.'cfg(target_os = "emscripten")'.dependencies]
 glutin_emscripten_sys = { version = "0.1.1", path = "../glutin_emscripten_sys" }


### PR DESCRIPTION
`winit` provides a `raw-window-handle` specifically for crates to process window pointers/references in a crate-agnostic way.  `glutin` can use it too, to get rid of its `ndk-glue` dependency which otherwise has a hard versioning dependency  as it should be updated in sync with `winit`.

Over time this should be worked into the other backends, in turn removing `winit` from the `new_windowed()` function signature and replacing it with `impl HasRawWindowHandle` or `dyn HasRawWindowHandle`.  This will also allow Android users to pass generic `Surface`s (first converted to a so-called `NativeWindow` in the NDK through [#272], then passed as `RawWindowHandle` thanks to [#274]) created in Java / Kotlin / Flutter to render to individual UI elements instead of the entire screen with a `NativeActivity` (`ndk-glue`).  It'll in turn make the code more generic, too, as `raw-window-handle` has a variant for every platform / windowing system currently supported by glutin.

[#272]: https://github.com/rust-windowing/android-ndk-rs/pull/272
[#274]: https://github.com/rust-windowing/android-ndk-rs/pull/274

CC @jamienicol

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
