### PR TITLE
egl: fix call to `eglCreate{Window,Pixmap}Surface`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fixed EGL/GLX display initialization when the provided raw-window-handle has an unknown visual_id.
 - Fixed EGL always returning `None` for `x11_visual()`.
 - Fixed GLX error handling assuming that `XError`'s will arrive like they should on X11.
+- Fixed EGL window/pixmap creation when using legacy path.
 
 # Version 0.30.4
 


### PR DESCRIPTION
These calls accepts a `EGLNativeWindow`, and not a pointer to `EGLNativeWindow` like EGL 1.5.

Fixes #1566.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
