### PR TITLE
Fix build on windows (examples)

### DIFF
--- a/glutin-winit/Cargo.toml
+++ b/glutin-winit/Cargo.toml
@@ -9,6 +9,9 @@ readme = "README.md"
 repository = "https://github.com/rust-windowing/glutin"
 edition = "2021"
 
+# Custom path for the build script
+build = "../glutin/build.rs"
+
 [features]
 default = ["egl", "glx", "x11", "wayland", "wgl"]
 egl = ["glutin/egl"]

--- a/glutin-winit/build.rs
+++ b/glutin-winit/build.rs
@@ -1,1 +1,0 @@
-../glutin/build.rs


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality

### Why?
On the sub-crate `glutin-winit` it was used a symlink to share its build script with glutin, but symlinks on windows git are problematic, not enabled by default and only easily available on window 10+, so to avoid platform specific behaviour I just suggest using the cargo manifest attribute to specify the path of the build script outside its base folder.
