### PR TITLE
glx: try all extensions when setting vsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- On GLX, try all extensions when setting vsync.
 - On WGL, fixed that `Surface::swap_buffers` takes longer with every call caused by frequent calls of the win32 function `HDC GetDC(HWND hWnd)`.
 
 # Version 0.30.0

--- a/glutin_egl_sys/build.rs
+++ b/glutin_egl_sys/build.rs
@@ -18,7 +18,7 @@ fn main() {
         || target.contains("android")
         || target.contains("ios")
     {
-        let mut file = File::create(&dest.join("egl_bindings.rs")).unwrap();
+        let mut file = File::create(dest.join("egl_bindings.rs")).unwrap();
         let reg = Registry::new(Api::Egl, (1, 5), Profile::Core, Fallbacks::All, [
             "EGL_ANDROID_native_fence_sync",
             "EGL_EXT_buffer_age",

--- a/glutin_examples/build.rs
+++ b/glutin_examples/build.rs
@@ -33,7 +33,7 @@ fn main() {
 
     println!("cargo:rerun-if-changed=build.rs");
 
-    let mut file = File::create(&dest.join("gl_bindings.rs")).unwrap();
+    let mut file = File::create(dest.join("gl_bindings.rs")).unwrap();
     Registry::new(Api::Gles2, (3, 0), Profile::Core, Fallbacks::All, [])
         .write_bindings(StructGenerator, &mut file)
         .unwrap();

--- a/glutin_gles2_sys/build.rs
+++ b/glutin_gles2_sys/build.rs
@@ -12,7 +12,7 @@ fn main() {
     if target.contains("ios") {
         println!("cargo:rustc-link-lib=framework=GLKit");
         println!("cargo:rustc-link-lib=framework=OpenGLES");
-        let mut file = File::create(&dest.join("gles2_bindings.rs")).unwrap();
+        let mut file = File::create(dest.join("gles2_bindings.rs")).unwrap();
         Registry::new(Api::Gles2, (2, 0), Profile::Core, Fallbacks::None, [])
             .write_bindings(gl_generator::StaticStructGenerator, &mut file)
             .unwrap();

--- a/glutin_glx_sys/build.rs
+++ b/glutin_glx_sys/build.rs
@@ -15,12 +15,12 @@ fn main() {
         || target.contains("netbsd")
         || target.contains("openbsd")
     {
-        let mut file = File::create(&dest.join("glx_bindings.rs")).unwrap();
+        let mut file = File::create(dest.join("glx_bindings.rs")).unwrap();
         Registry::new(Api::Glx, (1, 4), Profile::Core, Fallbacks::All, [])
             .write_bindings(gl_generator::StructGenerator, &mut file)
             .unwrap();
 
-        let mut file = File::create(&dest.join("glx_extra_bindings.rs")).unwrap();
+        let mut file = File::create(dest.join("glx_extra_bindings.rs")).unwrap();
         Registry::new(Api::Glx, (1, 4), Profile::Core, Fallbacks::All, [
             "GLX_ARB_context_flush_control",
             "GLX_ARB_create_context",

--- a/glutin_wgl_sys/build.rs
+++ b/glutin_wgl_sys/build.rs
@@ -10,12 +10,12 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
     if target.contains("windows") {
-        let mut file = File::create(&dest.join("wgl_bindings.rs")).unwrap();
+        let mut file = File::create(dest.join("wgl_bindings.rs")).unwrap();
         Registry::new(Api::Wgl, (1, 0), Profile::Core, Fallbacks::All, [])
             .write_bindings(gl_generator::StaticGenerator, &mut file)
             .unwrap();
 
-        let mut file = File::create(&dest.join("wgl_extra_bindings.rs")).unwrap();
+        let mut file = File::create(dest.join("wgl_extra_bindings.rs")).unwrap();
         Registry::new(Api::Wgl, (1, 0), Profile::Core, Fallbacks::All, [
             "WGL_ARB_context_flush_control",
             "WGL_ARB_create_context",


### PR DESCRIPTION
This also fixes clippy issues in build.rs.

Fixes #1513.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
