### PR TITLE
api: add `Display::supported_features`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 - Add `GlDisplay::version_string` to help with logging the display information.
 - Rename `NotCurrentGlContext::treat_as_current` to `NotCurrentGlContext::treat_as_possibly_current`.
 - Rename `Display::from_raw` to `Display::new`.
+- Added `GlDisplay::supported_features` to allow checking for extensions support beforehand.
+- **Breaking:** renamed `ReleaseBehaviour` to `ReleaseBehavior`.
 
 # Version 0.30.0-beta.2 (2022-09-03)
 

--- a/glutin/src/api/cgl/display.rs
+++ b/glutin/src/api/cgl/display.rs
@@ -9,7 +9,7 @@ use core_foundation::string::CFString;
 use raw_window_handle::RawDisplayHandle;
 
 use crate::config::ConfigTemplate;
-use crate::display::{AsRawDisplay, RawDisplay};
+use crate::display::{AsRawDisplay, DisplayFeatures, RawDisplay};
 use crate::error::{ErrorKind, Result};
 use crate::prelude::*;
 use crate::private::Sealed;
@@ -97,6 +97,13 @@ impl GlDisplay for Display {
 
     fn version_string(&self) -> String {
         String::from("Apple CGL")
+    }
+
+    fn supported_features(&self) -> DisplayFeatures {
+        DisplayFeatures::MULTISAMPLING_PIXEL_FORMATS
+            | DisplayFeatures::FLOAT_PIXEL_FORMAT
+            | DisplayFeatures::SRGB_FRAMEBUFFERS
+            | DisplayFeatures::SWAP_CONTROL
     }
 }
 

--- a/glutin/src/api/egl/context.rs
+++ b/glutin/src/api/egl/context.rs
@@ -11,7 +11,7 @@ use crate::config::{Api, GetGlConfig};
 use crate::context::{
     AsRawContext, ContextApi, ContextAttributes, GlProfile, RawContext, Robustness, Version,
 };
-use crate::display::GetGlDisplay;
+use crate::display::{DisplayFeatures, GetGlDisplay};
 use crate::error::{ErrorKind, Result};
 use crate::prelude::*;
 use crate::private::Sealed;
@@ -80,10 +80,8 @@ impl Display {
                 attrs.push(version.minor as EGLint);
             }
 
-            let has_robustsess = is_one_five
-                || self.inner.client_extensions.contains("EGL_EXT_create_context_robustness");
-            let has_no_error =
-                self.inner.client_extensions.contains("EGL_KHR_create_context_no_error");
+            let has_robustsess = self.inner.features.contains(DisplayFeatures::CONTEXT_ROBUSTNESS);
+            let has_no_error = self.inner.features.contains(DisplayFeatures::CONTEXT_NO_ERROR);
 
             match context_attributes.robustness {
                 Robustness::NotRobust => (),

--- a/glutin/src/api/egl/surface.rs
+++ b/glutin/src/api/egl/surface.rs
@@ -84,9 +84,7 @@ impl Display {
 
         let mut attrs = Vec::<EGLAttrib>::with_capacity(ATTR_SIZE_HINT);
 
-        if surface_attributes.srgb.is_some()
-            && self.inner.client_extensions.contains("EGL_KHR_gl_colorspace")
-        {
+        if surface_attributes.srgb.is_some() && config.srgb_capable() {
             attrs.push(egl::GL_COLORSPACE as EGLAttrib);
             let colorspace = match surface_attributes.srgb {
                 Some(true) => egl::GL_COLORSPACE_SRGB as EGLAttrib,
@@ -162,9 +160,7 @@ impl Display {
         attrs.push(buffer);
 
         // // Add colorspace if the extension is present.
-        if surface_attributes.srgb.is_some()
-            && self.inner.client_extensions.contains("EGL_KHR_gl_colorspace")
-        {
+        if surface_attributes.srgb.is_some() && config.srgb_capable() {
             attrs.push(egl::GL_COLORSPACE as EGLAttrib);
             let colorspace = match surface_attributes.srgb {
                 Some(true) => egl::GL_COLORSPACE_SRGB as EGLAttrib,

--- a/glutin/src/api/wgl/context.rs
+++ b/glutin/src/api/wgl/context.rs
@@ -13,10 +13,10 @@ use windows_sys::Win32::Graphics::Gdi::{self as gdi, HDC};
 
 use crate::config::GetGlConfig;
 use crate::context::{
-    AsRawContext, ContextApi, ContextAttributes, GlProfile, RawContext, ReleaseBehaviour,
+    AsRawContext, ContextApi, ContextAttributes, GlProfile, RawContext, ReleaseBehavior,
     Robustness, Version,
 };
-use crate::display::GetGlDisplay;
+use crate::display::{DisplayFeatures, GetGlDisplay};
 use crate::error::{ErrorKind, Result};
 use crate::prelude::*;
 use crate::private::Sealed;
@@ -78,9 +78,7 @@ impl Display {
         let mut attrs = Vec::<c_int>::with_capacity(16);
 
         // Check whether the ES context creation is supported.
-        let supports_es =
-            self.inner.client_extensions.contains("WGL_EXT_create_context_es2_profile")
-                || self.inner.client_extensions.contains("WGL_EXT_create_context_es_profile");
+        let supports_es = self.inner.features.contains(DisplayFeatures::CREATE_ES_CONTEXT);
 
         let (profile, version) = match context_attributes.api {
             api @ Some(ContextApi::OpenGl(_)) | api @ None => {
@@ -134,7 +132,7 @@ impl Display {
         }
 
         let mut flags: c_int = 0;
-        if self.inner.client_extensions.contains("WGL_ARB_create_context_robustness") {
+        if self.inner.features.contains(DisplayFeatures::CONTEXT_ROBUSTNESS) {
             match context_attributes.robustness {
                 Robustness::NotRobust => (),
                 Robustness::RobustNoResetNotification => {
@@ -148,7 +146,7 @@ impl Display {
                     flags |= wgl_extra::CONTEXT_ROBUST_ACCESS_BIT_ARB as c_int;
                 },
                 Robustness::NoError => {
-                    if !self.inner.client_extensions.contains("WGL_ARB_create_context_no_error") {
+                    if !self.inner.features.contains(DisplayFeatures::CONTEXT_NO_ERROR) {
                         return Err(ErrorKind::NotSupported(
                             "WGL_ARB_create_context_no_error not supported",
                         )
@@ -176,18 +174,18 @@ impl Display {
         }
 
         // Flush control.
-        if self.inner.client_extensions.contains("WGL_ARB_context_flush_control") {
+        if self.inner.features.contains(DisplayFeatures::CONTEXT_RELEASE_BEHAVIOR) {
             match context_attributes.release_behavior {
-                ReleaseBehaviour::Flush => {
+                ReleaseBehavior::Flush => {
                     attrs.push(wgl_extra::CONTEXT_RELEASE_BEHAVIOR_ARB as c_int);
                     attrs.push(wgl_extra::CONTEXT_RELEASE_BEHAVIOR_FLUSH_ARB as c_int);
                 },
-                ReleaseBehaviour::None => {
+                ReleaseBehavior::None => {
                     attrs.push(wgl_extra::CONTEXT_RELEASE_BEHAVIOR_ARB as c_int);
                     attrs.push(wgl_extra::CONTEXT_RELEASE_BEHAVIOR_NONE_ARB as c_int);
                 },
             }
-        } else if context_attributes.release_behavior != ReleaseBehaviour::Flush {
+        } else if context_attributes.release_behavior != ReleaseBehavior::Flush {
             return Err(ErrorKind::NotSupported(
                 "flush control behavior WGL_ARB_context_flush_control",
             )

--- a/glutin/src/api/wgl/surface.rs
+++ b/glutin/src/api/wgl/surface.rs
@@ -10,7 +10,7 @@ use windows_sys::Win32::Foundation::HWND;
 use windows_sys::Win32::Graphics::{Gdi as gdi, OpenGL as gl};
 
 use crate::config::GetGlConfig;
-use crate::display::GetGlDisplay;
+use crate::display::{DisplayFeatures, GetGlDisplay};
 use crate::error::{ErrorKind, Result};
 use crate::prelude::*;
 use crate::private::Sealed;
@@ -116,9 +116,9 @@ impl<T: SurfaceTypeTrait> GlSurface<T> for Surface<T> {
         };
 
         let res = match self.display.inner.wgl_extra {
-            Some(extra)
-                if self.display.inner.client_extensions.contains("WGL_EXT_swap_control") =>
-            unsafe { extra.SwapIntervalEXT(interval as _) },
+            Some(extra) if self.display.inner.features.contains(DisplayFeatures::SWAP_CONTROL) => unsafe {
+                extra.SwapIntervalEXT(interval as _)
+            },
             _ => {
                 return Err(
                     ErrorKind::NotSupported("swap contol extrensions are not supported").into()

--- a/glutin/src/context.rs
+++ b/glutin/src/context.rs
@@ -1,7 +1,7 @@
 //! OpenGL context creation and initialization.
 
 #![allow(unreachable_patterns)]
-use std::ffi::{self};
+use std::ffi;
 
 use raw_window_handle::RawWindowHandle;
 
@@ -155,11 +155,11 @@ impl ContextAttributesBuilder {
         self
     }
 
-    /// The behaviour when changing the current context. See the docs of
-    /// [`ReleaseBehaviour`].
+    /// The behavior when changing the current context. See the docs of
+    /// [`ReleaseBehavior`].
     ///
-    /// The default is [`ReleaseBehaviour::Flush`].
-    pub fn with_release_behavior(mut self, release_behavior: ReleaseBehaviour) -> Self {
+    /// The default is [`ReleaseBehavior::Flush`].
+    pub fn with_release_behavior(mut self, release_behavior: ReleaseBehavior) -> Self {
         self.attributes.release_behavior = release_behavior;
         self
     }
@@ -201,7 +201,7 @@ impl ContextAttributesBuilder {
 /// The attributes that are used to create a graphics context.
 #[derive(Default, Debug, Clone)]
 pub struct ContextAttributes {
-    pub(crate) release_behavior: ReleaseBehaviour,
+    pub(crate) release_behavior: ReleaseBehavior,
 
     pub(crate) debug: bool,
 
@@ -318,7 +318,7 @@ impl Version {
 
 /// The behavior of the driver when you change the current context.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum ReleaseBehaviour {
+pub enum ReleaseBehavior {
     /// Doesn't do anything. Most notably doesn't flush. Not supported by all
     /// drivers.
     ///
@@ -328,14 +328,14 @@ pub enum ReleaseBehaviour {
     None,
 
     /// Flushes the context that was previously current as if `glFlush` was
-    /// called. This is the default behaviour.
+    /// called. This is the default behavior.
     Flush,
 }
 
-impl Default for ReleaseBehaviour {
+impl Default for ReleaseBehavior {
     #[inline]
     fn default() -> Self {
-        ReleaseBehaviour::Flush
+        ReleaseBehavior::Flush
     }
 }
 


### PR DESCRIPTION
This should help with creating objects that are brought by extensions, like robust context. Right now users should try to create robust context, and then fallback if it's not present.

Fixes #1489.
