### PR TITLE
Fix clippy issues on macOS/ios

### DIFF
--- a/glutin/src/api/ios/mod.rs
+++ b/glutin/src/api/ios/mod.rs
@@ -1,5 +1,5 @@
 #![cfg(target_os = "ios")]
-
+#![allow(clippy::let_unit_value)]
 //! iOS support
 //!
 //! # Building app
@@ -420,11 +420,8 @@ fn create_view_class() {
     }
 
     extern "C" fn layer_class(_: &Class, _: Sel) -> *const Class {
-        unsafe {
-            std::mem::transmute(
-                Class::get("CAEAGLLayer").expect("Failed to get class `CAEAGLLayer`"),
-            )
-        }
+        Class::get("CAEAGLLayer").expect("Failed to get class `CAEAGLLayer`")
+            as *const objc::runtime::Class
     }
 
     let superclass = Class::get("GLKView").expect("Failed to get class `GLKView`");

--- a/glutin/src/platform_impl/macos/mod.rs
+++ b/glutin/src/platform_impl/macos/mod.rs
@@ -1,4 +1,5 @@
 #![cfg(target_os = "macos")]
+#![allow(clippy::let_unit_value)]
 use crate::{
     ContextError, CreationError, GlAttributes, PixelFormat, PixelFormatRequirements, Rect,
     Robustness,


### PR DESCRIPTION
On macOS/ios the `msg_send` macro relies on the returned type
even when it's a unit value.
