### PR TITLE
fix(api): multisampling requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - `Config` doesn't force OpenGL `Api` by default.
 - `Display::create_context` now uses the most recent available `Api` from the `Config` when `ContextApi` is not specified in `ContextAttributes`.
 - `PossiblyCurrentGlContext::get_proc_address` method was moved to `GlDisplay::get_proc_address`.
+- `ConfigTemplateBuilder::with_sample_buffers` now called `ConfigTemplateBuilder::with_multisampling`.
+- `GlConfig::sample_buffers` now called `GlConfig::num_samples` and returns the amount of samples in multisample buffer.
 
 # Version 0.30.0-beta.2 (2022-09-03)
 

--- a/glutin/src/api/cgl/config.rs
+++ b/glutin/src/api/cgl/config.rs
@@ -59,10 +59,12 @@ impl Display {
         }
 
         // Sample buffers.
-        if template.sample_buffers != 0 {
+        if let Some(num_samples) = template.num_samples {
             attrs.push(NSOpenGLPixelFormatAttribute::NSOpenGLPFAMultisample as u32);
             attrs.push(NSOpenGLPixelFormatAttribute::NSOpenGLPFASampleBuffers as u32);
-            attrs.push(template.sample_buffers as u32);
+            attrs.push(1);
+            attrs.push(NSOpenGLPixelFormatAttribute::NSOpenGLPFASamples as u32);
+            attrs.push(num_samples as u32);
         }
 
         // Double buffering.
@@ -162,8 +164,8 @@ impl GlConfig for Config {
         self.raw_attribute(NSOpenGLPixelFormatAttribute::NSOpenGLPFAStencilSize) as u8
     }
 
-    fn sample_buffers(&self) -> u8 {
-        self.raw_attribute(NSOpenGLPixelFormatAttribute::NSOpenGLPFASampleBuffers) as u8
+    fn num_samples(&self) -> u8 {
+        self.raw_attribute(NSOpenGLPixelFormatAttribute::NSOpenGLPFASamples) as u8
     }
 
     fn config_surface_types(&self) -> ConfigSurfaceTypes {

--- a/glutin/src/api/egl/config.rs
+++ b/glutin/src/api/egl/config.rs
@@ -115,9 +115,13 @@ impl Display {
             config_attributes.push(max_swap_interval as EGLint)
         }
 
-        // Add samples.
-        config_attributes.push(egl::SAMPLE_BUFFERS as EGLint);
-        config_attributes.push(template.sample_buffers as EGLint);
+        // Add multisampling.
+        if let Some(num_samples) = template.num_samples {
+            config_attributes.push(egl::SAMPLE_BUFFERS as EGLint);
+            config_attributes.push(1);
+            config_attributes.push(egl::SAMPLES as EGLint);
+            config_attributes.push(num_samples as EGLint);
+        }
 
         if let Some(requested_api) = template.api {
             let mut api = 0;
@@ -289,8 +293,8 @@ impl GlConfig for Config {
         unsafe { self.raw_attribute(egl::STENCIL_SIZE as EGLint) as u8 }
     }
 
-    fn sample_buffers(&self) -> u8 {
-        unsafe { self.raw_attribute(egl::SAMPLE_BUFFERS as EGLint) as u8 }
+    fn num_samples(&self) -> u8 {
+        unsafe { self.raw_attribute(egl::SAMPLES as EGLint) as u8 }
     }
 
     fn config_surface_types(&self) -> ConfigSurfaceTypes {

--- a/glutin/src/api/glx/config.rs
+++ b/glutin/src/api/glx/config.rs
@@ -134,12 +134,16 @@ impl Display {
             config_attributes.push(stereoscopy as c_int);
         }
 
-        // Add multisampling if supported.
-        if self.inner.version >= Version::new(1, 4)
-            || self.inner.client_extensions.contains("GLX_ARB_multisample")
-        {
-            config_attributes.push(glx::SAMPLE_BUFFERS as c_int);
-            config_attributes.push(template.sample_buffers as c_int);
+        // Add multisampling.
+        if let Some(num_samples) = template.num_samples {
+            if self.inner.version >= Version::new(1, 4)
+                || self.inner.client_extensions.contains("GLX_ARB_multisample")
+            {
+                config_attributes.push(glx::SAMPLE_BUFFERS as c_int);
+                config_attributes.push(1);
+                config_attributes.push(glx::SAMPLES as c_int);
+                config_attributes.push(num_samples as c_int);
+            }
         }
 
         // Push `glx::NONE` to terminate the list.
@@ -262,8 +266,8 @@ impl GlConfig for Config {
         unsafe { self.raw_attribute(glx::STENCIL_SIZE as c_int) as u8 }
     }
 
-    fn sample_buffers(&self) -> u8 {
-        unsafe { self.raw_attribute(glx::SAMPLE_BUFFERS as c_int) as u8 }
+    fn num_samples(&self) -> u8 {
+        unsafe { self.raw_attribute(glx::SAMPLES as c_int) as u8 }
     }
 
     fn config_surface_types(&self) -> ConfigSurfaceTypes {

--- a/glutin/src/api/wgl/config.rs
+++ b/glutin/src/api/wgl/config.rs
@@ -204,11 +204,13 @@ impl Display {
             wgl_extra::TYPE_RGBA_ARB
         };
 
-        if self.inner.client_extensions.contains(MULTI_SAMPLE_ARB) {
-            attrs.push(wgl_extra::SAMPLE_BUFFERS_ARB as c_int);
-            attrs.push((template.sample_buffers != 0) as c_int);
-            attrs.push(wgl_extra::SAMPLES_ARB as c_int);
-            attrs.push(template.sample_buffers as c_int);
+        if let Some(num_samples) = template.num_samples {
+            if self.inner.client_extensions.contains(MULTI_SAMPLE_ARB) {
+                attrs.push(wgl_extra::SAMPLE_BUFFERS_ARB as c_int);
+                attrs.push(1);
+                attrs.push(wgl_extra::SAMPLES_ARB as c_int);
+                attrs.push(num_samples as c_int);
+            }
         }
 
         attrs.push(wgl_extra::PIXEL_TYPE_ARB as c_int);
@@ -389,7 +391,7 @@ impl GlConfig for Config {
         }
     }
 
-    fn sample_buffers(&self) -> u8 {
+    fn num_samples(&self) -> u8 {
         if self.inner.display.inner.client_extensions.contains(MULTI_SAMPLE_ARB) {
             unsafe { self.raw_attribute(wgl_extra::SAMPLES_ARB as c_int) as _ }
         } else {


### PR DESCRIPTION
We were asking for sample buffers, but not samples per buffer, which is what required for AA and used.

Fixes #1462.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
