### PR TITLE
Make display, surface and context creation safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- **Breaking:** Bump `raw-window-handle` to v0.6.
+- **Breaking:** Make `glutin` types generic over the window/display they are wrapping.
+
 # Version 0.31.2
 
 - Fixed EGL not setting context version with EGL versions before 1.5 and missing context ext.

--- a/glutin-winit/Cargo.toml
+++ b/glutin-winit/Cargo.toml
@@ -19,8 +19,8 @@ wayland = ["glutin/wayland", "winit/wayland"]
 
 [dependencies]
 glutin = { version = "0.31.0", path = "../glutin", default-features = false }
-raw-window-handle = "0.5.2"
-winit = { version = "0.29.2", default-features = false, features = ["rwh_05"] }
+raw-window-handle = { version = "0.6.0", features = ["std"] }
+winit = { version = "0.29.2", default-features = false, features = ["rwh_06"] }
 
 [build-dependencies]
 cfg_aliases = "0.1.1"

--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -23,7 +23,7 @@ wayland = ["wayland-sys", "egl"]
 bitflags = "2.2.1"
 libloading = { version = "0.8.0", optional = true }
 once_cell = "1.13"
-raw-window-handle = "0.5.2"
+raw-window-handle = "0.6.0"
 
 [target.'cfg(windows)'.dependencies]
 glutin_egl_sys = { version = "0.6.0", path = "../glutin_egl_sys", optional = true }

--- a/glutin/src/api/wgl/mod.rs
+++ b/glutin/src/api/wgl/mod.rs
@@ -74,8 +74,7 @@ unsafe fn load_extra_functions(
         class
     };
 
-    let class_name =
-        OsStr::new("WglDummy Window").encode_wide().chain(Some(0).into_iter()).collect::<Vec<_>>();
+    let class_name = OsStr::new("WglDummy Window").encode_wide().chain(Some(0)).collect::<Vec<_>>();
 
     class.cbSize = mem::size_of::<WNDCLASSEXW>() as _;
     class.lpszClassName = class_name.as_ptr();
@@ -89,8 +88,7 @@ unsafe fn load_extra_functions(
 
     // This dummy wnidow should match the real one enough to get the same OpenGL
     // driver.
-    let title =
-        OsStr::new("dummy window").encode_wide().chain(Some(0).into_iter()).collect::<Vec<_>>();
+    let title = OsStr::new("dummy window").encode_wide().chain(Some(0)).collect::<Vec<_>>();
 
     let ex_style = wm::WS_EX_APPWINDOW;
     let style = wm::WS_POPUP | wm::WS_CLIPSIBLINGS | wm::WS_CLIPCHILDREN;

--- a/glutin/src/error.rs
+++ b/glutin/src/error.rs
@@ -1,5 +1,6 @@
 //! Glutin error handling.
 
+use raw_window_handle::HandleError;
 use std::fmt;
 
 /// A specialized [`Result`] type for graphics operations.
@@ -139,6 +140,12 @@ pub enum ErrorKind {
     /// The operation is not supported by the platform.
     NotSupported(&'static str),
 
+    /// The display/window handle is unavailable at this time.
+    HandleUnavailable,
+
+    /// The display/window handle is incompatible with the requested operation.
+    HandleNotSupported,
+
     /// The misc error that can't be classified occurred.
     Misc,
 }
@@ -166,6 +173,8 @@ impl ErrorKind {
             BadNativeWindow => "argument does not refer to a valid native window",
             ContextLost => "context loss",
             NotSupported(reason) => reason,
+            HandleUnavailable => "handle unavailable",
+            HandleNotSupported => "handle not supported",
             Misc => "misc platform error",
         }
     }
@@ -174,5 +183,21 @@ impl ErrorKind {
 impl fmt::Display for ErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
+    }
+}
+
+impl From<HandleError> for ErrorKind {
+    fn from(err: HandleError) -> Self {
+        match err {
+            HandleError::NotSupported => ErrorKind::HandleNotSupported,
+            HandleError::Unavailable => ErrorKind::HandleUnavailable,
+            _ => ErrorKind::BadDisplay,
+        }
+    }
+}
+
+impl From<HandleError> for Error {
+    fn from(err: HandleError) -> Self {
+        ErrorKind::from(err).into()
     }
 }

--- a/glutin/src/lib.rs
+++ b/glutin/src/lib.rs
@@ -81,3 +81,29 @@ pub(crate) mod private {
 
     pub(crate) use gl_api_dispatch;
 }
+
+/// The absence of a display handle.
+#[derive(Debug, Clone, Copy)]
+pub struct NoDisplay(core::convert::Infallible);
+
+impl raw_window_handle::HasDisplayHandle for NoDisplay {
+    fn display_handle(
+        &self,
+    ) -> std::result::Result<raw_window_handle::DisplayHandle<'_>, raw_window_handle::HandleError>
+    {
+        match self.0 {}
+    }
+}
+
+/// The absence of a window handle.
+#[derive(Debug, Clone, Copy)]
+pub struct NoWindow(core::convert::Infallible);
+
+impl raw_window_handle::HasWindowHandle for NoWindow {
+    fn window_handle(
+        &self,
+    ) -> std::result::Result<raw_window_handle::WindowHandle<'_>, raw_window_handle::HandleError>
+    {
+        match self.0 {}
+    }
+}

--- a/glutin_examples/Cargo.toml
+++ b/glutin_examples/Cargo.toml
@@ -21,8 +21,8 @@ wayland = ["glutin-winit/wayland", "winit/wayland-dlopen", "winit/wayland-csd-ad
 [dependencies]
 glutin = { path = "../glutin", default-features = false }
 glutin-winit = { path = "../glutin-winit", default-features = false }
+raw-window-handle = "0.6.0"
 png = { version = "0.17.6", optional = true }
-raw-window-handle = "0.5"
 winit = { version = "0.29.2", default-features = false, features = ["rwh_05"] }
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/glutin_examples/examples/egl_device.rs
+++ b/glutin_examples/examples/egl_device.rs
@@ -32,11 +32,12 @@ mod example {
         let device = devices.first().expect("No available devices");
 
         // Create a display using the device.
-        let display =
-            unsafe { Display::with_device(device, None) }.expect("Failed to create display");
+        let display = unsafe { Display::<glutin::NoDisplay>::with_device(device, None) }
+            .expect("Failed to create display");
 
         let template = config_template();
-        let config = unsafe { display.find_configs(template) }
+        let config = display
+            .find_configs(template)
             .unwrap()
             .reduce(
                 |config, acc| {
@@ -55,14 +56,15 @@ mod example {
         //
         // In particular, since we are doing offscreen rendering we have no raw window
         // handle to provide.
-        let context_attributes = ContextAttributesBuilder::new().build(None);
+        let context_attributes = ContextAttributesBuilder::new().build::<glutin::NoWindow>(None);
 
         // Since glutin by default tries to create OpenGL core context, which may not be
         // present we should try gles.
-        let fallback_context_attributes =
-            ContextAttributesBuilder::new().with_context_api(ContextApi::Gles(None)).build(None);
+        let fallback_context_attributes = ContextAttributesBuilder::new()
+            .with_context_api(ContextApi::Gles(None))
+            .build::<glutin::NoWindow>(None);
 
-        let not_current = unsafe {
+        let not_current = {
             display.create_context(&config, &context_attributes).unwrap_or_else(|_| {
                 display
                     .create_context(&config, &fallback_context_attributes)


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality

Uses rust-windowing/raw-window-handle#116 to make display, surface and context creation safe.

I want to get a good idea of what this kind of API would look like. I want to test out the new safe window handles before they're released onto the world.