### PR TITLE
api/surface: add missing derives on Rect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Fixed wrong amount of rects commited in `Surface::swap_buffers_with_damage` with EGL.
+- Added missing `Eq`, `PartialEq`, and `Hash` impls for `surface::Rect`.
 
 # Version 0.30.2
 

--- a/glutin/src/surface.rs
+++ b/glutin/src/surface.rs
@@ -504,7 +504,7 @@ pub enum RawSurface {
 ///
 /// The origin is in the bottom left of the surface.
 #[repr(C)]
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 pub struct Rect {
     /// `X` of the origin.
     pub x: i32,


### PR DESCRIPTION
This should provide a way to compare rects for equality and use them as a hash key downstream.