### PR TITLE
set default target for docs.rs

### DIFF
--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -68,3 +68,4 @@ targets = [
     "i686-unknown-linux-gnu",
     "i686-pc-windows-msvc",
 ]
+default-target = "x86_64-unknown-linux-gnu"


### PR DESCRIPTION
If the default target is not set and a list of targets is specifed, the first target is selected. Likely not too useful to have android be the default target on docs.rs

- [X] Tested on all platforms changed
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [X] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [X] Created or updated an example program if it would help users understand this functionality
