### PR TITLE
Glutin version 0.30.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# Version 0.30.2
+
 - Fixed robust context creation with EGL.
 - Moved to stable version of `wayland-sys`.
 - Allow offline renderers with CGL.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A low-level library for OpenGL context creation.
 
 ```toml
 [dependencies]
-glutin = "0.30.1"
+glutin = "0.30.2"
 ```
 
 ## [Documentation](https://docs.rs/glutin)
@@ -22,7 +22,7 @@ Join us in any of these:
 ## Usage Examples
 
 **Warning:** these are examples for master. For the latest released version you can
-find them [here](https://github.com/rust-windowing/glutin/releases/tag/v0.30.1).
+find them [here](https://github.com/rust-windowing/glutin/releases/tag/v0.30.2).
 
 The examples use [gl_generator](https://crates.io/crates/gl_generator) to
 generate OpenGL bindings.

--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glutin"
-version = "0.30.1"
+version = "0.30.2"
 authors = ["Kirill Chibisov <contact@kchibisov.com>"]
 description = "Cross-platform OpenGL context provider."
 keywords = ["windowing", "opengl", "egl"]


### PR DESCRIPTION
--

This should fix issues with the build failures on EGL platforms.