### PR TITLE
examples: Move support module into `glutin_examples` crate

### DIFF
--- a/glutin_examples/examples/window.rs
+++ b/glutin_examples/examples/window.rs
@@ -1,5 +1,3 @@
-mod support;
-
 fn main() {
-    support::main()
+    glutin_examples::main()
 }

--- a/glutin_examples/src/lib.rs
+++ b/glutin_examples/src/lib.rs
@@ -23,7 +23,7 @@ use glutin::surface::{
     Surface, SurfaceAttributes, SurfaceAttributesBuilder, SwapInterval, WindowSurface,
 };
 
-pub(crate) fn main() {
+pub fn main() {
     let event_loop = EventLoop::new();
 
     let raw_display = event_loop.raw_display_handle();


### PR DESCRIPTION
Instead of compiling this module as part of every example binary (currently only `window.rs`, but we'll add one for `android.rs` soon), compile it as part of the otherwise-unused `glutin_examples` crate so that the same compilation result gets statically linked into the individual example binaries.  After all, the containing lib is already linked into binary targets by default/design.
