### PR TITLE
Fix initializing glutin display with winit provided window handle on X11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fix EGL/GLX display initialization when the provided raw-window-handle has an unknown visual_id.
+
 # Version 0.30.4
 
 - Fixed EGL display initialization with XcbDisplayHandle.

--- a/glutin/src/api/egl/config.rs
+++ b/glutin/src/api/egl/config.rs
@@ -191,10 +191,10 @@ impl Display {
                 // XXX This can't be done by passing visual in the EGL attributes
                 // when calling `eglChooseConfig` since the visual is ignored.
                 match template.native_window {
-                    Some(RawWindowHandle::Xcb(xcb)) => {
+                    Some(RawWindowHandle::Xcb(xcb)) if xcb.visual_id > 0 => {
                         xcb.visual_id as u32 == config.native_visual()
                     },
-                    Some(RawWindowHandle::Xlib(xlib)) => {
+                    Some(RawWindowHandle::Xlib(xlib)) if xlib.visual_id > 0 => {
                         xlib.visual_id as u32 == config.native_visual()
                     },
                     _ => true,

--- a/glutin/src/api/glx/config.rs
+++ b/glutin/src/api/glx/config.rs
@@ -97,8 +97,10 @@ impl Display {
 
         // Add visual if was provided.
         if let Some(RawWindowHandle::Xlib(window)) = template.native_window {
-            config_attributes.push(glx::VISUAL_ID as c_int);
-            config_attributes.push(window.visual_id as c_int);
+            if window.visual_id > 0 {
+                config_attributes.push(glx::VISUAL_ID as c_int);
+                config_attributes.push(window.visual_id as c_int);
+            }
         }
 
         // Add surface type.


### PR DESCRIPTION
Commit f3ea5be2d6194d84ea370e6d59f4ee898325dd5c introduced a match on the window handle providex X11 visual with the EGL config. Unfortunately winit's implementation of raw_window_handle() sets the visual_id to 0, which is documented as the unknown visual. Handle this setup by filtering only if the visual id is known.

- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
