### PR TITLE
chore: udpate objc2 version requirements

### DIFF
--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -52,7 +52,7 @@ x11-dl = { version = "2.20.0", optional = true }
 [target.'cfg(any(target_os = "macos"))'.dependencies]
 cgl = "0.3.2"
 core-foundation = "0.9.3"
-objc2 = "=0.3.0-beta.3"
+objc2 = ">=0.3.0-beta.3, <0.3.0-beta.4"
 dispatch = "0.2.0"
 
 [build-dependencies]


### PR DESCRIPTION
This is required for winit to pick latest versions, which fixes the leaks.

