### PR TITLE
ci: remove NDK path setting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,13 +74,7 @@ jobs:
         targets: ${{ matrix.platform.target }}
         components: clippy
 
-    - name: Setup NDK path
-      shell: bash
-      # "Temporary" workaround until https://github.com/actions/virtual-environments/issues/5879#issuecomment-1195156618
-      # gets looked into.
-      run: echo "ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
       # We need those for examples.
-
     - name: Install GCC Multilib
       if: (matrix.platform.os == 'ubuntu-latest') && contains(matrix.platform.target, 'i686')
       run: sudo apt-get update && sudo apt-get install gcc-multilib


### PR DESCRIPTION
This removes a temporary workaround on the android
CI to set path. Now it's set by the action again.

cc @MarijnS95 