### PR TITLE
glx: harden error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Unreleased
 
 - Fixed EGL display initialization with XcbDisplayHandle.
-- Fixed EGL/GLX `Surface::width` returning the height instead of the width
+- Fixed EGL/GLX `Surface::width` returning the height instead of the width.
+- On GLX, fixed handling of errors not directly requested by glutin.
 
 # Version 0.30.3
 

--- a/glutin/src/api/glx/context.rs
+++ b/glutin/src/api/glx/context.rs
@@ -388,6 +388,7 @@ impl Drop for ContextInner {
         unsafe {
             self.display.inner.glx.DestroyContext(self.display.inner.raw.cast(), *self.raw);
         }
+        let _ = super::last_glx_error(self.display.inner.raw);
     }
 }
 

--- a/glutin/src/api/glx/surface.rs
+++ b/glutin/src/api/glx/surface.rs
@@ -188,6 +188,7 @@ impl<T: SurfaceTypeTrait> Drop for Surface<T> {
                 },
             }
         }
+        let _ = super::last_glx_error(self.display.inner.raw);
     }
 }
 


### PR DESCRIPTION
This also adjusts the use of the hook for the upcoming winit update which has a bug leaking errors. Now glutin hook will handle when it forces sync with X server.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
