### PR TITLE
example: make example more complex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - `ConfigTemplateBuilder::with_sample_buffers` now called `ConfigTemplateBuilder::with_multisampling`.
 - `GlConfig::sample_buffers` now called `GlConfig::num_samples` and returns the amount of samples in multisample buffer.
 - **Breaking:** Bump MSRV from `1.57` to `1.60`.
+- Fix `GlProfile::Core` requesting without explicit version.
+- Pick the latest available profile on macOS.
+- When using `ContextApi::Gles(None)` in `ContextAttributesBuilder` the latest known supported `major` ES version will be picked.
 
 # Version 0.30.0-beta.2 (2022-09-03)
 

--- a/glutin/src/context.rs
+++ b/glutin/src/context.rs
@@ -176,7 +176,7 @@ impl ContextAttributesBuilder {
     ///
     /// # Api-specific
     ///
-    /// **macOS:** - not supported.
+    /// **macOS:** - not supported, the latest is picked automatically.
     ///
     /// [`GlProfile`]: crate::context::GlProfile
     pub fn with_profile(mut self, profile: GlProfile) -> Self {
@@ -186,7 +186,7 @@ impl ContextAttributesBuilder {
 
     /// Set the desired OpenGL context api. See the docs of [`ContextApi`].
     ///
-    /// By default the lastest supported by the config is picked.
+    /// By default the supported api will be picked.
     ///
     /// [`ContextApi`]: crate::context::ContextApi
     pub fn with_context_api(mut self, api: ContextApi) -> Self {
@@ -268,6 +268,8 @@ impl Default for Robustness {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GlProfile {
     /// Include all the future-compatible functions and definitions.
+    ///
+    /// The requested OpenGL version with [`ContextApi`] should be at least 3.3.
     Core,
     /// Include all the immediate more functions and definitions.
     ///
@@ -280,16 +282,20 @@ pub enum GlProfile {
 pub enum ContextApi {
     /// OpenGL Api version that should be used by the context.
     ///
-    /// When using `None` as a `ApiVersion` any OpenGl context will be picked.
+    /// When using `None` as `Version` any OpenGL context will be picked,
+    /// however when the [`GlProfile::Core`] is used at least 3.3 will be
+    /// requested.
     OpenGl(Option<Version>),
 
     /// OpenGL Api version that should be used by the context.
     ///
-    /// When using `None` as a `ApiVersion` any Gles context will be picked.
+    /// When using `None` as `Version` the latest **known** major version is
+    /// picked. Versions that are higher than what was picked automatically
+    /// could still be supported.
     Gles(Option<Version>),
 }
 
-#[cfg(any(glx_backend, wgl_backend))]
+#[cfg(any(egl_backend, glx_backend, wgl_backend))]
 impl ContextApi {
     pub(crate) fn version(&self) -> Option<Version> {
         match self {
@@ -317,7 +323,7 @@ pub struct Version {
 
 impl Version {
     /// Create new version with the given `major` and `minor` values.
-    pub fn new(major: u8, minor: u8) -> Self {
+    pub const fn new(major: u8, minor: u8) -> Self {
         Self { major, minor }
     }
 }

--- a/glutin_examples/build.rs
+++ b/glutin_examples/build.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 use std::path::PathBuf;
 
 use cfg_aliases::cfg_aliases;
-use gl_generator::{Api, Fallbacks, GlobalGenerator, Profile, Registry};
+use gl_generator::{Api, Fallbacks, Profile, Registry, StructGenerator};
 
 fn main() {
     // XXX this is taken from glutin/build.rs.
@@ -34,7 +34,7 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
     let mut file = File::create(&dest.join("gl_bindings.rs")).unwrap();
-    Registry::new(Api::Gl, (3, 3), Profile::Core, Fallbacks::All, [])
-        .write_bindings(GlobalGenerator, &mut file)
+    Registry::new(Api::Gles2, (3, 0), Profile::Core, Fallbacks::All, [])
+        .write_bindings(StructGenerator, &mut file)
         .unwrap();
 }

--- a/glutin_examples/examples/support/mod.rs
+++ b/glutin_examples/examples/support/mod.rs
@@ -2,6 +2,7 @@
 #![allow(dead_code)]
 #![allow(unused_variables)]
 
+use std::ffi::{CStr, CString};
 use std::num::NonZeroU32;
 
 use raw_window_handle::{HasRawWindowHandle, RawDisplayHandle, RawWindowHandle};
@@ -19,6 +20,8 @@ use glutin::surface::{Surface, SurfaceAttributes, SurfaceAttributesBuilder, Wind
 pub mod gl {
     #![allow(clippy::all)]
     include!(concat!(env!("OUT_DIR"), "/gl_bindings.rs"));
+
+    pub use Gles2 as Gl;
 }
 
 /// Structure to hold winit window and gl surface.
@@ -44,12 +47,15 @@ impl GlWindow {
 
 /// Create template to find OpenGL config.
 pub fn config_template(raw_window_handle: RawWindowHandle) -> ConfigTemplate {
-    ConfigTemplateBuilder::new()
+    let builder = ConfigTemplateBuilder::new()
         .with_alpha_size(8)
-        .with_transparency(true)
         .compatible_with_native_window(raw_window_handle)
-        .with_surface_type(ConfigSurfaceTypes::WINDOW)
-        .build()
+        .with_surface_type(ConfigSurfaceTypes::WINDOW);
+
+    #[cfg(cgl_backend)]
+    let builder = builder.with_transparency(true).with_multisampling(8);
+
+    builder.build()
 }
 
 /// Create surface attributes for window surface.
@@ -89,3 +95,164 @@ pub fn create_display(
     // Create connection to underlying OpenGL client Api.
     unsafe { Display::from_raw(raw_display, preference).unwrap() }
 }
+
+pub struct Renderer {
+    program: gl::types::GLuint,
+    vao: gl::types::GLuint,
+    vbo: gl::types::GLuint,
+    gl: gl::Gl,
+}
+
+impl Renderer {
+    pub fn new(gl_display: &Display) -> Self {
+        unsafe {
+            let gl = gl::Gl::load_with(|symbol| {
+                let symbol = CString::new(symbol).unwrap();
+                gl_display.get_proc_address(symbol.as_c_str()).cast()
+            });
+
+            if let Some(renderer) = get_gl_string(&gl, gl::RENDERER) {
+                println!("Running on {}", renderer.to_string_lossy());
+            }
+            if let Some(version) = get_gl_string(&gl, gl::VERSION) {
+                println!("OpenGL Version {}", version.to_string_lossy());
+            }
+
+            if let Some(shaders_version) = get_gl_string(&gl, gl::SHADING_LANGUAGE_VERSION) {
+                println!("Shaders version on {}", shaders_version.to_string_lossy());
+            }
+
+            let vertex_shader = create_shader(&gl, gl::VERTEX_SHADER, VERTEX_SHADER_SOURCE);
+            let fragment_shader = create_shader(&gl, gl::FRAGMENT_SHADER, FRAGMENT_SHADER_SOURCE);
+
+            let program = gl.CreateProgram();
+
+            gl.AttachShader(program, vertex_shader);
+            gl.AttachShader(program, fragment_shader);
+
+            gl.LinkProgram(program);
+
+            gl.UseProgram(program);
+
+            gl.DeleteShader(vertex_shader);
+            gl.DeleteShader(fragment_shader);
+
+            let mut vao = std::mem::zeroed();
+            gl.GenVertexArrays(1, &mut vao);
+            gl.BindVertexArray(vao);
+
+            let mut vbo = std::mem::zeroed();
+            gl.GenBuffers(1, &mut vbo);
+            gl.BindBuffer(gl::ARRAY_BUFFER, vbo);
+            gl.BufferData(
+                gl::ARRAY_BUFFER,
+                (VERTEX_DATA.len() * std::mem::size_of::<f32>()) as gl::types::GLsizeiptr,
+                VERTEX_DATA.as_ptr() as *const _,
+                gl::STATIC_DRAW,
+            );
+
+            let pos_attrib = gl.GetAttribLocation(program, b"position\0".as_ptr() as *const _);
+            let color_attrib = gl.GetAttribLocation(program, b"color\0".as_ptr() as *const _);
+            gl.VertexAttribPointer(
+                pos_attrib as gl::types::GLuint,
+                2,
+                gl::FLOAT,
+                0,
+                5 * std::mem::size_of::<f32>() as gl::types::GLsizei,
+                std::ptr::null(),
+            );
+            gl.VertexAttribPointer(
+                color_attrib as gl::types::GLuint,
+                3,
+                gl::FLOAT,
+                0,
+                5 * std::mem::size_of::<f32>() as gl::types::GLsizei,
+                (2 * std::mem::size_of::<f32>()) as *const () as *const _,
+            );
+            gl.EnableVertexAttribArray(pos_attrib as gl::types::GLuint);
+            gl.EnableVertexAttribArray(color_attrib as gl::types::GLuint);
+
+            Self { program, vao, vbo, gl }
+        }
+    }
+
+    pub fn draw(&self) {
+        unsafe {
+            self.gl.UseProgram(self.program);
+
+            self.gl.BindVertexArray(self.vao);
+            self.gl.BindBuffer(gl::ARRAY_BUFFER, self.vbo);
+
+            self.gl.ClearColor(0.1, 0.1, 0.1, 0.9);
+            self.gl.Clear(gl::COLOR_BUFFER_BIT);
+            self.gl.DrawArrays(gl::TRIANGLES, 0, 3);
+        }
+    }
+
+    pub fn resize(&self, width: i32, height: i32) {
+        unsafe {
+            self.gl.Viewport(0, 0, width, height);
+        }
+    }
+}
+
+impl Drop for Renderer {
+    fn drop(&mut self) {
+        unsafe {
+            self.gl.DeleteProgram(self.program);
+            self.gl.DeleteBuffers(1, &self.vbo);
+            self.gl.DeleteVertexArrays(1, &self.vao);
+        }
+    }
+}
+
+unsafe fn create_shader(
+    gl: &gl::Gl,
+    shader: gl::types::GLenum,
+    source: &[u8],
+) -> gl::types::GLuint {
+    let shader = gl.CreateShader(shader);
+    gl.ShaderSource(shader, 1, [source.as_ptr().cast()].as_ptr(), std::ptr::null());
+    gl.CompileShader(shader);
+    shader
+}
+
+fn get_gl_string(gl: &gl::Gl, variant: gl::types::GLenum) -> Option<&'static CStr> {
+    unsafe {
+        let s = gl.GetString(variant);
+        (!s.is_null()).then(|| CStr::from_ptr(s.cast()))
+    }
+}
+
+#[rustfmt::skip]
+static VERTEX_DATA: [f32; 15] = [
+    -0.5, -0.5,  1.0,  0.0,  0.0,
+     0.0,  0.5,  0.0,  1.0,  0.0,
+     0.5, -0.5,  0.0,  0.0,  1.0,
+];
+
+const VERTEX_SHADER_SOURCE: &[u8] = b"
+#version 100
+precision mediump float;
+
+attribute vec2 position;
+attribute vec3 color;
+
+varying vec3 v_color;
+
+void main() {
+    gl_Position = vec4(position, 0.0, 1.0);
+    v_color = color;
+}
+\0";
+
+const FRAGMENT_SHADER_SOURCE: &[u8] = b"
+#version 100
+precision mediump float;
+
+varying vec3 v_color;
+
+void main() {
+    gl_FragColor = vec4(v_color, 1.0);
+}
+\0";

--- a/glutin_examples/examples/window.rs
+++ b/glutin_examples/examples/window.rs
@@ -1,4 +1,3 @@
-use std::ffi::CString;
 use std::num::NonZeroU32;
 
 use raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle};
@@ -7,7 +6,7 @@ use winit::event::{Event, WindowEvent};
 use winit::event_loop::{ControlFlow, EventLoop};
 use winit::window::WindowBuilder;
 
-use glutin::context::ContextAttributesBuilder;
+use glutin::context::{ContextApi, ContextAttributesBuilder};
 use glutin::prelude::*;
 use glutin::surface::SwapInterval;
 
@@ -34,7 +33,29 @@ fn main() {
     // raw-window-handle for it to get the right visual and use proper hdc. Note
     // that you can likely use it for other windows using the same config.
     let template = config_template(window.raw_window_handle());
-    let config = unsafe { gl_display.find_configs(template).unwrap().next().unwrap() };
+    let config = unsafe {
+        gl_display
+            .find_configs(template)
+            .unwrap()
+            .reduce(|accum, config| {
+                // Find the config with the maximum number of samples.
+                //
+                // In general if you're not sure what you want in template you can request or
+                // don't want to require multisampling for example, you can search for a
+                // specific option you want afterwards.
+                //
+                // XXX however on macOS you can request only one config, so you should do
+                // a search with the help of `find_configs` and adjusting your template.
+                if config.num_samples() > accum.num_samples() {
+                    config
+                } else {
+                    accum
+                }
+            })
+            .unwrap()
+    };
+
+    println!("Picked a config with {} samples", config.num_samples());
 
     // Create a wrapper for GL window and surface.
     let gl_window = GlWindow::from_existing(&gl_display, window, &config);
@@ -43,7 +64,19 @@ fn main() {
     // it's expected in multithreaded + multiwindow operation mode, since you
     // can send NotCurrentContext, but not Surface.
     let context_attributes = ContextAttributesBuilder::new().build(Some(raw_window_handle));
-    let gl_context = unsafe { gl_display.create_context(&config, &context_attributes).unwrap() };
+
+    // Since glutin by default tries to create OpenGL core context, which may not be
+    // present we should try gles.
+    let fallback_context_attributes = ContextAttributesBuilder::new()
+        .with_context_api(ContextApi::Gles(None))
+        .build(Some(raw_window_handle));
+    let gl_context = unsafe {
+        gl_display.create_context(&config, &context_attributes).unwrap_or_else(|_| {
+            gl_display
+                .create_context(&config, &fallback_context_attributes)
+                .expect("failed to create context")
+        })
+    };
 
     // Make it current and load symbols.
     let gl_context = gl_context.make_current(&gl_window.surface).unwrap();
@@ -51,10 +84,9 @@ fn main() {
     // WGL requires current context on the calling thread to load symbols properly,
     // so the call here is for portability reasons. In case you don't target WGL
     // you can call it right after display creation.
-    gl::load_with(|symbol| {
-        let symbol = CString::new(symbol).unwrap();
-        gl_display.get_proc_address(symbol.as_c_str()) as *const _
-    });
+    //
+    // The symbol loading is done by the renderer.
+    let renderer = Renderer::new(&gl_display);
 
     // Try setting vsync.
     if let Err(res) = gl_window
@@ -79,6 +111,7 @@ fn main() {
                             NonZeroU32::new(size.width).unwrap(),
                             NonZeroU32::new(size.height).unwrap(),
                         );
+                        renderer.resize(size.width as i32, size.height as i32);
                     }
                 },
                 WindowEvent::CloseRequested => {
@@ -87,11 +120,8 @@ fn main() {
                 _ => (),
             },
             Event::RedrawEventsCleared => {
-                unsafe {
-                    gl::ClearColor(0., 0.3, 0.3, 0.8);
-                    gl::Clear(gl::COLOR_BUFFER_BIT);
-                    gl_window.window.request_redraw();
-                }
+                renderer.draw();
+                gl_window.window.request_redraw();
 
                 gl_window.surface.swap_buffers(&gl_context).unwrap();
             },


### PR DESCRIPTION
This should make use of shaders and pick config
with the maximum sample buffers.

Besides that, this commit also fixes the core
profile picking, since you must specify the
version higher than 3.3.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
