### PR TITLE
glx: fix attribute list termination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Rename `Display::from_raw` to `Display::new`.
 - Added `GlDisplay::supported_features` to allow checking for extensions support beforehand.
 - **Breaking:** renamed `ReleaseBehaviour` to `ReleaseBehavior`.
+- Fix GLX not working with nvidia binary drivers.
 
 # Version 0.30.0-beta.2 (2022-09-03)
 

--- a/glutin/src/api/glx/config.rs
+++ b/glutin/src/api/glx/config.rs
@@ -143,8 +143,8 @@ impl Display {
             }
         }
 
-        // Push `glx::NONE` to terminate the list.
-        config_attributes.push(glx::NONE as c_int);
+        // Push X11 `None` to terminate the list.
+        config_attributes.push(0);
 
         unsafe {
             let mut num_configs = 0;

--- a/glutin/src/api/glx/surface.rs
+++ b/glutin/src/api/glx/surface.rs
@@ -43,8 +43,8 @@ impl Display {
 
         let mut attrs = Vec::<c_int>::with_capacity(ATTR_SIZE_HINT);
 
-        // Push `glx::NONE` to terminate the list.
-        attrs.push(glx::NONE as c_int);
+        // Push X11 `None` to terminate the list.
+        attrs.push(0);
 
         let config = config.clone();
         let surface = unsafe {
@@ -84,8 +84,8 @@ impl Display {
         attrs.push(glx::LARGEST_PBUFFER as c_int);
         attrs.push(surface_attributes.largest_pbuffer as c_int);
 
-        // Push `glx::NONE` to terminate the list.
-        attrs.push(glx::NONE as c_int);
+        // Push X11 `None` to terminate the list.
+        attrs.push(0);
 
         let config = config.clone();
         let surface = unsafe {
@@ -119,8 +119,8 @@ impl Display {
 
         let mut attrs = Vec::<c_int>::with_capacity(ATTR_SIZE_HINT);
 
-        // Push `glx::NONE` to terminate the list.
-        attrs.push(glx::NONE as c_int);
+        // Push X11 `None` to terminate the list.
+        attrs.push(0);
 
         let config = config.clone();
         let surface = unsafe {


### PR DESCRIPTION
The lists are terminated with X11 None which is zero, but we were using the glx None, which is 0x8000. While mesa allows that, nvidia does not.

Fixes #1496.

