### PR TITLE
egl: fix robust context creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Fixed robust context creation with EGL.
 - Moved to stable version of `wayland-sys`.
 - Allow offline renderers with CGL.
 - Fixed an error when compiling the EGL backend with only one of Wayland and X11 enabled.

--- a/glutin/src/api/egl/context.rs
+++ b/glutin/src/api/egl/context.rs
@@ -91,12 +91,12 @@ impl Display {
                 Robustness::RobustLoseContextOnReset if has_robustsess => {
                     attrs.push(egl::CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY as EGLint);
                     attrs.push(egl::LOSE_CONTEXT_ON_RESET as EGLint);
-                    flags |= egl::CONTEXT_OPENGL_ROBUST_ACCESS;
+                    flags |= egl::CONTEXT_OPENGL_ROBUST_ACCESS_BIT_KHR;
                 },
                 Robustness::RobustNoResetNotification if has_robustsess => {
                     attrs.push(egl::CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY as EGLint);
                     attrs.push(egl::NO_RESET_NOTIFICATION as EGLint);
-                    flags |= egl::CONTEXT_OPENGL_ROBUST_ACCESS;
+                    flags |= egl::CONTEXT_OPENGL_ROBUST_ACCESS_BIT_KHR;
                 },
                 _ => {
                     return Err(


### PR DESCRIPTION
Wrong enum entry was used to set robust context flag.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
