### PR TITLE
egl/surface: fix swap_buffers_with_damage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fixed wrong amount of rects commited in `Surface::swap_buffers_with_damage` with EGL.
+
 # Version 0.30.2
 
 - Fixed robust context creation with EGL.

--- a/glutin/src/api/egl/surface.rs
+++ b/glutin/src/api/egl/surface.rs
@@ -255,7 +255,7 @@ impl<T: SurfaceTypeTrait> Surface<T> {
                     *self.display.inner.raw,
                     self.raw,
                     rects.as_ptr() as *mut _,
-                    (rects.len() * 4) as _,
+                    rects.len() as _,
                 )
             } else if self
                 .display
@@ -267,7 +267,7 @@ impl<T: SurfaceTypeTrait> Surface<T> {
                     *self.display.inner.raw,
                     self.raw,
                     rects.as_ptr() as *mut _,
-                    (rects.len() * 4) as _,
+                    rects.len() as _,
                 )
             } else {
                 self.display.inner.egl.SwapBuffers(*self.display.inner.raw, self.raw)


### PR DESCRIPTION
The wrong amount of rects were committed in those functions leading to spurious rectangles being sent to the system compositor.

