### PR TITLE
Bump MSRV to 1.60

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust_version: [1.57.0, stable, nightly]
+        rust_version: [1.60.0, stable, nightly]
         platform:
           - { target: x86_64-pc-windows-msvc,   os: windows-latest,  }
           - { target: i686-pc-windows-msvc,     os: windows-latest,  }
@@ -100,6 +100,6 @@ jobs:
 
     - name: Lint with clippy
       shell: bash
-      if: (matrix.rust_version == '1.57.0') && !contains(matrix.platform.options, '--no-default-features')
+      if: (matrix.rust_version == '1.60.0') && !contains(matrix.platform.options, '--no-default-features')
       run: cargo clippy --workspace --all-targets --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES -- -Dwarnings
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `PossiblyCurrentGlContext::get_proc_address` method was moved to `GlDisplay::get_proc_address`.
 - `ConfigTemplateBuilder::with_sample_buffers` now called `ConfigTemplateBuilder::with_multisampling`.
 - `GlConfig::sample_buffers` now called `GlConfig::num_samples` and returns the amount of samples in multisample buffer.
+- **Breaking:** Bump MSRV from `1.57` to `1.60`.
 
 # Version 0.30.0-beta.2 (2022-09-03)
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Note that glutin aims at being a low-level brick in your rendering
 infrastructure. You are encouraged to write another layer of abstraction
 between glutin and your application.
 
-The minimum rust version target by glutin is `1.57.0`.
+The minimum rust version target by glutin is `1.60.0`.
 
 ## Platform-specific notes
 

--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-windowing/glutin"
 documentation = "https://docs.rs/glutin"
-rust-version = "1.57.0"
+rust-version = "1.60.0"
 edition = "2021"
 
 [features]

--- a/glutin/src/api/cgl/mod.rs
+++ b/glutin/src/api/cgl/mod.rs
@@ -1,6 +1,7 @@
 //! The CGL Api.
 
 #![allow(non_upper_case_globals)]
+#![allow(clippy::let_unit_value)] // Temporary
 
 use std::ffi::CStr;
 use std::os::raw::c_int;

--- a/glutin_egl_sys/Cargo.toml
+++ b/glutin_egl_sys/Cargo.toml
@@ -6,7 +6,7 @@ description = "The egl bindings for glutin"
 repository = "https://github.com/rust-windowing/glutin"
 license = "Apache-2.0"
 readme = "README.md"
-rust-version = "1.57.0"
+rust-version = "1.60.0"
 edition = "2021"
 
 [build-dependencies]

--- a/glutin_examples/Cargo.toml
+++ b/glutin_examples/Cargo.toml
@@ -6,7 +6,7 @@ description = "Examples for glutin"
 repository = "https://github.com/rust-windowing/glutin"
 license = "Apache-2.0"
 readme = "../README.md"
-rust-version = "1.57.0"
+rust-version = "1.60.0"
 edition = "2021"
 publish = false
 

--- a/glutin_gles2_sys/Cargo.toml
+++ b/glutin_gles2_sys/Cargo.toml
@@ -6,7 +6,7 @@ description = "The gles2 bindings for glutin"
 repository = "https://github.com/rust-windowing/glutin"
 license = "Apache-2.0"
 readme = "README.md"
-rust-version = "1.57.0"
+rust-version = "1.60.0"
 edition = "2021"
 
 [build-dependencies]

--- a/glutin_glx_sys/Cargo.toml
+++ b/glutin_glx_sys/Cargo.toml
@@ -6,7 +6,7 @@ description = "The glx bindings for glutin"
 repository = "https://github.com/rust-windowing/glutin"
 license = "Apache-2.0"
 readme = "README.md"
-rust-version = "1.57.0"
+rust-version = "1.60.0"
 edition = "2021"
 
 [build-dependencies]

--- a/glutin_wgl_sys/Cargo.toml
+++ b/glutin_wgl_sys/Cargo.toml
@@ -6,7 +6,7 @@ description = "The wgl bindings for glutin"
 repository = "https://github.com/rust-windowing/glutin"
 license = "Apache-2.0"
 readme = "README.md"
-rust-version = "1.57.0"
+rust-version = "1.60.0"
 edition = "2021"
 
 [build-dependencies]


### PR DESCRIPTION
Required by https://github.com/rust-windowing/glutin/pull/1461

- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
