### PR TITLE
api: implement `Clone` for builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add `GetDisplayExtensions` trait to obtain api display extensions implemented on  `EGL`, `WGL`, and `GLX`.
 - Fallback to `Surface::swap_buffers` when `Surface::swap_buffers_with_damage` is not supported on `EGL`.
 - Add missing `GetGlConfig` implementation for `NotCurrentContext` and `PossiblyCurrentContext`.
+- Implement `Clone` for builders.
 
 # Version 0.30.0-beta.2 (2022-09-03)
 

--- a/glutin/src/config.rs
+++ b/glutin/src/config.rs
@@ -72,7 +72,7 @@ pub trait AsRawConfig {
 }
 
 /// Builder for the [`ConfigTemplate`].
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct ConfigTemplateBuilder {
     template: ConfigTemplate,
 }

--- a/glutin/src/context.rs
+++ b/glutin/src/context.rs
@@ -108,7 +108,7 @@ pub trait AsRawContext {
 }
 
 /// The builder to help customizing context
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct ContextAttributesBuilder {
     attributes: ContextAttributes,
 }
@@ -199,7 +199,7 @@ impl ContextAttributesBuilder {
 }
 
 /// The attributes that are used to create a graphics context.
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct ContextAttributes {
     pub(crate) release_behavior: ReleaseBehaviour,
 

--- a/glutin/src/surface.rs
+++ b/glutin/src/surface.rs
@@ -91,7 +91,7 @@ pub trait AsRawSurface {
 }
 
 /// Builder to get the required set of attributes initialized before hand.
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct SurfaceAttributesBuilder<T: SurfaceTypeTrait + Default> {
     attributes: SurfaceAttributes<T>,
 }


### PR DESCRIPTION
It's useful to clone builders to have branching
during construction.
