### PR TITLE
context: add `GlContext::context_api`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fixed EGL/GLX `Surface::width` returning the height instead of the width.
 - On GLX, fixed handling of errors not directly requested by glutin.
 - Added `GlConfig::hardware_accelerated` to check if the config is hardware accelerated.
+- Added `GlContext::context_api` to get the `ContextApi` used by the context.
 
 # Version 0.30.3
 

--- a/glutin/src/api/cgl/context.rs
+++ b/glutin/src/api/cgl/context.rs
@@ -103,6 +103,12 @@ impl<T: SurfaceTypeTrait> NotCurrentGlContextSurfaceAccessor<T> for NotCurrentCo
     }
 }
 
+impl GlContext for NotCurrentContext {
+    fn context_api(&self) -> ContextApi {
+        self.inner.context_api()
+    }
+}
+
 impl GetGlConfig for NotCurrentContext {
     type Target = Config;
 
@@ -173,6 +179,12 @@ impl<T: SurfaceTypeTrait> PossiblyCurrentContextGlSurfaceAccessor<T> for Possibl
     }
 }
 
+impl GlContext for PossiblyCurrentContext {
+    fn context_api(&self) -> ContextApi {
+        self.inner.context_api()
+    }
+}
+
 impl GetGlConfig for PossiblyCurrentContext {
     type Target = Config;
 
@@ -219,6 +231,10 @@ impl ContextInner {
             self.raw.setView_(surface.ns_view);
             Ok(())
         })
+    }
+
+    fn context_api(&self) -> ContextApi {
+        ContextApi::OpenGl(None)
     }
 
     pub(crate) fn set_swap_interval(&self, interval: SwapInterval) {

--- a/glutin/src/api/glx/context.rs
+++ b/glutin/src/api/glx/context.rs
@@ -58,7 +58,9 @@ impl Display {
         }
 
         let config = config.clone();
-        let inner = ContextInner { display: self.clone(), config, raw: GlxContext(context) };
+        let is_gles = matches!(context_attributes.api, Some(ContextApi::Gles(_)));
+        let inner =
+            ContextInner { display: self.clone(), config, raw: GlxContext(context), is_gles };
 
         Ok(NotCurrentContext::new(inner))
     }
@@ -254,6 +256,12 @@ impl<T: SurfaceTypeTrait> NotCurrentGlContextSurfaceAccessor<T> for NotCurrentCo
     }
 }
 
+impl GlContext for NotCurrentContext {
+    fn context_api(&self) -> ContextApi {
+        self.inner.context_api()
+    }
+}
+
 impl GetGlConfig for NotCurrentContext {
     type Target = Config;
 
@@ -315,6 +323,12 @@ impl<T: SurfaceTypeTrait> PossiblyCurrentContextGlSurfaceAccessor<T> for Possibl
     }
 }
 
+impl GlContext for PossiblyCurrentContext {
+    fn context_api(&self) -> ContextApi {
+        self.inner.context_api()
+    }
+}
+
 impl GetGlConfig for PossiblyCurrentContext {
     type Target = Config;
 
@@ -343,6 +357,7 @@ struct ContextInner {
     display: Display,
     config: Config,
     raw: GlxContext,
+    is_gles: bool,
 }
 
 impl ContextInner {
@@ -379,6 +394,14 @@ impl ContextInner {
             } else {
                 Ok(())
             }
+        }
+    }
+
+    fn context_api(&self) -> ContextApi {
+        if self.is_gles {
+            ContextApi::Gles(None)
+        } else {
+            ContextApi::OpenGl(None)
         }
     }
 }

--- a/glutin/src/context.rs
+++ b/glutin/src/context.rs
@@ -28,6 +28,14 @@ use crate::api::wgl::context::{
     NotCurrentContext as NotCurrentWglContext, PossiblyCurrentContext as PossiblyCurrentWglContext,
 };
 
+/// A trait to group common context operations.
+pub trait GlContext: Sealed {
+    /// Get the [`ContextApi`] used by the context.
+    ///
+    /// The returned value's [`Version`] will always be `None`.
+    fn context_api(&self) -> ContextApi;
+}
+
 /// A trait to group common not current operations.
 pub trait NotCurrentGlContext: Sealed {
     /// The type of possibly current context.
@@ -434,6 +442,12 @@ impl<T: SurfaceTypeTrait> NotCurrentGlContextSurfaceAccessor<T> for NotCurrentCo
     }
 }
 
+impl GlContext for NotCurrentContext {
+    fn context_api(&self) -> ContextApi {
+        gl_api_dispatch!(self; Self(context) => context.context_api())
+    }
+}
+
 impl GetGlConfig for NotCurrentContext {
     type Target = Config;
 
@@ -548,6 +562,12 @@ impl<T: SurfaceTypeTrait> PossiblyCurrentContextGlSurfaceAccessor<T> for Possibl
             },
             _ => unreachable!(),
         }
+    }
+}
+
+impl GlContext for PossiblyCurrentContext {
+    fn context_api(&self) -> ContextApi {
+        gl_api_dispatch!(self; Self(context) => context.context_api())
     }
 }
 

--- a/glutin/src/prelude.rs
+++ b/glutin/src/prelude.rs
@@ -16,3 +16,6 @@ pub use crate::context::{
 };
 pub use crate::display::GlDisplay;
 pub use crate::surface::GlSurface;
+
+// TODO(breaking release) - make pub.
+pub(crate) use crate::context::GlContext;


### PR DESCRIPTION
This should help distinguishing GLES vs OpenGL, since some operations change a lot, and shader versions are not that representative for stuff like that.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality

