### PR TITLE
ci: fix android ci job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
 
     - name: Install cargo-apk
       if: contains(matrix.platform.target, 'android')
-      run: cargo install cargo-apk
+      run: cargo +stable install cargo-apk
 
     - name: Build tests
       shell: bash


### PR DESCRIPTION
This should install cargo-apk using stable and not the MSRV, since testing its MSRV is irrelevant for glutin.
