### PR TITLE
refactor: use NO constant on macos

### DIFF
--- a/glutin/src/api/cgl/config.rs
+++ b/glutin/src/api/cgl/config.rs
@@ -8,7 +8,7 @@ use cocoa::appkit::{
     NSOpenGLPixelFormat, NSOpenGLPixelFormatAttribute, NSOpenGLProfileVersion3_2Core,
     NSOpenGLProfileVersion4_1Core, NSOpenGLProfileVersionLegacy,
 };
-use cocoa::base::{id, nil, BOOL};
+use cocoa::base::{id, nil, BOOL, NO};
 
 use crate::config::{
     Api, AsRawConfig, ColorBufferType, ConfigSurfaceTypes, ConfigTemplate, GlConfig, RawConfig,
@@ -235,7 +235,7 @@ impl PartialEq for ConfigInner {
     fn eq(&self, other: &Self) -> bool {
         unsafe {
             let is_equal: BOOL = msg_send![*self.raw, isEqual: *other.raw];
-            is_equal != 0
+            is_equal != NO
         }
     }
 }


### PR DESCRIPTION
I fixed error that `is_equal != 0` is not matched type on macos.

- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
