### PR TITLE
Fix initialization of EGL display from xcb display handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fixed EGL display initialization with XcbDisplayHandle.
+
 # Version 0.30.3
 
 - Fixed wrong amount of rects commited in `Surface::swap_buffers_with_damage` with EGL.

--- a/glutin/src/api/egl/display.rs
+++ b/glutin/src/api/egl/display.rs
@@ -257,7 +257,7 @@ impl Display {
                 if extensions.contains("EGL_MESA_platform_xcb")
                     || extensions.contains("EGL_EXT_platform_xcb") =>
             {
-                attrs.push(egl::PLATFORM_XCB_EXT as EGLint);
+                attrs.push(egl::PLATFORM_XCB_SCREEN_EXT as EGLint);
                 attrs.push(handle.screen as EGLint);
                 (egl::PLATFORM_XCB_EXT, handle.connection)
             },

--- a/glutin_egl_sys/src/lib.rs
+++ b/glutin_egl_sys/src/lib.rs
@@ -29,7 +29,7 @@ pub mod egl {
     // TODO should upstream these:
     // EGL_EXT_platform_xcb
     pub const PLATFORM_XCB_EXT: super::EGLenum = 0x31DC;
-    pub const PLATFORM_XCB_SCREEN_EXT: super::EGLenum = 0x31DC;
+    pub const PLATFORM_XCB_SCREEN_EXT: super::EGLenum = 0x31DE;
     // EGL_EXT_device_query_name
     pub const RENDERER_EXT: super::EGLenum = 0x335F;
 }


### PR DESCRIPTION
* https://registry.khronos.org/EGL/extensions/EXT/EGL_EXT_platform_xcb.txt suggests that the value for EGL_PLATFORM_XCB_SCREEN_EXT is 0x31DE
* Pass EGL_PLATFORM_XCB_SCREEN_EXT as screen selection attribute instead of the platform parameter PLATFORM_XCB_EXT

- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
