### PR TITLE
api: add `GetDisplayExtensions` trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,15 @@
 
 - `Config` doesn't force OpenGL `Api` by default.
 - `Display::create_context` now uses the most recent available `Api` from the `Config` when `ContextApi` is not specified in `ContextAttributes`.
-- `PossiblyCurrentGlContext::get_proc_address` method was moved to `GlDisplay::get_proc_address`.
-- `ConfigTemplateBuilder::with_sample_buffers` now called `ConfigTemplateBuilder::with_multisampling`.
-- `GlConfig::sample_buffers` now called `GlConfig::num_samples` and returns the amount of samples in multisample buffer.
+- **Breaking:** `PossiblyCurrentGlContext::get_proc_address` method was moved to `GlDisplay::get_proc_address`.
+- **Breaking:** `ConfigTemplateBuilder::with_sample_buffers` now called `ConfigTemplateBuilder::with_multisampling`.
+- **Breaking:** `GlConfig::sample_buffers` now called `GlConfig::num_samples` and returns the amount of samples in multisample buffer.
 - **Breaking:** Bump MSRV from `1.57` to `1.60`.
 - Fix `GlProfile::Core` requesting without explicit version.
 - Pick the latest available profile on macOS.
 - When using `ContextApi::Gles(None)` in `ContextAttributesBuilder` the latest known supported `major` ES version will be picked.
 - Fix `Eq` implementation for `Config` on `CGL`.
+- Add `GetDisplayExtensions` trait to obtain api display extensions implemented on  `EGL`, `WGL`, and `GLX`.
 
 # Version 0.30.0-beta.2 (2022-09-03)
 

--- a/glutin/src/api/egl/display.rs
+++ b/glutin/src/api/egl/display.rs
@@ -15,7 +15,7 @@ use raw_window_handle::RawDisplayHandle;
 
 use crate::config::ConfigTemplate;
 use crate::context::Version;
-use crate::display::{AsRawDisplay, RawDisplay};
+use crate::display::{AsRawDisplay, GetDisplayExtensions, RawDisplay};
 use crate::error::{ErrorKind, Result};
 use crate::prelude::*;
 use crate::private::Sealed;
@@ -274,6 +274,12 @@ impl GlDisplay for Display {
 
     fn get_proc_address(&self, addr: &CStr) -> *const ffi::c_void {
         unsafe { self.inner.egl.GetProcAddress(addr.as_ptr()) as *const _ }
+    }
+}
+
+impl GetDisplayExtensions for Display {
+    fn extensions(&self) -> &HashSet<&'static str> {
+        &self.inner.client_extensions
     }
 }
 

--- a/glutin/src/api/glx/display.rs
+++ b/glutin/src/api/glx/display.rs
@@ -13,7 +13,7 @@ use raw_window_handle::RawDisplayHandle;
 
 use crate::config::ConfigTemplate;
 use crate::context::Version;
-use crate::display::{AsRawDisplay, RawDisplay};
+use crate::display::{AsRawDisplay, GetDisplayExtensions, RawDisplay};
 use crate::error::{ErrorKind, Result};
 use crate::prelude::*;
 use crate::private::Sealed;
@@ -156,6 +156,12 @@ impl GlDisplay for Display {
 
     fn get_proc_address(&self, addr: &CStr) -> *const ffi::c_void {
         unsafe { self.inner.glx.GetProcAddress(addr.as_ptr() as *const _) as *const _ }
+    }
+}
+
+impl GetDisplayExtensions for Display {
+    fn extensions(&self) -> &HashSet<&'static str> {
+        &self.inner.client_extensions
     }
 }
 

--- a/glutin/src/api/wgl/display.rs
+++ b/glutin/src/api/wgl/display.rs
@@ -13,7 +13,7 @@ use windows_sys::Win32::Graphics::Gdi::HDC;
 use windows_sys::Win32::System::LibraryLoader as dll_loader;
 
 use crate::config::ConfigTemplate;
-use crate::display::{AsRawDisplay, RawDisplay};
+use crate::display::{AsRawDisplay, GetDisplayExtensions, RawDisplay};
 use crate::error::{ErrorKind, Result};
 use crate::prelude::*;
 use crate::private::Sealed;
@@ -130,6 +130,12 @@ impl GlDisplay for Display {
                     .map_or(std::ptr::null(), |fn_ptr| fn_ptr as *const _)
             }
         }
+    }
+}
+
+impl GetDisplayExtensions for Display {
+    fn extensions(&self) -> &HashSet<&'static str> {
+        &self.inner.client_extensions
     }
 }
 

--- a/glutin/src/display.rs
+++ b/glutin/src/display.rs
@@ -1,6 +1,7 @@
 //! The OpenGL platform display selection and creation.
 #![allow(unreachable_patterns)]
 
+use std::collections::HashSet;
 use std::ffi::{self, CStr};
 use std::fmt;
 
@@ -121,6 +122,17 @@ pub trait GetGlDisplay: Sealed {
 
     /// Obtain the GL display used to create a particular GL object.
     fn display(&self) -> Self::Target;
+}
+
+/// Obtain the underlying api extensions.
+pub trait GetDisplayExtensions: Sealed {
+    /// Supported extensions by the display.
+    ///
+    /// # Api-specific
+    ///
+    /// **WGL:** - To have extensions loaded, `raw_window_handle` must be used
+    /// when creating display.
+    fn extensions(&self) -> &HashSet<&'static str>;
 }
 
 /// Get the raw handle to the [`Display`].

--- a/glutin/src/surface.rs
+++ b/glutin/src/surface.rs
@@ -153,7 +153,7 @@ impl SurfaceAttributesBuilder<PbufferSurface> {
     }
 
     /// The same as in
-    /// [`SurfaceAttributesBuilder::<WindowSurface>::with_single_buffer``].
+    /// [`SurfaceAttributesBuilder::<WindowSurface>::with_single_buffer`].
     pub fn with_single_buffer(mut self, single_buffer: bool) -> Self {
         self.attributes.single_buffer = single_buffer;
         self


### PR DESCRIPTION
This trait should provide a way to obtain supported extensions
by the api. The trait is intentionally isn't implemented for
top-level `Display` due to difference in extension naming.

--

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality

