### PR TITLE
glutin-winit: Update to winit 0.28

### DIFF
--- a/glutin-winit/CHANGELOG.md
+++ b/glutin-winit/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- **Breaking:** Update _winit_ to `0.28`. See [winit's CHANGELOG](https://github.com/rust-windowing/winit/releases/tag/v0.28.0) for more info.
+
 # Version 0.2.2
 
 - Add traits `GlWindow` with helper methods for building and resizing surfaces using a winit `Window`.

--- a/glutin-winit/Cargo.toml
+++ b/glutin-winit/Cargo.toml
@@ -18,7 +18,7 @@ x11 = ["glutin/x11", "winit/x11"]
 wayland = ["glutin/wayland", "winit/wayland"]
 
 [dependencies]
-winit = { version = "0.27.5", default-features = false }
+winit = { version = "0.28", default-features = false }
 glutin = { version = "0.30.1", path = "../glutin", default-features = false }
 raw-window-handle = "0.5.0"
 

--- a/glutin-winit/Cargo.toml
+++ b/glutin-winit/Cargo.toml
@@ -18,7 +18,7 @@ x11 = ["glutin/x11", "winit/x11"]
 wayland = ["glutin/wayland", "winit/wayland"]
 
 [dependencies]
-winit = { version = "0.28", default-features = false }
+winit = { version = "0.28.1", default-features = false }
 glutin = { version = "0.30.1", path = "../glutin", default-features = false }
 raw-window-handle = "0.5.0"
 

--- a/glutin-winit/src/lib.rs
+++ b/glutin-winit/src/lib.rs
@@ -30,9 +30,9 @@ use winit::event_loop::EventLoopWindowTarget;
 use winit::window::{Window, WindowBuilder};
 
 #[cfg(glx_backend)]
-use winit::platform::unix;
+use winit::platform::x11::register_xlib_error_hook;
 #[cfg(x11_platform)]
-use winit::platform::unix::WindowBuilderExtUnix;
+use winit::platform::x11::WindowBuilderExtX11;
 
 #[cfg(all(not(egl_backend), not(glx_backend), not(wgl_backend), not(cgl_backend)))]
 compile_error!("Please select at least one api backend");
@@ -147,7 +147,7 @@ fn create_display<T>(
     let _preference = DisplayApiPreference::Egl;
 
     #[cfg(glx_backend)]
-    let _preference = DisplayApiPreference::Glx(Box::new(unix::register_xlib_error_hook));
+    let _preference = DisplayApiPreference::Glx(Box::new(register_xlib_error_hook));
 
     #[cfg(cgl_backend)]
     let _preference = DisplayApiPreference::Cgl;
@@ -158,10 +158,10 @@ fn create_display<T>(
     #[cfg(all(egl_backend, glx_backend))]
     let _preference = match _api_preference {
         ApiPrefence::PreferEgl => {
-            DisplayApiPreference::EglThenGlx(Box::new(unix::register_xlib_error_hook))
+            DisplayApiPreference::EglThenGlx(Box::new(register_xlib_error_hook))
         },
         ApiPrefence::FallbackEgl => {
-            DisplayApiPreference::GlxThenEgl(Box::new(unix::register_xlib_error_hook))
+            DisplayApiPreference::GlxThenEgl(Box::new(register_xlib_error_hook))
         },
     };
 

--- a/glutin/src/display.rs
+++ b/glutin/src/display.rs
@@ -507,7 +507,7 @@ impl fmt::Debug for DisplayApiPreference {
             DisplayApiPreference::Cgl => "Cgl",
         };
 
-        f.write_fmt(format_args!("DisplayApiPreference::{}", api))
+        f.write_fmt(format_args!("DisplayApiPreference::{api}"))
     }
 }
 

--- a/glutin/src/error.rs
+++ b/glutin/src/error.rs
@@ -50,7 +50,7 @@ impl Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(raw_code) = self.raw_code {
-            write!(f, "[{:x}] ", raw_code)?;
+            write!(f, "[{raw_code:x}] ")?;
         }
 
         let msg = if let Some(raw_os_message) = self.raw_os_message.as_ref() {
@@ -59,7 +59,7 @@ impl fmt::Display for Error {
             self.kind.as_str()
         };
 
-        write!(f, "{}", msg)
+        write!(f, "{msg}")
     }
 }
 

--- a/glutin_examples/Cargo.toml
+++ b/glutin_examples/Cargo.toml
@@ -16,17 +16,17 @@ egl = ["glutin-winit/egl", "png"]
 glx = ["glutin-winit/glx"]
 wgl = ["glutin-winit/wgl"]
 x11 = ["glutin-winit/x11"]
-wayland = ["glutin-winit/wayland", "winit/wayland-dlopen", "winit/wayland-csd-adwaita-notitle"]
+wayland = ["glutin-winit/wayland", "winit/wayland-dlopen", "winit/wayland-csd-adwaita"]
 
 [dependencies]
 glutin = { path = "../glutin", default-features = false }
-winit = { version = "0.28", default-features = false }
+winit = { version = "0.28.1", default-features = false }
 glutin-winit = { path = "../glutin-winit", default-features = false }
 raw-window-handle = "0.5.0"
 png = { version = "0.17.6", optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
-ndk-glue = "0.7" # Keep in sync with winit dependency
+winit = { version = "0.28.1", default-features = false, features = ["android-native-activity"] }
 
 [build-dependencies]
 gl_generator = "0.14"

--- a/glutin_examples/Cargo.toml
+++ b/glutin_examples/Cargo.toml
@@ -20,7 +20,7 @@ wayland = ["glutin-winit/wayland", "winit/wayland-dlopen", "winit/wayland-csd-ad
 
 [dependencies]
 glutin = { path = "../glutin", default-features = false }
-winit = { version = "0.27.2", default-features = false }
+winit = { version = "0.28", default-features = false }
 glutin-winit = { path = "../glutin-winit", default-features = false }
 raw-window-handle = "0.5.0"
 png = { version = "0.17.6", optional = true }

--- a/glutin_examples/examples/android.rs
+++ b/glutin_examples/examples/android.rs
@@ -1,6 +1,10 @@
 #![cfg(target_os = "android")]
 
-#[ndk_glue::main(backtrace = "on")]
-fn main() {
-    glutin_examples::main()
+use winit::event_loop::EventLoopBuilder;
+use winit::platform::android::EventLoopBuilderExtAndroid;
+
+#[no_mangle]
+fn android_main(app: winit::platform::android::activity::AndroidApp) {
+    let event_loop = EventLoopBuilder::new().with_android_app(app).build();
+    glutin_examples::main(event_loop)
 }

--- a/glutin_examples/examples/window.rs
+++ b/glutin_examples/examples/window.rs
@@ -1,3 +1,5 @@
+use winit::event_loop::EventLoopBuilder;
+
 fn main() {
-    glutin_examples::main()
+    glutin_examples::main(EventLoopBuilder::new().build())
 }

--- a/glutin_examples/src/lib.rs
+++ b/glutin_examples/src/lib.rs
@@ -129,7 +129,7 @@ pub fn main() {
                 if let Err(res) = gl_surface
                     .set_swap_interval(&gl_context, SwapInterval::Wait(NonZeroU32::new(1).unwrap()))
                 {
-                    eprintln!("Error setting vsync: {:?}", res);
+                    eprintln!("Error setting vsync: {res:?}");
                 }
 
                 assert!(state.replace((gl_context, gl_surface, window)).is_none());

--- a/glutin_examples/src/lib.rs
+++ b/glutin_examples/src/lib.rs
@@ -3,7 +3,6 @@ use std::num::NonZeroU32;
 use std::ops::Deref;
 
 use winit::event::{Event, WindowEvent};
-use winit::event_loop::EventLoopBuilder;
 use winit::window::WindowBuilder;
 
 use raw_window_handle::HasRawWindowHandle;
@@ -23,9 +22,7 @@ pub mod gl {
     pub use Gles2 as Gl;
 }
 
-pub fn main() {
-    let event_loop = EventLoopBuilder::new().build();
-
+pub fn main(event_loop: winit::event_loop::EventLoop<()>) {
     // Only windows requires the window to be present before creating the display.
     // Other platforms don't really need one.
     //


### PR DESCRIPTION
Also fix the rust 1.67 clippy lints (since these are deny).

@kchibisov can this be released as _glutin-winit_ `0.3`?

- [x] Tested on all platforms changed _(assuming winit itself was tested)_
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- ~[x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior~
- ~[x] Created or updated an example program if it would help users understand this functionality~
