### PR TITLE
Add glutin-winit GlWindow trait helper

### DIFF
--- a/glutin-winit/CHANGELOG.md
+++ b/glutin-winit/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Unreleased
+
+- Add traits `GlWindow` with helper methods for building and resizing surfaces using a winit `Window`.
+
+# Version 0.2.1
+
+- Fix WGL window initialization.
+
+# Version 0.2.0
+
+- Fix API typo.
+
+# Version 0.1.0
+
+- Implement _glutin-winit_ helpers.

--- a/glutin-winit/src/lib.rs
+++ b/glutin-winit/src/lib.rs
@@ -8,6 +8,10 @@
 #![deny(missing_docs)]
 #![cfg_attr(feature = "cargo-clippy", deny(warnings))]
 
+mod window;
+
+pub use window::GlWindow;
+
 use std::error::Error;
 
 use glutin::config::{Config, ConfigTemplateBuilder};

--- a/glutin-winit/src/window.rs
+++ b/glutin-winit/src/window.rs
@@ -1,0 +1,80 @@
+use glutin::context::PossiblyCurrentContext;
+use glutin::surface::{
+    GlSurface, ResizeableSurface, Surface, SurfaceAttributes, SurfaceAttributesBuilder,
+    SurfaceTypeTrait, WindowSurface,
+};
+use raw_window_handle::HasRawWindowHandle;
+use std::num::NonZeroU32;
+use winit::window::Window;
+
+/// [`Window`] extensions for working with [`glutin`] surfaces.
+pub trait GlWindow {
+    /// Build the surface attributes suitable to create a window surface.
+    ///
+    /// # Panics
+    /// Panics if either window inner dimension is zero.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use glutin_winit::GlWindow;
+    /// # let winit_window: winit::window::Window = unimplemented!();
+    ///
+    /// let attrs = winit_window.build_surface_attributes(<_>::default());
+    /// ```
+    fn build_surface_attributes(
+        &self,
+        builder: SurfaceAttributesBuilder<WindowSurface>,
+    ) -> SurfaceAttributes<WindowSurface>;
+
+    /// Resize the surface to the window inner size.
+    ///
+    /// No-op if either window size is zero.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use glutin_winit::GlWindow;
+    /// # use glutin::surface::{Surface, WindowSurface};
+    /// # let winit_window: winit::window::Window = unimplemented!();
+    /// # let (gl_surface, gl_context): (Surface<WindowSurface>, _) = unimplemented!();
+    ///
+    /// winit_window.resize_surface(&gl_surface, &gl_context);
+    /// ```
+    fn resize_surface(
+        &self,
+        surface: &Surface<impl SurfaceTypeTrait + ResizeableSurface>,
+        context: &PossiblyCurrentContext,
+    );
+}
+
+impl GlWindow for Window {
+    fn build_surface_attributes(
+        &self,
+        builder: SurfaceAttributesBuilder<WindowSurface>,
+    ) -> SurfaceAttributes<WindowSurface> {
+        let (w, h) = self.inner_size().non_zero().expect("invalid zero inner size");
+        builder.build(self.raw_window_handle(), w, h)
+    }
+
+    fn resize_surface(
+        &self,
+        surface: &Surface<impl SurfaceTypeTrait + ResizeableSurface>,
+        context: &PossiblyCurrentContext,
+    ) {
+        if let Some((w, h)) = self.inner_size().non_zero() {
+            surface.resize(context, w, h)
+        }
+    }
+}
+
+/// [`winit::dpi::PhysicalSize<u32>`] non-zero extensions.
+trait NonZeroU32PhysicalSize {
+    /// Converts to non-zero `(width, height)`.
+    fn non_zero(self) -> Option<(NonZeroU32, NonZeroU32)>;
+}
+impl NonZeroU32PhysicalSize for winit::dpi::PhysicalSize<u32> {
+    fn non_zero(self) -> Option<(NonZeroU32, NonZeroU32)> {
+        let w = NonZeroU32::new(self.width)?;
+        let h = NonZeroU32::new(self.height)?;
+        Some((w, h))
+    }
+}


### PR DESCRIPTION
I thought I'd experiment with reducing the noise using glutin-winit vs glutin `0.29`. This pr adds `glutin_winit::GlWindow` trait with extensions for winit `Window`s. (It could alternatively be called `glutin_winit::WindowExt` if you prefer).

I updated the example replacing the example `GlWindow` struct as it's simpler to use the trait.

I think this is quite a light touch, but still useful. Wdyt?

- [x] ~Tested on all platforms changed~
- [x] ~Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users~
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
