### PR TITLE
examples: Bump `image` dependency from `0.21` to `0.24` to address CVE-2020-35916

### DIFF
--- a/glutin_examples/Cargo.toml
+++ b/glutin_examples/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 [dependencies]
 glutin = { path = "../glutin" }
 takeable-option = "0.4"
-image = "0.21"
+image = "0.24"
 
 [build-dependencies]
 gl_generator = "0.14"

--- a/glutin_examples/examples/headless.rs
+++ b/glutin_examples/examples/headless.rs
@@ -140,7 +140,7 @@ fn main() {
         &pixels_flipped,
         size.width as u32,
         size.height as u32,
-        image::RGB(8),
+        image::ColorType::Rgb8,
     )
     .unwrap();
 


### PR DESCRIPTION
Dependabot showed this security alert on my fork, which is trivially addressable by bumping the version.

@kchibisov you probably want to turn on dependabot alerts for this repo :)

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
