### PR TITLE
api: emphasize `possibly` in `treat_as_current`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
 - Add missing `GetGlConfig` implementation for `NotCurrentContext` and `PossiblyCurrentContext`.
 - Implement `Clone` for builders.
 - **Breaking:** move `DamageRect` into `surface::Rect`.
-- Added `Display::version_string` to help with logging the display information.
+- Added `GlDisplay::version_string` to help with logging the display information.
+- Renamed `NotCurrentGlContext::treat_as_current` to `NotCurrentGlContext::treat_as_possibly_current`.
 
 # Version 0.30.0-beta.2 (2022-09-03)
 

--- a/glutin/src/api/cgl/context.rs
+++ b/glutin/src/api/cgl/context.rs
@@ -80,7 +80,7 @@ impl NotCurrentContext {
 impl NotCurrentGlContext for NotCurrentContext {
     type PossiblyCurrentContext = PossiblyCurrentContext;
 
-    fn treat_as_current(self) -> PossiblyCurrentContext {
+    fn treat_as_possibly_current(self) -> PossiblyCurrentContext {
         PossiblyCurrentContext { inner: self.inner, _nosendsync: PhantomData }
     }
 }

--- a/glutin/src/api/egl/context.rs
+++ b/glutin/src/api/egl/context.rs
@@ -173,7 +173,7 @@ impl NotCurrentContext {
 impl NotCurrentGlContext for NotCurrentContext {
     type PossiblyCurrentContext = PossiblyCurrentContext;
 
-    fn treat_as_current(self) -> Self::PossiblyCurrentContext {
+    fn treat_as_possibly_current(self) -> Self::PossiblyCurrentContext {
         PossiblyCurrentContext { inner: self.inner, _nosendsync: PhantomData }
     }
 }

--- a/glutin/src/api/glx/context.rs
+++ b/glutin/src/api/glx/context.rs
@@ -236,7 +236,7 @@ impl NotCurrentContext {
 impl NotCurrentGlContext for NotCurrentContext {
     type PossiblyCurrentContext = PossiblyCurrentContext;
 
-    fn treat_as_current(self) -> PossiblyCurrentContext {
+    fn treat_as_possibly_current(self) -> PossiblyCurrentContext {
         PossiblyCurrentContext { inner: self.inner, _nosendsync: PhantomData }
     }
 }

--- a/glutin/src/api/wgl/context.rs
+++ b/glutin/src/api/wgl/context.rs
@@ -304,7 +304,7 @@ impl PossiblyCurrentGlContext for PossiblyCurrentContext {
 impl NotCurrentGlContext for NotCurrentContext {
     type PossiblyCurrentContext = PossiblyCurrentContext;
 
-    fn treat_as_current(self) -> PossiblyCurrentContext {
+    fn treat_as_possibly_current(self) -> PossiblyCurrentContext {
         PossiblyCurrentContext { inner: self.inner, _nosendsync: PhantomData }
     }
 }

--- a/glutin/src/context.rs
+++ b/glutin/src/context.rs
@@ -36,7 +36,7 @@ pub trait NotCurrentGlContext: Sealed {
     /// Treat the not current context as possibly current. The operation is safe
     /// because the possibly current context is more restricted and not
     /// guaranteed to be current.
-    fn treat_as_current(self) -> Self::PossiblyCurrentContext;
+    fn treat_as_possibly_current(self) -> Self::PossiblyCurrentContext;
 }
 
 /// A trait that splits the methods accessing [`crate::surface::Surface`] on not
@@ -376,8 +376,8 @@ pub enum NotCurrentContext {
 impl NotCurrentGlContext for NotCurrentContext {
     type PossiblyCurrentContext = PossiblyCurrentContext;
 
-    fn treat_as_current(self) -> Self::PossiblyCurrentContext {
-        gl_api_dispatch!(self; Self(context) => context.treat_as_current(); as PossiblyCurrentContext)
+    fn treat_as_possibly_current(self) -> Self::PossiblyCurrentContext {
+        gl_api_dispatch!(self; Self(context) => context.treat_as_possibly_current(); as PossiblyCurrentContext)
     }
 }
 


### PR DESCRIPTION
The function doesn't treat anything as current it treats as possibly current. This was causing confusing and looked like unsafe operation while in reality it was making an object with less options.

