### PR TITLE
api: move `get_proc_address` to `GlDisplay`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - `Config` doesn't force OpenGL `Api` by default.
 - `Display::create_context` now uses the most recent available `Api` from the `Config` when `ContextApi` is not specified in `ContextAttributes`.
+- `PossiblyCurrentGlContext::get_proc_address` method was moved to `GlDisplay::get_proc_address`.
 
 # Version 0.30.0-beta.2 (2022-09-03)
 

--- a/glutin/src/api/cgl/context.rs
+++ b/glutin/src/api/cgl/context.rs
@@ -1,6 +1,5 @@
 //! Everything related to `NSOpenGLContext`.
 
-use std::ffi::{self, CStr};
 use std::fmt;
 use std::marker::PhantomData;
 use std::ops::Deref;
@@ -8,9 +7,7 @@ use std::ops::Deref;
 use cgl::CGLSetParameter;
 use cocoa::appkit::{NSOpenGLContext, NSOpenGLContextParameter};
 use cocoa::base::{id, nil};
-use core_foundation::base::TCFType;
-use core_foundation::bundle::{CFBundleGetBundleWithIdentifier, CFBundleGetFunctionPointerForName};
-use core_foundation::string::CFString;
+
 use objc::rc::autoreleasepool;
 use objc::runtime::{BOOL, NO};
 
@@ -157,15 +154,6 @@ impl PossiblyCurrentGlContext for PossiblyCurrentContext {
                 false
             }
         })
-    }
-
-    fn get_proc_address(&self, addr: &CStr) -> *const ffi::c_void {
-        let symbol_name = CFString::new(addr.to_str().unwrap());
-        let framework_name = CFString::new("com.apple.opengl");
-        unsafe {
-            let framework = CFBundleGetBundleWithIdentifier(framework_name.as_concrete_TypeRef());
-            CFBundleGetFunctionPointerForName(framework, symbol_name.as_concrete_TypeRef()).cast()
-        }
     }
 }
 

--- a/glutin/src/api/cgl/display.rs
+++ b/glutin/src/api/cgl/display.rs
@@ -1,7 +1,11 @@
 //! A CGL display.
 
+use std::ffi::{self, CStr};
 use std::marker::PhantomData;
 
+use core_foundation::base::TCFType;
+use core_foundation::bundle::{CFBundleGetBundleWithIdentifier, CFBundleGetFunctionPointerForName};
+use core_foundation::string::CFString;
 use raw_window_handle::RawDisplayHandle;
 
 use crate::config::ConfigTemplate;
@@ -80,6 +84,15 @@ impl GlDisplay for Display {
         surface_attributes: &SurfaceAttributes<PixmapSurface>,
     ) -> Result<Self::PixmapSurface> {
         unsafe { Self::create_pixmap_surface(self, config, surface_attributes) }
+    }
+
+    fn get_proc_address(&self, addr: &CStr) -> *const ffi::c_void {
+        let symbol_name = CFString::new(addr.to_str().unwrap());
+        let framework_name = CFString::new("com.apple.opengl");
+        unsafe {
+            let framework = CFBundleGetBundleWithIdentifier(framework_name.as_concrete_TypeRef());
+            CFBundleGetFunctionPointerForName(framework, symbol_name.as_concrete_TypeRef()).cast()
+        }
     }
 }
 

--- a/glutin/src/api/egl/context.rs
+++ b/glutin/src/api/egl/context.rs
@@ -1,6 +1,5 @@
 //! Everything related to `EGLContext` management.
 
-use std::ffi::{self, CStr};
 use std::fmt;
 use std::marker::PhantomData;
 use std::ops::Deref;
@@ -227,10 +226,6 @@ impl PossiblyCurrentGlContext for PossiblyCurrentContext {
             self.inner.bind_api();
             self.inner.display.inner.egl.GetCurrentContext() == *self.inner.raw
         }
-    }
-
-    fn get_proc_address(&self, addr: &CStr) -> *const ffi::c_void {
-        unsafe { self.inner.display.inner.egl.GetProcAddress(addr.as_ptr()) as *const _ }
     }
 }
 

--- a/glutin/src/api/egl/display.rs
+++ b/glutin/src/api/egl/display.rs
@@ -1,7 +1,7 @@
 //! Everything related to `EGLDisplay`.
 
 use std::collections::HashSet;
-use std::ffi::CStr;
+use std::ffi::{self, CStr};
 use std::fmt;
 use std::ops::Deref;
 use std::sync::Arc;
@@ -270,6 +270,10 @@ impl GlDisplay for Display {
         surface_attributes: &SurfaceAttributes<PixmapSurface>,
     ) -> Result<Self::PixmapSurface> {
         unsafe { Self::create_pixmap_surface(self, config, surface_attributes) }
+    }
+
+    fn get_proc_address(&self, addr: &CStr) -> *const ffi::c_void {
+        unsafe { self.inner.egl.GetProcAddress(addr.as_ptr()) as *const _ }
     }
 }
 

--- a/glutin/src/api/glx/context.rs
+++ b/glutin/src/api/glx/context.rs
@@ -1,6 +1,5 @@
 //! Everything related to `GLXContext`.
 
-use std::ffi::{self, CStr};
 use std::fmt;
 use std::marker::PhantomData;
 use std::ops::Deref;
@@ -295,12 +294,6 @@ impl PossiblyCurrentGlContext for PossiblyCurrentContext {
 
     fn is_current(&self) -> bool {
         unsafe { self.inner.display.inner.glx.GetCurrentContext() == *self.inner.raw }
-    }
-
-    fn get_proc_address(&self, addr: &CStr) -> *const ffi::c_void {
-        unsafe {
-            self.inner.display.inner.glx.GetProcAddress(addr.as_ptr() as *const _) as *const _
-        }
     }
 }
 

--- a/glutin/src/api/glx/display.rs
+++ b/glutin/src/api/glx/display.rs
@@ -1,7 +1,7 @@
 //! GLX object creation.
 
 use std::collections::HashSet;
-use std::ffi::CStr;
+use std::ffi::{self, CStr};
 use std::fmt;
 use std::ops::Deref;
 use std::sync::atomic::Ordering;
@@ -152,6 +152,10 @@ impl GlDisplay for Display {
         surface_attributes: &SurfaceAttributes<PixmapSurface>,
     ) -> Result<Self::PixmapSurface> {
         unsafe { Self::create_pixmap_surface(self, config, surface_attributes) }
+    }
+
+    fn get_proc_address(&self, addr: &CStr) -> *const ffi::c_void {
+        unsafe { self.inner.glx.GetProcAddress(addr.as_ptr() as *const _) as *const _ }
     }
 }
 

--- a/glutin/src/api/wgl/context.rs
+++ b/glutin/src/api/wgl/context.rs
@@ -1,6 +1,5 @@
 //! WGL context handling.
 
-use std::ffi::{self, CStr};
 use std::fmt;
 use std::io::Error as IoError;
 use std::marker::PhantomData;
@@ -11,7 +10,6 @@ use glutin_wgl_sys::wgl::types::HGLRC;
 use glutin_wgl_sys::{wgl, wgl_extra};
 use raw_window_handle::RawWindowHandle;
 use windows_sys::Win32::Graphics::Gdi::{self as gdi, HDC};
-use windows_sys::Win32::System::LibraryLoader as dll_loader;
 
 use crate::config::GetGlConfig;
 use crate::context::{
@@ -292,19 +290,6 @@ impl PossiblyCurrentGlContext for PossiblyCurrentContext {
 
     fn is_current(&self) -> bool {
         unsafe { wgl::GetCurrentContext() == *self.inner.raw }
-    }
-
-    fn get_proc_address(&self, addr: &CStr) -> *const ffi::c_void {
-        unsafe {
-            let addr = addr.as_ptr();
-            let fn_ptr = wgl::GetProcAddress(addr);
-            if !fn_ptr.is_null() {
-                fn_ptr.cast()
-            } else {
-                dll_loader::GetProcAddress(self.inner.display.inner.lib_opengl32, addr.cast())
-                    .map_or(std::ptr::null(), |fn_ptr| fn_ptr as *const _)
-            }
-        }
     }
 }
 

--- a/glutin/src/context.rs
+++ b/glutin/src/context.rs
@@ -1,7 +1,7 @@
 //! OpenGL context creation and initialization.
 
 #![allow(unreachable_patterns)]
-use std::ffi::{self, CStr};
+use std::ffi::{self};
 
 use raw_window_handle::RawWindowHandle;
 
@@ -77,10 +77,6 @@ pub trait PossiblyCurrentGlContext: Sealed {
     /// [`Self::NotCurrentContext`] to indicate that the context is a not
     /// current to allow sending it to the different thread.
     fn make_not_current(self) -> Result<Self::NotCurrentContext>;
-
-    /// Returns the address of an OpenGL function. The context must be current
-    /// when doing so.
-    fn get_proc_address(&self, addr: &CStr) -> *const ffi::c_void;
 }
 
 /// A trait that splits the methods accessing [`crate::surface::Surface`].
@@ -505,10 +501,6 @@ impl PossiblyCurrentGlContext for PossiblyCurrentContext {
         Ok(
             gl_api_dispatch!(self; Self(context) => context.make_not_current()?; as NotCurrentContext),
         )
-    }
-
-    fn get_proc_address(&self, addr: &CStr) -> *const ffi::c_void {
-        gl_api_dispatch!(self; Self(context) => context.get_proc_address(addr))
     }
 }
 

--- a/glutin/src/display.rs
+++ b/glutin/src/display.rs
@@ -108,7 +108,7 @@ pub trait GlDisplay: Sealed {
     ///
     /// # Api-specific
     ///
-    /// **WGL:** - To load all the funcitons you must have a current context on
+    /// **WGL:** - To load all the functions you must have a current context on
     /// the calling thread, otherwise only limited set of functions will be
     /// loaded.
     fn get_proc_address(&self, addr: &CStr) -> *const ffi::c_void;

--- a/glutin/src/display.rs
+++ b/glutin/src/display.rs
@@ -1,6 +1,7 @@
 //! The OpenGL platform display selection and creation.
 #![allow(unreachable_patterns)]
 
+use std::ffi::{self, CStr};
 use std::fmt;
 
 use raw_window_handle::RawDisplayHandle;
@@ -102,6 +103,15 @@ pub trait GlDisplay: Sealed {
         config: &Self::Config,
         surface_attributes: &SurfaceAttributes<PixmapSurface>,
     ) -> Result<Self::PixmapSurface>;
+
+    /// Return the address of an OpenGL function.
+    ///
+    /// # Api-specific
+    ///
+    /// **WGL:** - To load all the funcitons you must have a current context on
+    /// the calling thread, otherwise only limited set of functions will be
+    /// loaded.
+    fn get_proc_address(&self, addr: &CStr) -> *const ffi::c_void;
 }
 
 /// Get the [`Display`].
@@ -349,6 +359,10 @@ impl GlDisplay for Display {
             },
             _ => unreachable!(),
         }
+    }
+
+    fn get_proc_address(&self, addr: &CStr) -> *const ffi::c_void {
+        gl_api_dispatch!(self; Self(display) => display.get_proc_address(addr))
     }
 }
 

--- a/glutin_examples/examples/window.rs
+++ b/glutin_examples/examples/window.rs
@@ -48,9 +48,12 @@ fn main() {
     // Make it current and load symbols.
     let gl_context = gl_context.make_current(&gl_window.surface).unwrap();
 
+    // WGL requires current context on the calling thread to load symbols properly,
+    // so the call here is for portability reasons. In case you don't target WGL
+    // you can call it right after display creation.
     gl::load_with(|symbol| {
         let symbol = CString::new(symbol).unwrap();
-        gl_context.get_proc_address(symbol.as_c_str()) as *const _
+        gl_display.get_proc_address(symbol.as_c_str()) as *const _
     });
 
     // Try setting vsync.


### PR DESCRIPTION
This should made it clear that you should call this only once and not on each context creation.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
