### PR TITLE
fix: call to GetDC in swap_buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- On Windows (WGL), fixed that `Surface::swap_buffers` takes longer with every call caused by frequent calls of the win32 function `HDC GetDC(HWND hWnd)`.
+- On WGL, fixed that `Surface::swap_buffers` takes longer with every call caused by frequent calls of the win32 function `HDC GetDC(HWND hWnd)`.
 
 # Version 0.30.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- On Windows (WGL), fixed that `Surface::swap_buffers` takes longer with every call caused by frequent calls of the win32 function `HDC GetDC(HWND hWnd)`.
+
 # Version 0.30.0
 
 - **This version of `glutin` has been rewritten from the ground and no longer depends on `winit`, the `raw-window-handle` is now used instead of it.**

--- a/glutin/src/api/wgl/context.rs
+++ b/glutin/src/api/wgl/context.rs
@@ -372,8 +372,7 @@ impl ContextInner {
 
     fn make_current<T: SurfaceTypeTrait>(&self, surface: &Surface<T>) -> Result<()> {
         unsafe {
-            let hdc = gdi::GetDC(surface.hwnd);
-            if wgl::MakeCurrent(hdc as _, self.raw.cast()) == 0 {
+            if wgl::MakeCurrent(surface.hdc as _, self.raw.cast()) == 0 {
                 Err(IoError::last_os_error().into())
             } else {
                 Ok(())

--- a/glutin/src/api/wgl/surface.rs
+++ b/glutin/src/api/wgl/surface.rs
@@ -78,7 +78,9 @@ pub struct Surface<T: SurfaceTypeTrait> {
 
 impl<T: SurfaceTypeTrait> Drop for Surface<T> {
     fn drop(&mut self) {
-        unsafe { gdi::ReleaseDC(self.hwnd, self.hdc); }
+        unsafe { 
+            gdi::ReleaseDC(self.hwnd, self.hdc);
+        }
     }
 }
 

--- a/glutin/src/api/wgl/surface.rs
+++ b/glutin/src/api/wgl/surface.rs
@@ -78,7 +78,7 @@ pub struct Surface<T: SurfaceTypeTrait> {
 
 impl<T: SurfaceTypeTrait> Drop for Surface<T> {
     fn drop(&mut self) {
-        // This line intentionally left blank.
+        unsafe { gdi::ReleaseDC(self.hwnd, self.hdc); }
     }
 }
 
@@ -158,6 +158,7 @@ impl<T: SurfaceTypeTrait> fmt::Debug for Surface<T> {
         f.debug_struct("Surface")
             .field("config", &self.config.inner.pixel_format_index)
             .field("hwnd", &self.hwnd)
+            .field("hdc", &self.hdc)
             .finish()
     }
 }

--- a/glutin/src/api/wgl/surface.rs
+++ b/glutin/src/api/wgl/surface.rs
@@ -78,7 +78,7 @@ pub struct Surface<T: SurfaceTypeTrait> {
 
 impl<T: SurfaceTypeTrait> Drop for Surface<T> {
     fn drop(&mut self) {
-        unsafe { 
+        unsafe {
             gdi::ReleaseDC(self.hwnd, self.hdc);
         }
     }


### PR DESCRIPTION
- fix the error that frequent calls to GetDC slows down swap_buffers over time
- moved the call of GetDC to the surface creation and cached the HDC in WGL's GlSurface

Frequent calls to GetDC slows down swap_buffers over time. The issue is also described in https://stackoverflow.com/questions/37347939/swapbuffers-getting-slow-over-time.

The change fixes the issue, but I'm not quite sure if it is problematic that the aquired handle is not release with a following
call to ReleaseDC (see https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getdc).

If required I can provide an example to reproduce the issue.

Frametimes before the change:

![grafik](https://user-images.githubusercontent.com/19536702/198818299-43ca0db6-6b52-4bad-b187-9a6ff1126cb7.png)

Frametimes after the change:

![grafik](https://user-images.githubusercontent.com/19536702/198818369-a3b35a0d-8659-405d-80ba-2a392b47cb4d.png)
