### PR TITLE
cgl: fix `Eq` implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix `GlProfile::Core` requesting without explicit version.
 - Pick the latest available profile on macOS.
 - When using `ContextApi::Gles(None)` in `ContextAttributesBuilder` the latest known supported `major` ES version will be picked.
+- Fix `Eq` implementation for `Config` on `CGL`.
 
 # Version 0.30.0-beta.2 (2022-09-03)
 

--- a/glutin/src/api/cgl/config.rs
+++ b/glutin/src/api/cgl/config.rs
@@ -8,7 +8,7 @@ use cocoa::appkit::{
     NSOpenGLPixelFormat, NSOpenGLPixelFormatAttribute, NSOpenGLProfileVersion3_2Core,
     NSOpenGLProfileVersion4_1Core, NSOpenGLProfileVersionLegacy,
 };
-use cocoa::base::{id, nil, BOOL};
+use cocoa::base::{id, nil, BOOL, NO};
 
 use crate::config::{
     Api, AsRawConfig, ColorBufferType, ConfigSurfaceTypes, ConfigTemplate, GlConfig, RawConfig,
@@ -235,7 +235,7 @@ impl PartialEq for ConfigInner {
     fn eq(&self, other: &Self) -> bool {
         unsafe {
             let is_equal: BOOL = msg_send![*self.raw, isEqual: *other.raw];
-            is_equal != 0
+            is_equal != NO
         }
     }
 }


### PR DESCRIPTION
We should compare `BOOL` with `NO` and not with `0`.

- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality


