### PR TITLE
Switch from `lazy_static` to `once_cell`

### DIFF
--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -23,7 +23,7 @@ wayland-csd-adwaita = ["winit/wayland-csd-adwaita"]
 wayland-csd-adwaita-notitle = ["winit/wayland-csd-adwaita-notitle"]
 
 [dependencies]
-lazy_static = "1.3"
+once_cell = "1.10"
 winit = { version = "0.27.0", default-features = false }
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/glutin/src/api/glx/mod.rs
+++ b/glutin/src/api/glx/mod.rs
@@ -15,6 +15,7 @@ use std::os::raw;
 use std::sync::Arc;
 
 use glutin_glx_sys as ffi;
+use once_cell::sync::Lazy;
 use winit::dpi;
 
 use self::make_current_guard::MakeCurrentGuard;
@@ -64,9 +65,7 @@ impl DerefMut for Glx {
     }
 }
 
-lazy_static! {
-    pub static ref GLX: Option<Glx> = Glx::new().ok();
-}
+pub static GLX: Lazy<Option<Glx>> = Lazy::new(|| Glx::new().ok());
 
 #[derive(Debug)]
 pub struct Context {

--- a/glutin/src/lib.rs
+++ b/glutin/src/lib.rs
@@ -66,17 +66,6 @@
 #![allow(clippy::missing_safety_doc, clippy::too_many_arguments)]
 #![cfg_attr(feature = "cargo-clippy", deny(warnings))]
 
-#[cfg(any(
-    target_os = "windows",
-    target_os = "linux",
-    target_os = "android",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "netbsd",
-    target_os = "openbsd",
-))]
-#[macro_use]
-extern crate lazy_static;
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 #[macro_use]
 extern crate objc;


### PR DESCRIPTION
`winit` has just done it, so `glutin` should probably do the same.

- [ ] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
