### PR TITLE
egl: fix handling of `*_base` platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fixed handling of `*_base` extensions with EGL.
+
 # Version 0.30.5
 
 - Fixed EGL/GLX display initialization when the provided raw-window-handle has an unknown visual_id.


### PR DESCRIPTION
The `Create{Window,Surface}` functions are tied to the display we've used. So make `EglDisplay` an enum represeting `Khr`, `Ext`, and `Legacy` variants, this fixes potential issues of using a method we shouldn't be using.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
