### PR TITLE
Replace hardcoded `html` links with intradoc-links

### DIFF
--- a/glutin/src/api/egl/mod.rs
+++ b/glutin/src/api/egl/mod.rs
@@ -130,17 +130,17 @@ lazy_static! {
 #[derive(Debug)]
 #[allow(dead_code)]
 pub enum NativeDisplay {
-    /// `None` means `EGL_DEFAULT_DISPLAY`.
+    /// [`None`] means `EGL_DEFAULT_DISPLAY`.
     X11(Option<ffi::EGLNativeDisplayType>),
-    /// `None` means `EGL_DEFAULT_DISPLAY`.
+    /// [`None`] means `EGL_DEFAULT_DISPLAY`.
     Gbm(Option<ffi::EGLNativeDisplayType>),
-    /// `None` means `EGL_DEFAULT_DISPLAY`.
+    /// [`None`] means `EGL_DEFAULT_DISPLAY`.
     Wayland(Option<ffi::EGLNativeDisplayType>),
     /// `EGL_DEFAULT_DISPLAY` is mandatory for Android.
     Android,
     // TODO: should be `EGLDeviceEXT`
     Device(ffi::EGLNativeDisplayType),
-    /// Don't specify any display type. Useful on windows. `None` means
+    /// Don't specify any display type. Useful on windows. [`None`] means
     /// `EGL_DEFAULT_DISPLAY`.
     Other(Option<ffi::EGLNativeDisplayType>),
 }

--- a/glutin/src/api/wgl/mod.rs
+++ b/glutin/src/api/wgl/mod.rs
@@ -72,7 +72,7 @@ impl Context {
     ///
     /// # Unsafety
     ///
-    /// The `window` must continue to exist as long as the resulting `Context`
+    /// The `window` must continue to exist as long as the resulting [`Context`]
     /// exists.
     #[inline]
     pub unsafe fn new(
@@ -220,7 +220,7 @@ unsafe impl Sync for Context {}
 
 /// Creates an OpenGL context.
 ///
-/// If `extra` is `Some`, this function will attempt to use the latest WGL
+/// If `extra` is [`Some`], this function will attempt to use the latest WGL
 /// functions to create the context.
 ///
 /// Otherwise, only the basic API will be used and the chances of

--- a/glutin/src/context.rs
+++ b/glutin/src/context.rs
@@ -26,10 +26,6 @@ use winit::event_loop::EventLoopWindowTarget;
 ///     .with_shared_lists(some_context.context());
 /// # }
 /// ```
-///
-/// [`WindowedContext<T>`]: type.WindowedContext.html
-/// [`RawContext<T>`]: type.RawContext.html
-/// [`Context`]: struct.Context.html
 #[derive(Debug)]
 pub struct Context<T: ContextCurrentState> {
     pub(crate) context: platform_impl::Context,
@@ -37,10 +33,7 @@ pub struct Context<T: ContextCurrentState> {
 }
 
 impl<T: ContextCurrentState> Context<T> {
-    /// See [`ContextWrapper::make_current`].
-    ///
-    /// [`ContextWrapper::make_current`]:
-    /// struct.ContextWrapper.html#method.make_current
+    /// See [`ContextWrapper::make_current()`].
     pub unsafe fn make_current(self) -> Result<Context<PossiblyCurrent>, (Self, ContextError)> {
         match self.context.make_current() {
             Ok(()) => Ok(Context { context: self.context, phantom: PhantomData }),
@@ -48,10 +41,7 @@ impl<T: ContextCurrentState> Context<T> {
         }
     }
 
-    /// See [`ContextWrapper::make_not_current`].
-    ///
-    /// [`ContextWrapper::make_not_current`]:
-    /// struct.ContextWrapper.html#method.make_not_current
+    /// See [`ContextWrapper::make_not_current()`].
     pub unsafe fn make_not_current(self) -> Result<Context<NotCurrent>, (Self, ContextError)> {
         match self.context.make_not_current() {
             Ok(()) => Ok(Context { context: self.context, phantom: PhantomData }),
@@ -59,43 +49,29 @@ impl<T: ContextCurrentState> Context<T> {
         }
     }
 
-    /// See [`ContextWrapper::treat_as_not_current`].
-    ///
-    /// [`ContextWrapper::treat_as_not_current`]:
-    /// struct.ContextWrapper.html#method.treat_as_not_current
+    /// See [`ContextWrapper::treat_as_not_current()`].
     pub unsafe fn treat_as_not_current(self) -> Context<NotCurrent> {
         Context { context: self.context, phantom: PhantomData }
     }
 
-    /// See [`ContextWrapper::treat_as_current`].
-    ///
-    /// [`ContextWrapper::treat_as_current`]:
-    /// struct.ContextWrapper.html#method.treat_as_current
+    /// See [`ContextWrapper::treat_as_current()`].
     pub unsafe fn treat_as_current(self) -> Context<PossiblyCurrent> {
         Context { context: self.context, phantom: PhantomData }
     }
 
-    /// See [`ContextWrapper::is_current`].
-    ///
-    /// [`ContextWrapper::is_current`]:
-    /// struct.ContextWrapper.html#method.is_current
+    /// See [`ContextWrapper::is_current()`].
     pub fn is_current(&self) -> bool {
         self.context.is_current()
     }
 
-    /// See [`ContextWrapper::get_api`].
-    ///
-    /// [`ContextWrapper::get_api`]: struct.ContextWrapper.html#method.get_api
+    /// See [`ContextWrapper::get_api()`].
     pub fn get_api(&self) -> Api {
         self.context.get_api()
     }
 }
 
 impl Context<PossiblyCurrent> {
-    /// See [`ContextWrapper::get_proc_address`].
-    ///
-    /// [`ContextWrapper::get_proc_address`]:
-    /// struct.ContextWrapper.html#method.get_proc_address
+    /// See [`ContextWrapper::get_proc_address()`].
     pub fn get_proc_address(&self, addr: &str) -> *const core::ffi::c_void {
         self.context.get_proc_address(addr)
     }
@@ -104,11 +80,11 @@ impl Context<PossiblyCurrent> {
 impl<'a, T: ContextCurrentState> ContextBuilder<'a, T> {
     /// Builds the given GL context.
     ///
-    /// When on a unix operating system, prefer [`build_surfaceless`]. If both
-    /// [`build_surfaceless`] and `build_headless` fail, try using a hidden
-    /// window, or [`build_osmesa`]. Please note that if you choose to use a
-    /// hidden window, you must still handle the events it generates on the
-    /// events loop.
+    /// When on a unix operating system, prefer [`build_surfaceless()`]. If both
+    /// [`build_surfaceless()`] and [`build_headless()`][Self::build_headless()]
+    /// fail, try using a hidden window, or [`build_osmesa()`]. Please note that
+    /// if you choose to use a hidden window, you must still handle the events
+    /// it generates on the events loop.
     ///
     /// Errors can occur in two scenarios:
     ///  - If the window could not be created (via permission denied,
@@ -116,8 +92,6 @@ impl<'a, T: ContextCurrentState> ContextBuilder<'a, T> {
     ///  - If the OpenGL [`Context`] could not be created. This generally
     ///    happens
     ///  because the underlying platform doesn't support a requested feature.
-    ///
-    /// [`Context`]: struct.Context.html
     #[cfg_attr(
         not(any(
             target_os = "linux",
@@ -126,9 +100,9 @@ impl<'a, T: ContextCurrentState> ContextBuilder<'a, T> {
             target_os = "netbsd",
             target_os = "openbsd",
         )),
-        doc = "\
-    [`build_surfaceless`]: platform/index.html\n\
-    [`build_osmesa`]: platform/index.html\
+        doc = "\n
+    [`build_surfaceless()`]: crate::platform\n
+    [`build_osmesa()`]: crate::platform
     "
     )]
     #[cfg_attr(
@@ -139,9 +113,9 @@ impl<'a, T: ContextCurrentState> ContextBuilder<'a, T> {
             target_os = "netbsd",
             target_os = "openbsd",
         ),
-        doc = "\
-    [`build_surfaceless`]: platform/unix/trait.HeadlessContextExt.html#tymethod.build_surfaceless\n\
-    [`build_osmesa`]: platform/unix/trait.HeadlessContextExt.html#tymethod.build_osmesa\
+        doc = "\n
+    [`build_surfaceless()`]: platform::unix::HeadlessContextExt::build_surfaceless()\n
+    [`build_osmesa()`]: platform::unix::HeadlessContextExt::build_osmesa()
     "
     )]
     pub fn build_headless<TE>(
@@ -165,11 +139,7 @@ impl<'a, T: ContextCurrentState> ContextBuilder<'a, T> {
 /// A type that [`Context`]s which might possibly be currently current on some
 /// thread take as a generic.
 ///
-/// See [`ContextWrapper::make_current`] for more details.
-///
-/// [`ContextWrapper::make_current`]:
-/// struct.ContextWrapper.html#method.make_current
-/// [`Context`]: struct.Context.html
+/// See [`ContextWrapper::make_current()`] for more details.
 #[derive(Debug, Clone, Copy)]
 pub struct PossiblyCurrent {
     phantom: PhantomData<*mut ()>,
@@ -178,19 +148,12 @@ pub struct PossiblyCurrent {
 /// A type that [`Context`]s which are not currently current on any thread take
 /// as a generic.
 ///
-/// See [`ContextWrapper::make_current`] for more details.
-///
-/// [`ContextWrapper::make_current`]:
-/// struct.ContextWrapper.html#method.make_current
-/// [`Context`]: struct.Context.html
+/// See [`ContextWrapper::make_current()`] for more details.
 #[derive(Debug, Clone, Copy)]
 pub enum NotCurrent {}
 
 /// A trait implemented on both [`NotCurrent`] and
 /// [`PossiblyCurrent`].
-///
-/// [`NotCurrent`]: enum.NotCurrent.html
-/// [`PossiblyCurrent`]: struct.PossiblyCurrent.html
 pub trait ContextCurrentState: std::fmt::Debug + Clone {}
 
 impl ContextCurrentState for PossiblyCurrent {}

--- a/glutin/src/platform/mod.rs
+++ b/glutin/src/platform/mod.rs
@@ -36,9 +36,7 @@ pub mod run_return {
 
 use std::os::raw;
 
-/// Platform-specific extensions for OpenGL [`Context`]s.
-///
-/// [`Context`]: ../struct.Context.html
+/// Platform-specific extensions for OpenGL [`Context`][crate::Context]s.
 pub trait ContextTraitExt {
     /// Raw context handle.
     type Handle;
@@ -49,7 +47,7 @@ pub trait ContextTraitExt {
     /// Returns a pointer to the `EGLDisplay` object of EGL that is used by this
     /// context.
     ///
-    /// Return `None` if the context doesn't use EGL.
+    /// Return [`None`] if the context doesn't use EGL.
     // The pointer will become invalid when the context is destroyed.
     unsafe fn get_egl_display(&self) -> Option<*const raw::c_void>;
 }

--- a/glutin/src/platform_impl/unix/mod.rs
+++ b/glutin/src/platform_impl/unix/mod.rs
@@ -312,18 +312,14 @@ impl Context {
     }
 }
 
-/// A unix-specific extension to the [`ContextBuilder`] which allows building
-/// unix-specific headless contexts.
-///
-/// [`ContextBuilder`]: ../../struct.ContextBuilder.html
+/// A unix-specific extension to the [`ContextBuilder`][crate::ContextBuilder]
+/// which allows building unix-specific headless contexts.
 pub trait HeadlessContextExt {
     /// Builds an OsMesa context.
     ///
-    /// Errors can occur if the OpenGL [`Context`] could not be created. This
-    /// generally happens because the underlying platform doesn't support a
+    /// Errors can occur if the OpenGL [`Context`][crate::Context] could not be created.
+    /// This generally happens because the underlying platform doesn't support a
     /// requested feature.
-    ///
-    /// [`Context`]: struct.Context.html
     fn build_osmesa(
         self,
         size: dpi::PhysicalSize<u32>,
@@ -333,11 +329,9 @@ pub trait HeadlessContextExt {
 
     /// Builds an EGL-surfaceless context.
     ///
-    /// Errors can occur if the OpenGL [`Context`] could not be created. This
-    /// generally happens because the underlying platform doesn't support a
+    /// Errors can occur if the OpenGL [`Context`][crate::Context] could not be created.
+    /// This generally happens because the underlying platform doesn't support a
     /// requested feature.
-    ///
-    /// [`Context`]: struct.Context.html
     fn build_surfaceless<TE>(
         self,
         el: &EventLoopWindowTarget<TE>,
@@ -382,11 +376,8 @@ impl<'a, T: ContextCurrentState> HeadlessContextExt for crate::ContextBuilder<'a
     }
 }
 
-/// A unix-specific extension for the [`ContextBuilder`] which allows
-/// assembling [`RawContext<T>`]s.
-///
-/// [`RawContext<T>`]: ../../type.RawContext.html
-/// [`ContextBuilder`]: ../../struct.ContextBuilder.html
+/// A unix-specific extension for the [`ContextBuilder`][crate::ContextBuilder]
+/// which allows assembling [`RawContext<T>`][crate::RawContext]s.
 pub trait RawContextExt {
     /// Creates a raw context on the provided surface.
     ///

--- a/glutin/src/platform_impl/unix/x11.rs
+++ b/glutin/src/platform_impl/unix/x11.rs
@@ -357,12 +357,12 @@ impl Context {
                 }
 
                 // force_prefer_unless_only does what it says on the tin, it
-                // forces only the prefered method to happen unless it's the
+                // forces only the preferred method to happen unless it's the
                 // only method available.
                 //
                 // Users of this function should first call with `prefer_egl`
                 // as `<status of their choice>`, with
-                // `force_prefer_unless_only` as `false`.
+                // `force_prefer_unless_only` as [`false`].
                 //
                 // Then, if those users want to fallback and try the other
                 // method, they should call us with `prefer_egl` equal to


### PR DESCRIPTION
Intradoc links are more concise to write and checked by `rustdoc` for validity.  It'll not be allowed to create a link to an item that doesn't exist - something rustdoc can't really check with (relative or not) links to "random" html pages.

For example, this change helped find dead links to `RawContextExt` whose module was renamed from `os` to `platform_impl` + `platform` well over 3 years ago, yet the links weren't updated.

At the same time intradoc-links receive a nice highlight from rust-analyzer, and can be navigated to using jump-to-symbol.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
