### PR TITLE
Fixed EGL/GLX `Surface::width` returning height instead of width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Fixed EGL display initialization with XcbDisplayHandle.
+- Fixed EGL/GLX `Surface::width` returning the height instead of the width
 
 # Version 0.30.3
 
@@ -33,7 +34,7 @@
 - The underlying Api providers are publically exposed now, so glutin could be used with just e.g. `EGL`.
 - Fixed soundness issues with `Surface` MT safety, since before `EGLSurface` could be sent to a different thread, which is not safe.
 - Fallback to `Surface::swap_buffers` when `Surface::swap_buffers_with_damage` is not supported on `EGL`.
- 
+
 # Version 0.29.1 (2022-08-10)
 
 - Fix build failures when building from crates.io

--- a/glutin/src/api/egl/surface.rs
+++ b/glutin/src/api/egl/surface.rs
@@ -320,7 +320,7 @@ impl<T: SurfaceTypeTrait> GlSurface<T> for Surface<T> {
     }
 
     fn width(&self) -> Option<u32> {
-        unsafe { Some(self.raw_attribute(egl::HEIGHT as EGLint) as u32) }
+        unsafe { Some(self.raw_attribute(egl::WIDTH as EGLint) as u32) }
     }
 
     fn height(&self) -> Option<u32> {

--- a/glutin/src/api/glx/surface.rs
+++ b/glutin/src/api/glx/surface.rs
@@ -205,7 +205,7 @@ impl<T: SurfaceTypeTrait> GlSurface<T> for Surface<T> {
     }
 
     fn width(&self) -> Option<u32> {
-        unsafe { Some(self.raw_attribute(glx::HEIGHT as c_int) as u32) }
+        unsafe { Some(self.raw_attribute(glx::WIDTH as c_int) as u32) }
     }
 
     fn height(&self) -> Option<u32> {


### PR DESCRIPTION
- [X] Tested on all platforms changed
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality

Tested it by adding a temporary `println!()` outputting the `gl_window.surface.width()` and `gl_window.surface.height()`, which returned the height before, and now returns the expected value.