### PR TITLE
Move to `objc2`

### DIFF
--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -51,9 +51,8 @@ x11-dl = { version = "2.20.0", optional = true }
 
 [target.'cfg(any(target_os = "macos"))'.dependencies]
 cgl = "0.3.2"
-cocoa = "0.24.0"
 core-foundation = "0.9.3"
-objc = "0.2.7"
+objc2 = "=0.3.0-beta.3"
 
 [build-dependencies]
 cfg_aliases = "0.1.1"

--- a/glutin/src/api/cgl/appkit.rs
+++ b/glutin/src/api/cgl/appkit.rs
@@ -1,0 +1,171 @@
+//! The parts of AppKit related to OpenGL.
+//!
+//! TODO: Move this to another crate.
+#![allow(dead_code)]
+#![allow(non_snake_case)]
+use objc2::encode::{Encoding, RefEncode};
+use objc2::foundation::{NSInteger, NSObject};
+use objc2::rc::{Id, Shared};
+use objc2::{extern_class, extern_methods, msg_send_id, ClassType};
+
+pub type GLint = i32;
+
+pub enum CGLContextObj {}
+
+unsafe impl RefEncode for CGLContextObj {
+    const ENCODING_REF: Encoding = Encoding::Pointer(&Encoding::Struct("_CGLContextObject", &[]));
+}
+
+extern_class!(
+    #[derive(Debug, PartialEq, Eq, Hash)]
+    pub(crate) struct NSOpenGLContext;
+
+    unsafe impl ClassType for NSOpenGLContext {
+        type Super = NSObject;
+    }
+);
+
+unsafe impl Send for NSOpenGLContext {}
+unsafe impl Sync for NSOpenGLContext {}
+
+extern_methods!(
+    unsafe impl NSOpenGLContext {
+        pub(crate) fn currentContext() -> Option<Id<Self, Shared>> {
+            unsafe { msg_send_id![Self::class(), currentContext] }
+        }
+
+        pub(crate) fn newWithFormat_shareContext(
+            format: &NSOpenGLPixelFormat,
+            share: Option<&NSOpenGLContext>,
+        ) -> Option<Id<Self, Shared>> {
+            unsafe {
+                msg_send_id![
+                    msg_send_id![Self::class(), alloc],
+                    initWithFormat: format,
+                    shareContext: share,
+                ]
+            }
+        }
+
+        #[sel(clearCurrentContext)]
+        pub(crate) fn clearCurrentContext();
+
+        #[sel(makeCurrentContext)]
+        pub(crate) fn makeCurrentContext(&self);
+
+        #[sel(update)]
+        pub(crate) fn update(&self);
+
+        #[sel(flushBuffer)]
+        pub(crate) fn flushBuffer(&self);
+
+        pub(crate) fn view(&self) -> Option<Id<NSObject, Shared>> {
+            unsafe { msg_send_id![self, view] }
+        }
+
+        #[sel(setView:)]
+        pub(crate) unsafe fn setView(&self, view: Option<&NSObject>);
+
+        #[sel(setValues:forParameter:)]
+        pub(crate) unsafe fn setValues_forParameter(
+            &self,
+            vals: *const GLint,
+            param: NSOpenGLContextParameter,
+        );
+
+        #[sel(CGLContextObj)]
+        pub(crate) fn CGLContextObj(&self) -> *mut CGLContextObj;
+    }
+);
+
+extern_class!(
+    #[derive(Debug, PartialEq, Eq, Hash)]
+    pub(crate) struct NSOpenGLPixelFormat;
+
+    unsafe impl ClassType for NSOpenGLPixelFormat {
+        type Super = NSObject;
+    }
+);
+
+unsafe impl Send for NSOpenGLPixelFormat {}
+unsafe impl Sync for NSOpenGLPixelFormat {}
+
+extern_methods!(
+    unsafe impl NSOpenGLPixelFormat {
+        pub(crate) unsafe fn newWithAttributes(
+            attrs: &[NSOpenGLPixelFormatAttribute],
+        ) -> Option<Id<Self, Shared>> {
+            unsafe {
+                msg_send_id![
+                    msg_send_id![Self::class(), alloc],
+                    initWithAttributes: attrs.as_ptr(),
+                ]
+            }
+        }
+
+        #[sel(getValues:forAttribute:forVirtualScreen:)]
+        pub(crate) unsafe fn getValues_forAttribute_forVirtualScreen(
+            &self,
+            vals: *mut GLint,
+            param: NSOpenGLPixelFormatAttribute,
+            screen: GLint,
+        );
+    }
+);
+
+type NSOpenGLContextParameter = NSInteger;
+pub(crate) const NSOpenGLCPSwapInterval: NSOpenGLContextParameter = 222;
+pub(crate) const NSOpenGLCPSurfaceOrder: NSOpenGLContextParameter = 235;
+pub(crate) const NSOpenGLCPSurfaceOpacity: NSOpenGLContextParameter = 236;
+pub(crate) const NSOpenGLCPSurfaceBackingSize: NSOpenGLContextParameter = 304;
+pub(crate) const NSOpenGLCPReclaimResources: NSOpenGLContextParameter = 308;
+pub(crate) const NSOpenGLCPCurrentRendererID: NSOpenGLContextParameter = 309;
+pub(crate) const NSOpenGLCPGPUVertexProcessing: NSOpenGLContextParameter = 310;
+pub(crate) const NSOpenGLCPGPUFragmentProcessing: NSOpenGLContextParameter = 311;
+pub(crate) const NSOpenGLCPHasDrawable: NSOpenGLContextParameter = 314;
+pub(crate) const NSOpenGLCPMPSwapsInFlight: NSOpenGLContextParameter = 315;
+
+pub(crate) type NSOpenGLPixelFormatAttribute = u32;
+pub(crate) const NSOpenGLPFAAllRenderers: NSOpenGLPixelFormatAttribute = 1;
+pub(crate) const NSOpenGLPFATripleBuffer: NSOpenGLPixelFormatAttribute = 3;
+pub(crate) const NSOpenGLPFADoubleBuffer: NSOpenGLPixelFormatAttribute = 5;
+pub(crate) const NSOpenGLPFAStereo: NSOpenGLPixelFormatAttribute = 6;
+pub(crate) const NSOpenGLPFAAuxBuffers: NSOpenGLPixelFormatAttribute = 7;
+pub(crate) const NSOpenGLPFAColorSize: NSOpenGLPixelFormatAttribute = 8;
+pub(crate) const NSOpenGLPFAAlphaSize: NSOpenGLPixelFormatAttribute = 11;
+pub(crate) const NSOpenGLPFADepthSize: NSOpenGLPixelFormatAttribute = 12;
+pub(crate) const NSOpenGLPFAStencilSize: NSOpenGLPixelFormatAttribute = 13;
+pub(crate) const NSOpenGLPFAAccumSize: NSOpenGLPixelFormatAttribute = 14;
+pub(crate) const NSOpenGLPFAMinimumPolicy: NSOpenGLPixelFormatAttribute = 51;
+pub(crate) const NSOpenGLPFAMaximumPolicy: NSOpenGLPixelFormatAttribute = 52;
+pub(crate) const NSOpenGLPFAOffScreen: NSOpenGLPixelFormatAttribute = 53;
+pub(crate) const NSOpenGLPFAFullScreen: NSOpenGLPixelFormatAttribute = 54;
+pub(crate) const NSOpenGLPFASampleBuffers: NSOpenGLPixelFormatAttribute = 55;
+pub(crate) const NSOpenGLPFASamples: NSOpenGLPixelFormatAttribute = 56;
+pub(crate) const NSOpenGLPFAAuxDepthStencil: NSOpenGLPixelFormatAttribute = 57;
+pub(crate) const NSOpenGLPFAColorFloat: NSOpenGLPixelFormatAttribute = 58;
+pub(crate) const NSOpenGLPFAMultisample: NSOpenGLPixelFormatAttribute = 59;
+pub(crate) const NSOpenGLPFASupersample: NSOpenGLPixelFormatAttribute = 60;
+pub(crate) const NSOpenGLPFASampleAlpha: NSOpenGLPixelFormatAttribute = 61;
+pub(crate) const NSOpenGLPFARendererID: NSOpenGLPixelFormatAttribute = 70;
+pub(crate) const NSOpenGLPFASingleRenderer: NSOpenGLPixelFormatAttribute = 71;
+pub(crate) const NSOpenGLPFANoRecovery: NSOpenGLPixelFormatAttribute = 72;
+pub(crate) const NSOpenGLPFAAccelerated: NSOpenGLPixelFormatAttribute = 73;
+pub(crate) const NSOpenGLPFAClosestPolicy: NSOpenGLPixelFormatAttribute = 74;
+pub(crate) const NSOpenGLPFARobust: NSOpenGLPixelFormatAttribute = 75;
+pub(crate) const NSOpenGLPFABackingStore: NSOpenGLPixelFormatAttribute = 76;
+pub(crate) const NSOpenGLPFAMPSafe: NSOpenGLPixelFormatAttribute = 78;
+pub(crate) const NSOpenGLPFAWindow: NSOpenGLPixelFormatAttribute = 80;
+pub(crate) const NSOpenGLPFAMultiScreen: NSOpenGLPixelFormatAttribute = 81;
+pub(crate) const NSOpenGLPFACompliant: NSOpenGLPixelFormatAttribute = 83;
+pub(crate) const NSOpenGLPFAScreenMask: NSOpenGLPixelFormatAttribute = 84;
+pub(crate) const NSOpenGLPFAPixelBuffer: NSOpenGLPixelFormatAttribute = 90;
+pub(crate) const NSOpenGLPFARemotePixelBuffer: NSOpenGLPixelFormatAttribute = 91;
+pub(crate) const NSOpenGLPFAAllowOfflineRenderers: NSOpenGLPixelFormatAttribute = 96;
+pub(crate) const NSOpenGLPFAAcceleratedCompute: NSOpenGLPixelFormatAttribute = 97;
+pub(crate) const NSOpenGLPFAOpenGLProfile: NSOpenGLPixelFormatAttribute = 99;
+pub(crate) const NSOpenGLPFAVirtualScreenCount: NSOpenGLPixelFormatAttribute = 128;
+// OpenGL Profiles
+pub(crate) const NSOpenGLProfileVersionLegacy: NSOpenGLPixelFormatAttribute = 0x1000;
+pub(crate) const NSOpenGLProfileVersion3_2Core: NSOpenGLPixelFormatAttribute = 0x3200;
+pub(crate) const NSOpenGLProfileVersion4_1Core: NSOpenGLPixelFormatAttribute = 0x4100;

--- a/glutin/src/api/cgl/mod.rs
+++ b/glutin/src/api/cgl/mod.rs
@@ -10,6 +10,7 @@ use cgl::{kCGLNoError, CGLError, CGLErrorString};
 
 use crate::error::{Error, ErrorKind, Result};
 
+mod appkit;
 pub mod config;
 pub mod context;
 pub mod display;

--- a/glutin/src/lib.rs
+++ b/glutin/src/lib.rs
@@ -35,10 +35,6 @@ pub mod surface;
 #[cfg(any(egl_backend, glx_backend))]
 mod lib_loading;
 
-#[cfg(cgl_backend)]
-#[macro_use]
-extern crate objc;
-
 pub(crate) mod private {
     /// Prevent traits from being implemented downstream, since those are used
     /// purely for documentation organization and simplify platform api

--- a/glutin_gles2_sys/Cargo.toml
+++ b/glutin_gles2_sys/Cargo.toml
@@ -11,6 +11,3 @@ edition = "2021"
 
 [build-dependencies]
 gl_generator = "0.14"
-
-[target.'cfg(target_os = "ios")'.dependencies]
-objc = "0.2.7"

--- a/glutin_gles2_sys/src/lib.rs
+++ b/glutin_gles2_sys/src/lib.rs
@@ -8,85 +8,35 @@ pub mod gles {
     include!(concat!(env!("OUT_DIR"), "/gles2_bindings.rs"));
 }
 
-use objc::runtime::Object;
-use objc::{Encode, Encoding};
-
 use std::os::raw;
 
-pub type id = *mut Object;
-pub const nil: id = 0 as id;
+pub const UIViewAutoresizingFlexibleWidth: usize = 1 << 1;
+pub const UIViewAutoresizingFlexibleHeight: usize = 1 << 4;
 
-pub const UIViewAutoresizingFlexibleWidth: NSUInteger = 1 << 1;
-pub const UIViewAutoresizingFlexibleHeight: NSUInteger = 1 << 4;
+pub const GLKViewDrawableColorFormatRGBA8888: gles::types::GLint = 0;
+pub const GLKViewDrawableColorFormatRGB565: gles::types::GLint = 1;
+pub const GLKViewDrawableColorFormatSRGBA8888: gles::types::GLint = 2;
 
-#[cfg(target_pointer_width = "32")]
-pub type CGFloat = f32;
-#[cfg(target_pointer_width = "64")]
-pub type CGFloat = f64;
+pub const GLKViewDrawableDepthFormatNone: gles::types::GLint = 0;
+pub const GLKViewDrawableDepthFormat16: gles::types::GLint = 1;
+pub const GLKViewDrawableDepthFormat24: gles::types::GLint = 2;
 
-#[cfg(target_pointer_width = "32")]
-pub type NSUInteger = u32;
-#[cfg(target_pointer_width = "64")]
-pub type NSUInteger = u64;
+pub const GLKViewDrawableStencilFormatNone: gles::types::GLint = 0;
+pub const GLKViewDrawableStencilFormat8: gles::types::GLint = 1;
 
-#[repr(C)]
-#[derive(Debug, Clone)]
-pub struct CGPoint {
-    pub x: CGFloat,
-    pub y: CGFloat,
-}
+pub const GLKViewDrawableMultisampleNone: gles::types::GLint = 0;
+pub const GLKViewDrawableMultisample4X: gles::types::GLint = 1;
 
-#[repr(C)]
-#[derive(Debug, Clone)]
-pub struct CGRect {
-    pub origin: CGPoint,
-    pub size: CGSize,
-}
-
-unsafe impl Encode for CGRect {
-    fn encode() -> Encoding {
-        #[cfg(target_pointer_width = "32")]
-        unsafe {
-            Encoding::from_str("{CGRect={CGPoint=ff}{CGSize=ff}}")
-        }
-        #[cfg(target_pointer_width = "64")]
-        unsafe {
-            Encoding::from_str("{CGRect={CGPoint=dd}{CGSize=dd}}")
-        }
-    }
-}
-
-#[repr(C)]
-#[derive(Debug, Clone)]
-pub struct CGSize {
-    pub width: CGFloat,
-    pub height: CGFloat,
-}
-
-pub const GLKViewDrawableColorFormatRGBA8888: NSUInteger = 0;
-pub const GLKViewDrawableColorFormatRGB565: NSUInteger = 1;
-pub const GLKViewDrawableColorFormatSRGBA8888: NSUInteger = 2;
-
-pub const GLKViewDrawableDepthFormatNone: NSUInteger = 0;
-pub const GLKViewDrawableDepthFormat16: NSUInteger = 1;
-pub const GLKViewDrawableDepthFormat24: NSUInteger = 2;
-
-pub const GLKViewDrawableStencilFormatNone: NSUInteger = 0;
-pub const GLKViewDrawableStencilFormat8: NSUInteger = 1;
-
-pub const GLKViewDrawableMultisampleNone: NSUInteger = 0;
-pub const GLKViewDrawableMultisample4X: NSUInteger = 1;
-
-pub const kEAGLRenderingAPIOpenGLES1: NSUInteger = 1;
+pub const kEAGLRenderingAPIOpenGLES1: usize = 1;
 #[allow(dead_code)]
-pub const kEAGLRenderingAPIOpenGLES2: NSUInteger = 2;
-pub const kEAGLRenderingAPIOpenGLES3: NSUInteger = 3;
+pub const kEAGLRenderingAPIOpenGLES2: usize = 2;
+pub const kEAGLRenderingAPIOpenGLES3: usize = 3;
 
 extern "C" {
-    pub static kEAGLColorFormatRGB565: id;
-    // pub static kEAGLColorFormatRGBA8: id;
-    pub static kEAGLDrawablePropertyColorFormat: id;
-    pub static kEAGLDrawablePropertyRetainedBacking: id;
+    pub static kEAGLColorFormatRGB565: *const raw::c_void;
+    // pub static kEAGLColorFormatRGBA8: *const raw::c_void;
+    pub static kEAGLDrawablePropertyColorFormat: *const raw::c_void;
+    pub static kEAGLDrawablePropertyRetainedBacking: *const raw::c_void;
 }
 
 pub const RTLD_LAZY: raw::c_int = 0x001;


### PR DESCRIPTION
Helps with following Cocoa's memory management rules (for example, https://github.com/rust-windowing/glutin/pull/1453 wouldn't have happened with this) - and while I was at it, I fixed a few C `enum` definitions (`objc2`'s `verify_message` feature is a great help with that).

See commit messages for details.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
