### PR TITLE
api: don't overwrite user specified context version

### DIFF
--- a/glutin/src/api/egl/context.rs
+++ b/glutin/src/api/egl/context.rs
@@ -9,7 +9,7 @@ use glutin_egl_sys::{egl, EGLContext};
 
 use crate::config::{Api, GetGlConfig};
 use crate::context::{
-    AsRawContext, ContextApi, ContextAttributes, GlProfile, RawContext, Robustness, Version,
+    self, AsRawContext, ContextApi, ContextAttributes, GlProfile, RawContext, Robustness, Version,
 };
 use crate::display::{DisplayFeatures, GetGlDisplay};
 use crate::error::{ErrorKind, Result};
@@ -60,13 +60,12 @@ impl Display {
 
             // Add profile for the OpenGL Api.
             if api == egl::OPENGL_API {
-                let profile = match context_attributes.profile {
-                    Some(GlProfile::Core) | None => {
-                        version = Some(Version::new(3, 3));
-                        egl::CONTEXT_OPENGL_CORE_PROFILE_BIT
-                    },
-
-                    Some(GlProfile::Compatibility) => egl::CONTEXT_OPENGL_COMPATIBILITY_PROFILE_BIT,
+                let (profile, new_version) =
+                    context::pick_profile(context_attributes.profile, version);
+                version = Some(new_version);
+                let profile = match profile {
+                    GlProfile::Core => egl::CONTEXT_OPENGL_CORE_PROFILE_BIT,
+                    GlProfile::Compatibility => egl::CONTEXT_OPENGL_COMPATIBILITY_PROFILE_BIT,
                 };
 
                 attrs.push(egl::CONTEXT_OPENGL_PROFILE_MASK as EGLint);

--- a/glutin/src/context.rs
+++ b/glutin/src/context.rs
@@ -594,3 +594,20 @@ pub enum RawContext {
     #[cfg(cgl_backend)]
     Cgl(*const ffi::c_void),
 }
+
+/// Pick `GlProfile` and `Version` based on the provided params.
+#[cfg(any(egl_backend, glx_backend, wgl_backend))]
+pub(crate) fn pick_profile(
+    profile: Option<GlProfile>,
+    version: Option<Version>,
+) -> (GlProfile, Version) {
+    match (profile, version) {
+        (Some(GlProfile::Core), Some(version)) => (GlProfile::Core, version),
+        (Some(GlProfile::Compatibility), Some(version)) => (GlProfile::Compatibility, version),
+        (None, Some(version)) if version >= Version::new(3, 3) => (GlProfile::Core, version),
+        (None, Some(version)) => (GlProfile::Compatibility, version),
+        (Some(GlProfile::Core), None) => (GlProfile::Core, Version::new(3, 3)),
+        (Some(GlProfile::Compatibility), None) => (GlProfile::Compatibility, Version::new(2, 1)),
+        (None, None) => (GlProfile::Core, Version::new(3, 3)),
+    }
+}


### PR DESCRIPTION
We shouldn't do that when the user doesn't provide profile. Instead we should try to guess the intent and use appropriate profile with the user provided version.

