### PR TITLE
egl: add fallback in swap_buffers_with_damage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - When using `ContextApi::Gles(None)` in `ContextAttributesBuilder` the latest known supported `major` ES version will be picked.
 - Fix `Eq` implementation for `Config` on `CGL`.
 - Add `GetDisplayExtensions` trait to obtain api display extensions implemented on  `EGL`, `WGL`, and `GLX`.
+- Fallback to `Surface::swap_buffers` when `Surface::swap_buffers_with_damage` is not supported on `EGL`.
 
 # Version 0.30.0-beta.2 (2022-09-03)
 

--- a/glutin_egl_sys/build.rs
+++ b/glutin_egl_sys/build.rs
@@ -27,6 +27,7 @@ fn main() {
             "EGL_EXT_platform_device",
             "EGL_EXT_platform_wayland",
             "EGL_EXT_platform_x11",
+            "EGL_EXT_swap_buffers_with_damage",
             "EGL_KHR_create_context",
             "EGL_KHR_create_context_no_error",
             "EGL_KHR_platform_android",


### PR DESCRIPTION
Given that functionality of the swap_buffers_with_damage is basically about providing the hints to the compositor, we should fallback to normal `swap_buffers` when the extension is not supported.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality

