### PR TITLE
Explicitly specify minimum crate versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fix build failures when building from crates.io
+
 # Version 0.29.0 (2022-07-30)
 
 - Fix crash when creating OpenGLES context without explicit version.

--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -28,7 +28,7 @@ once_cell = "1.13"
 winit = { version = "0.27.1", default-features = false }
 
 [target.'cfg(target_os = "android")'.dependencies]
-glutin_egl_sys = { version = "0.1.5", path = "../glutin_egl_sys" }
+glutin_egl_sys = { version = "0.1.6", path = "../glutin_egl_sys" }
 libloading = "0.7"
 parking_lot = "0.12"
 raw-window-handle = "0.5"
@@ -54,15 +54,15 @@ features = [
 [target.'cfg(target_os = "windows")'.dependencies]
 libloading = "0.7"
 glutin_wgl_sys = { version = "0.1.5", path = "../glutin_wgl_sys" }
-glutin_egl_sys = { version = "0.1.5", path = "../glutin_egl_sys" }
+glutin_egl_sys = { version = "0.1.6", path = "../glutin_egl_sys" }
 parking_lot = "0.12"
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
 osmesa-sys = "0.1"
-wayland-client = { version = "0.29", features = ["dlopen"], optional = true }
-wayland-egl = { version = "0.29", optional = true }
+wayland-client = { version = "0.29.4", features = ["dlopen"], optional = true }
+wayland-egl = { version = "0.29.4", optional = true }
 libloading = "0.7"
-glutin_egl_sys = { version = "0.1.5", path = "../glutin_egl_sys" }
-glutin_glx_sys = { version = "0.1.7", path = "../glutin_glx_sys", optional = true }
+glutin_egl_sys = { version = "0.1.6", path = "../glutin_egl_sys" }
+glutin_glx_sys = { version = "0.1.8", path = "../glutin_glx_sys", optional = true }
 parking_lot = "0.12"
 log = "0.4"


### PR DESCRIPTION
This should fix building from crates.io

