### PR TITLE
api: rename `Display::from_raw` to `Display::new`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@
 - Add missing `GetGlConfig` implementation for `NotCurrentContext` and `PossiblyCurrentContext`.
 - Implement `Clone` for builders.
 - **Breaking:** move `DamageRect` into `surface::Rect`.
-- Added `GlDisplay::version_string` to help with logging the display information.
-- Renamed `NotCurrentGlContext::treat_as_current` to `NotCurrentGlContext::treat_as_possibly_current`.
+- Add `GlDisplay::version_string` to help with logging the display information.
+- Rename `NotCurrentGlContext::treat_as_current` to `NotCurrentGlContext::treat_as_possibly_current`.
+- Rename `Display::from_raw` to `Display::new`.
 
 # Version 0.30.0-beta.2 (2022-09-03)
 

--- a/glutin/src/api/cgl/display.rs
+++ b/glutin/src/api/cgl/display.rs
@@ -32,7 +32,7 @@ impl Display {
     /// # Safety
     ///
     /// The function is unsafe for consistency.
-    pub unsafe fn from_raw(display: RawDisplayHandle) -> Result<Self> {
+    pub unsafe fn new(display: RawDisplayHandle) -> Result<Self> {
         match display {
             RawDisplayHandle::AppKit(..) => Ok(Display { _marker: PhantomData }),
             _ => Err(ErrorKind::NotSupported("provided native display is not supported").into()),

--- a/glutin/src/api/egl/display.rs
+++ b/glutin/src/api/egl/display.rs
@@ -46,7 +46,7 @@ impl Display {
     /// `[std::ptr::null]` for the display will result in using
     /// `EGL_DEFAULT_DISPLAY`, which is not recommended or will
     /// work on a platform with a concept of native display, like Wayland.
-    pub unsafe fn from_raw(raw_display: RawDisplayHandle) -> Result<Self> {
+    pub unsafe fn new(raw_display: RawDisplayHandle) -> Result<Self> {
         let egl = match EGL.as_ref() {
             Some(egl) => egl,
             None => return Err(ErrorKind::NotFound.into()),

--- a/glutin/src/api/glx/display.rs
+++ b/glutin/src/api/glx/display.rs
@@ -38,7 +38,7 @@ impl Display {
     /// The `display` must point to the valid Xlib display and
     /// `error_hook_registrar` must be registered in your Xlib error handling
     /// callback.
-    pub unsafe fn from_raw(
+    pub unsafe fn new(
         display: RawDisplayHandle,
         error_hook_registrar: XlibErrorHookRegistrar,
     ) -> Result<Self> {

--- a/glutin/src/api/wgl/display.rs
+++ b/glutin/src/api/wgl/display.rs
@@ -41,7 +41,7 @@ impl Display {
     ///
     /// The `native_window` must point to the valid platform window and have
     /// valid `hinstance`.
-    pub unsafe fn from_raw(
+    pub unsafe fn new(
         display: RawDisplayHandle,
         native_window: Option<RawWindowHandle>,
     ) -> Result<Self> {

--- a/glutin/src/display.rs
+++ b/glutin/src/display.rs
@@ -191,55 +191,52 @@ impl Display {
     ///
     /// The `preference` must contain pointers to the valid values if GLX or WGL
     /// specific options were used.
-    pub unsafe fn from_raw(
-        display: RawDisplayHandle,
-        preference: DisplayApiPreference,
-    ) -> Result<Self> {
+    pub unsafe fn new(display: RawDisplayHandle, preference: DisplayApiPreference) -> Result<Self> {
         match preference {
             #[cfg(egl_backend)]
-            DisplayApiPreference::Egl => unsafe { Ok(Self::Egl(EglDisplay::from_raw(display)?)) },
+            DisplayApiPreference::Egl => unsafe { Ok(Self::Egl(EglDisplay::new(display)?)) },
             #[cfg(glx_backend)]
             DisplayApiPreference::Glx(registrar) => unsafe {
-                Ok(Self::Glx(GlxDisplay::from_raw(display, registrar)?))
+                Ok(Self::Glx(GlxDisplay::new(display, registrar)?))
             },
             #[cfg(all(egl_backend, glx_backend))]
             DisplayApiPreference::GlxThenEgl(registrar) => unsafe {
-                if let Ok(display) = GlxDisplay::from_raw(display, registrar) {
+                if let Ok(display) = GlxDisplay::new(display, registrar) {
                     Ok(Self::Glx(display))
                 } else {
-                    Ok(Self::Egl(EglDisplay::from_raw(display)?))
+                    Ok(Self::Egl(EglDisplay::new(display)?))
                 }
             },
             #[cfg(all(egl_backend, glx_backend))]
             DisplayApiPreference::EglThenGlx(registrar) => unsafe {
-                if let Ok(display) = EglDisplay::from_raw(display) {
+                if let Ok(display) = EglDisplay::new(display) {
                     Ok(Self::Egl(display))
                 } else {
-                    Ok(Self::Glx(GlxDisplay::from_raw(display, registrar)?))
+                    Ok(Self::Glx(GlxDisplay::new(display, registrar)?))
                 }
             },
             #[cfg(wgl_backend)]
             DisplayApiPreference::Wgl(window_handle) => unsafe {
-                Ok(Self::Wgl(WglDisplay::from_raw(display, window_handle)?))
+                Ok(Self::Wgl(WglDisplay::new(display, window_handle)?))
             },
             #[cfg(all(egl_backend, wgl_backend))]
             DisplayApiPreference::EglThenWgl(window_handle) => unsafe {
-                if let Ok(display) = EglDisplay::from_raw(display) {
+                if let Ok(display) = EglDisplay::new(display) {
                     Ok(Self::Egl(display))
                 } else {
-                    Ok(Self::Wgl(WglDisplay::from_raw(display, window_handle)?))
+                    Ok(Self::Wgl(WglDisplay::new(display, window_handle)?))
                 }
             },
             #[cfg(all(egl_backend, wgl_backend))]
             DisplayApiPreference::WglThenEgl(window_handle) => unsafe {
-                if let Ok(display) = WglDisplay::from_raw(display, window_handle) {
+                if let Ok(display) = WglDisplay::new(display, window_handle) {
                     Ok(Self::Wgl(display))
                 } else {
-                    Ok(Self::Egl(EglDisplay::from_raw(display)?))
+                    Ok(Self::Egl(EglDisplay::new(display)?))
                 }
             },
             #[cfg(cgl_backend)]
-            DisplayApiPreference::Cgl => unsafe { Ok(Self::Cgl(CglDisplay::from_raw(display)?)) },
+            DisplayApiPreference::Cgl => unsafe { Ok(Self::Cgl(CglDisplay::new(display)?)) },
         }
     }
 }

--- a/glutin_examples/src/lib.rs
+++ b/glutin_examples/src/lib.rs
@@ -293,7 +293,7 @@ pub fn create_display(
     let preference = DisplayApiPreference::GlxThenEgl(Box::new(unix::register_xlib_error_hook));
 
     // Create connection to underlying OpenGL client Api.
-    unsafe { Display::from_raw(raw_display, preference).unwrap() }
+    unsafe { Display::new(raw_display, preference).unwrap() }
 }
 
 pub struct Renderer {


### PR DESCRIPTION
This should make it clear that we don't take ownership of the pointer and don't build from e.g. EGLDisplay.

Fixed  #1478.
