### PR TITLE
api: add `Display::version_string`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add missing `GetGlConfig` implementation for `NotCurrentContext` and `PossiblyCurrentContext`.
 - Implement `Clone` for builders.
 - **Breaking:** move `DamageRect` into `surface::Rect`.
+- Added `Display::version_string` to help with logging the display information.
 
 # Version 0.30.0-beta.2 (2022-09-03)
 

--- a/glutin/src/api/cgl/display.rs
+++ b/glutin/src/api/cgl/display.rs
@@ -94,6 +94,10 @@ impl GlDisplay for Display {
             CFBundleGetFunctionPointerForName(framework, symbol_name.as_concrete_TypeRef()).cast()
         }
     }
+
+    fn version_string(&self) -> String {
+        String::from("Apple CGL")
+    }
 }
 
 impl AsRawDisplay for Display {

--- a/glutin/src/api/egl/display.rs
+++ b/glutin/src/api/egl/display.rs
@@ -275,6 +275,10 @@ impl GlDisplay for Display {
     fn get_proc_address(&self, addr: &CStr) -> *const ffi::c_void {
         unsafe { self.inner.egl.GetProcAddress(addr.as_ptr()) as *const _ }
     }
+
+    fn version_string(&self) -> String {
+        format!("EGL {}.{}", self.inner.version.major, self.inner.version.minor)
+    }
 }
 
 impl GetDisplayExtensions for Display {

--- a/glutin/src/api/glx/display.rs
+++ b/glutin/src/api/glx/display.rs
@@ -157,6 +157,10 @@ impl GlDisplay for Display {
     fn get_proc_address(&self, addr: &CStr) -> *const ffi::c_void {
         unsafe { self.inner.glx.GetProcAddress(addr.as_ptr() as *const _) as *const _ }
     }
+
+    fn version_string(&self) -> String {
+        format!("GLX {}.{}", self.inner.version.major, self.inner.version.minor)
+    }
 }
 
 impl GetDisplayExtensions for Display {

--- a/glutin/src/api/wgl/display.rs
+++ b/glutin/src/api/wgl/display.rs
@@ -131,6 +131,10 @@ impl GlDisplay for Display {
             }
         }
     }
+
+    fn version_string(&self) -> String {
+        String::from("WGL")
+    }
 }
 
 impl GetDisplayExtensions for Display {

--- a/glutin/src/display.rs
+++ b/glutin/src/display.rs
@@ -113,6 +113,12 @@ pub trait GlDisplay: Sealed {
     /// the calling thread, otherwise only limited set of functions will be
     /// loaded.
     fn get_proc_address(&self, addr: &CStr) -> *const ffi::c_void;
+
+    /// Helper to obtain the information about the underlying display.
+    ///
+    /// This function is intended to be used for logging purposes to help with
+    /// trouble shooting issues.
+    fn version_string(&self) -> String;
 }
 
 /// Get the [`Display`].
@@ -375,6 +381,10 @@ impl GlDisplay for Display {
 
     fn get_proc_address(&self, addr: &CStr) -> *const ffi::c_void {
         gl_api_dispatch!(self; Self(display) => display.get_proc_address(addr))
+    }
+
+    fn version_string(&self) -> String {
+        gl_api_dispatch!(self; Self(display) => display.version_string())
     }
 }
 

--- a/glutin_examples/src/lib.rs
+++ b/glutin_examples/src/lib.rs
@@ -43,6 +43,7 @@ pub fn main() {
     // Create the GL display. This will create display automatically for the
     // underlying GL platform. See support module on how it's being done.
     let gl_display = create_display(raw_display, raw_window_handle);
+    println!("Running on: {}", gl_display.version_string());
 
     // Create the config we'll be used for window. We'll use the native window
     // raw-window-handle for it to get the right visual and use proper hdc. Note


### PR DESCRIPTION
This should help automatic display users to log the display platform that got picked.
