### PR TITLE
egl/surface: Don't dereference native window pointer before passing to legacy `CreateWindowSurface`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Bump MSRV from `1.60` to `1.65`.
+- Fixed EGL dereferencing raw window handles on everything but X11 in legacy `Window` and `Pixmap` surface creation.
 
 # Version 0.30.7
 

--- a/glutin-winit/build.rs
+++ b/glutin-winit/build.rs
@@ -6,7 +6,6 @@ fn main() {
     // Setup alias to reduce `cfg` boilerplate.
     cfg_aliases! {
         // Systems.
-        android: { target_os = "android" },
         wasm: { target_arch = "wasm32" },
         macos: { target_os = "macos" },
         ios: { target_os = "ios" },

--- a/glutin-winit/build.rs
+++ b/glutin-winit/build.rs
@@ -6,20 +6,21 @@ fn main() {
     // Setup alias to reduce `cfg` boilerplate.
     cfg_aliases! {
         // Systems.
-        wasm: { target_arch = "wasm32" },
-        macos: { target_os = "macos" },
-        ios: { target_os = "ios" },
-        apple: { any(target_os = "ios", target_os = "macos") },
-        free_unix: { all(unix, not(apple), not(android)) },
+        android_platform: { target_os = "android" },
+        wasm_platform: { target_family = "wasm" },
+        macos_platform: { target_os = "macos" },
+        ios_platform: { target_os = "ios" },
+        apple: { any(ios_platform, macos_platform) },
+        free_unix: { all(unix, not(apple), not(android_platform)) },
 
         // Native displays.
-        x11_platform: { all(feature = "x11", free_unix, not(wasm)) },
-        wayland_platform: { all(feature = "wayland", free_unix, not(wasm)) },
+        x11_platform: { all(feature = "x11", free_unix, not(wasm_platform)) },
+        wayland_platform: { all(feature = "wayland", free_unix, not(wasm_platform)) },
 
         // Backends.
-        egl_backend: { all(feature = "egl", any(windows, unix), not(apple), not(wasm)) },
-        glx_backend: { all(feature = "glx", x11_platform, not(wasm)) },
-        wgl_backend: { all(feature = "wgl", windows, not(wasm)) },
-        cgl_backend: { all(macos, not(wasm)) },
+        egl_backend: { all(feature = "egl", any(windows, unix), not(apple), not(wasm_platform)) },
+        glx_backend: { all(feature = "glx", x11_platform, not(wasm_platform)) },
+        wgl_backend: { all(feature = "wgl", windows, not(wasm_platform)) },
+        cgl_backend: { all(macos_platform, not(wasm_platform)) },
     }
 }

--- a/glutin/build.rs
+++ b/glutin/build.rs
@@ -4,21 +4,21 @@ fn main() {
     // Setup alias to reduce `cfg` boilerplate.
     cfg_aliases! {
         // Systems.
-        android: { target_os = "android" },
-        wasm: { target_arch = "wasm32" },
-        macos: { target_os = "macos" },
-        ios: { target_os = "ios" },
-        apple: { any(target_os = "ios", target_os = "macos") },
-        free_unix: { all(unix, not(apple), not(android)) },
+        android_platform: { target_os = "android" },
+        wasm_platform: { target_family = "wasm" },
+        macos_platform: { target_os = "macos" },
+        ios_platform: { target_os = "ios" },
+        apple: { any(ios_platform, macos_platform) },
+        free_unix: { all(unix, not(apple), not(android_platform)) },
 
         // Native displays.
-        x11_platform: { all(feature = "x11", free_unix, not(wasm)) },
-        wayland_platform: { all(feature = "wayland", free_unix, not(wasm)) },
+        x11_platform: { all(feature = "x11", free_unix, not(wasm_platform)) },
+        wayland_platform: { all(feature = "wayland", free_unix, not(wasm_platform)) },
 
         // Backends.
-        egl_backend: { all(feature = "egl", any(windows, unix), not(apple), not(wasm)) },
-        glx_backend: { all(feature = "glx", x11_platform, not(wasm)) },
-        wgl_backend: { all(feature = "wgl", windows, not(wasm)) },
-        cgl_backend: { all(macos, not(wasm)) },
+        egl_backend: { all(feature = "egl", any(windows, unix), not(apple), not(wasm_platform)) },
+        glx_backend: { all(feature = "glx", x11_platform, not(wasm_platform)) },
+        wgl_backend: { all(feature = "wgl", windows, not(wasm_platform)) },
+        cgl_backend: { all(macos_platform, not(wasm_platform)) },
     }
 }

--- a/glutin/src/api/egl/surface.rs
+++ b/glutin/src/api/egl/surface.rs
@@ -431,13 +431,13 @@ enum NativeWindow {
     #[cfg(x11_platform)]
     Xcb(u32),
 
-    #[cfg(target_os = "android")]
+    #[cfg(android_platform)]
     Android(*mut ffi::c_void),
 
     #[cfg(windows)]
-    Win32(*mut ffi::c_void),
+    Win32(isize),
 
-    #[cfg(unix)]
+    #[cfg(free_unix)]
     Gbm(*mut ffi::c_void),
 }
 
@@ -466,13 +466,13 @@ impl NativeWindow {
             RawWindowHandle::Xlib(window_handle) => Self::Xlib(window_handle.window as _),
             #[cfg(x11_platform)]
             RawWindowHandle::Xcb(window_handle) => Self::Xcb(window_handle.window as _),
-            #[cfg(target_os = "android")]
+            #[cfg(android_platform)]
             RawWindowHandle::AndroidNdk(window_handle) => {
                 Self::Android(window_handle.a_native_window)
             },
             #[cfg(windows)]
-            RawWindowHandle::Win32(window_hanlde) => Self::Win32(window_hanlde.hwnd),
-            #[cfg(unix)]
+            RawWindowHandle::Win32(window_handle) => Self::Win32(window_handle.hwnd as _),
+            #[cfg(free_unix)]
             RawWindowHandle::Gbm(window_handle) => Self::Gbm(window_handle.gbm_surface),
             _ => {
                 return Err(
@@ -511,10 +511,10 @@ impl NativeWindow {
             #[cfg(x11_platform)]
             Self::Xcb(window_id) => window_id as egl::NativeWindowType,
             #[cfg(windows)]
-            Self::Win32(hwnd) => hwnd as egl::NativeWindowType,
-            #[cfg(target_os = "android")]
+            Self::Win32(hwnd) => hwnd,
+            #[cfg(android_platform)]
             Self::Android(a_native_window) => a_native_window,
-            #[cfg(unix)]
+            #[cfg(free_unix)]
             Self::Gbm(gbm_surface) => gbm_surface,
         }
     }
@@ -541,10 +541,10 @@ impl NativeWindow {
             #[cfg(x11_platform)]
             Self::Xcb(window_id) => window_id as *const _ as *mut ffi::c_void,
             #[cfg(windows)]
-            Self::Win32(hwnd) => *hwnd,
-            #[cfg(target_os = "android")]
+            Self::Win32(hwnd) => *hwnd as *const ffi::c_void as *mut _,
+            #[cfg(android_platform)]
             Self::Android(a_native_window) => *a_native_window,
-            #[cfg(unix)]
+            #[cfg(free_unix)]
             Self::Gbm(gbm_surface) => *gbm_surface,
         }
     }

--- a/glutin/src/api/egl/surface.rs
+++ b/glutin/src/api/egl/surface.rs
@@ -195,11 +195,10 @@ impl Display {
             },
             EglDisplay::Legacy(display) => unsafe {
                 let attrs: Vec<EGLint> = attrs.into_iter().map(|attr| attr as EGLint).collect();
-                // This call accepts raw value, instead of pointer.
                 self.inner.egl.CreateWindowSurface(
                     display,
                     *config.inner.raw,
-                    *(native_window.as_ptr() as *const egl::NativeWindowType),
+                    native_window.as_ptr().cast(),
                     attrs.as_ptr(),
                 )
             },

--- a/glutin/src/api/egl/surface.rs
+++ b/glutin/src/api/egl/surface.rs
@@ -431,10 +431,13 @@ enum NativeWindow {
     #[cfg(x11_platform)]
     Xcb(u32),
 
+    #[cfg(target_os = "android")]
     Android(*mut ffi::c_void),
 
+    #[cfg(windows)]
     Win32(*mut ffi::c_void),
 
+    #[cfg(unix)]
     Gbm(*mut ffi::c_void),
 }
 
@@ -463,10 +466,13 @@ impl NativeWindow {
             RawWindowHandle::Xlib(window_handle) => Self::Xlib(window_handle.window as _),
             #[cfg(x11_platform)]
             RawWindowHandle::Xcb(window_handle) => Self::Xcb(window_handle.window as _),
+            #[cfg(target_os = "android")]
             RawWindowHandle::AndroidNdk(window_handle) => {
                 Self::Android(window_handle.a_native_window)
             },
+            #[cfg(windows)]
             RawWindowHandle::Win32(window_hanlde) => Self::Win32(window_hanlde.hwnd),
+            #[cfg(unix)]
             RawWindowHandle::Gbm(window_handle) => Self::Gbm(window_handle.gbm_surface),
             _ => {
                 return Err(
@@ -503,8 +509,11 @@ impl NativeWindow {
             Self::Xlib(window_id) => window_id as egl::NativeWindowType,
             #[cfg(x11_platform)]
             Self::Xcb(window_id) => window_id as egl::NativeWindowType,
+            #[cfg(windows)]
             Self::Win32(hwnd) => hwnd as egl::NativeWindowType,
+            #[cfg(target_os = "android")]
             Self::Android(a_native_window) => a_native_window,
+            #[cfg(unix)]
             Self::Gbm(gbm_surface) => gbm_surface,
         }
     }
@@ -523,8 +532,11 @@ impl NativeWindow {
             Self::Xlib(window_id) => window_id as *const _ as *mut ffi::c_void,
             #[cfg(x11_platform)]
             Self::Xcb(window_id) => window_id as *const _ as *mut ffi::c_void,
+            #[cfg(windows)]
             Self::Win32(hwnd) => *hwnd,
+            #[cfg(target_os = "android")]
             Self::Android(a_native_window) => *a_native_window,
+            #[cfg(unix)]
             Self::Gbm(gbm_surface) => *gbm_surface,
         }
     }

--- a/glutin/src/api/egl/surface.rs
+++ b/glutin/src/api/egl/surface.rs
@@ -121,7 +121,7 @@ impl Display {
                 self.inner.egl.CreatePixmapSurface(
                     display,
                     *config.inner.raw,
-                    *(native_pixmap.as_ptr() as *const egl::NativePixmapType),
+                    native_pixmap.as_ptr(),
                     attrs.as_ptr(),
                 )
             },
@@ -526,7 +526,7 @@ impl NativePixmap {
         match self {
             Self::XlibPixmap(xid) => xid as *const _ as *mut _,
             Self::XcbPixmap(xid) => xid as *const _ as *mut _,
-            Self::WindowsPixmap(hbitmap) => hbitmap as *const _ as *mut _,
+            Self::WindowsPixmap(hbitmap) => *hbitmap as *const ffi::c_void as *mut _,
         }
     }
 }

--- a/glutin/src/api/egl/surface.rs
+++ b/glutin/src/api/egl/surface.rs
@@ -501,7 +501,7 @@ impl NativeWindow {
         }
     }
 
-    /// Returns the underlying handle value
+    /// Returns the underlying handle value.
     fn as_native_window(&self) -> egl::NativeWindowType {
         match *self {
             #[cfg(wayland_platform)]
@@ -519,7 +519,7 @@ impl NativeWindow {
         }
     }
 
-    /// Returns a pointer to the underlying handle value on X11 and Xlib,
+    /// Returns a pointer to the underlying handle value on X11,
     /// the raw underlying handle value on all other platforms.
     ///
     /// This exists because of a discrepancy in the new
@@ -530,8 +530,9 @@ impl NativeWindow {
     /// See also:
     /// <https://gitlab.freedesktop.org/mesa/mesa/-/blob/4de9a4b2b8c41864aadae89be705ef125a745a0a/src/egl/main/eglapi.c#L1102-1127>
     ///
-    /// # Safety:
-    /// The returned pointer is a cast of the `&self` borrow.
+    /// # Safety
+    ///
+    /// On X11 the returned pointer is a cast of the `&self` borrow.
     fn as_platform_window(&self) -> *mut ffi::c_void {
         match self {
             #[cfg(wayland_platform)]
@@ -562,7 +563,7 @@ impl Drop for NativeWindow {
 }
 
 impl NativePixmap {
-    /// Returns the underlying handle value
+    /// Returns the underlying handle value.
     fn as_native_pixmap(&self) -> egl::NativePixmapType {
         match *self {
             Self::XlibPixmap(xid) => xid as egl::NativePixmapType,
@@ -571,7 +572,7 @@ impl NativePixmap {
         }
     }
 
-    /// Returns a pointer to the underlying handle value on X11 and Xlib,
+    /// Returns a pointer to the underlying handle value on X11,
     /// the raw underlying handle value on all other platforms.
     ///
     /// This exists because of a discrepancy in the new
@@ -582,8 +583,9 @@ impl NativePixmap {
     /// See also:
     /// <https://gitlab.freedesktop.org/mesa/mesa/-/blob/4de9a4b2b8c41864aadae89be705ef125a745a0a/src/egl/main/eglapi.c#L1166-1190>
     ///
-    /// # Safety:
-    /// The returned pointer is a cast of the `&self` borrow.
+    /// # Safety
+    ///
+    /// On X11 the returned pointer is a cast of the `&self` borrow.
     fn as_platform_pixmap(&self) -> *mut ffi::c_void {
         match self {
             Self::XlibPixmap(xid) => xid as *const _ as *mut _,

--- a/glutin/src/api/egl/surface.rs
+++ b/glutin/src/api/egl/surface.rs
@@ -180,7 +180,7 @@ impl Display {
                 self.inner.egl.CreatePlatformWindowSurface(
                     display,
                     *config.inner.raw,
-                    native_window.as_ptr().cast(),
+                    native_window.as_ptr(),
                     attrs.as_ptr(),
                 )
             },
@@ -189,7 +189,7 @@ impl Display {
                 self.inner.egl.CreatePlatformWindowSurfaceEXT(
                     display,
                     *config.inner.raw,
-                    native_window.as_ptr().cast(),
+                    native_window.as_ptr(),
                     attrs.as_ptr(),
                 )
             },
@@ -198,7 +198,7 @@ impl Display {
                 self.inner.egl.CreateWindowSurface(
                     display,
                     *config.inner.raw,
-                    native_window.as_ptr().cast(),
+                    native_window.as_ptr(),
                     attrs.as_ptr(),
                 )
             },

--- a/glutin/src/surface.rs
+++ b/glutin/src/surface.rs
@@ -485,6 +485,8 @@ pub enum NativePixmap {
     XcbPixmap(u32),
 
     /// HBITMAP handle for windows bitmap.
+    // TODO: Consistency between HBITMAP and HWND should be solved in the
+    // next breaking release. Either both are `*mut c_void`, or `isize`.
     WindowsPixmap(isize),
 }
 

--- a/glutin/src/surface.rs
+++ b/glutin/src/surface.rs
@@ -485,8 +485,6 @@ pub enum NativePixmap {
     XcbPixmap(u32),
 
     /// HBITMAP handle for windows bitmap.
-    // TODO: Consistency between HBITMAP and HWND should be solved in the
-    // next breaking release. Either both are `*mut c_void`, or `isize`.
     WindowsPixmap(isize),
 }
 

--- a/glutin_egl_sys/Cargo.toml
+++ b/glutin_egl_sys/Cargo.toml
@@ -16,4 +16,5 @@ gl_generator = "0.14"
 version = "0.45"
 features = [
     "Win32_Foundation",
+    "Win32_Graphics_Gdi",
 ]

--- a/glutin_egl_sys/src/lib.rs
+++ b/glutin_egl_sys/src/lib.rs
@@ -44,6 +44,13 @@ pub type khronos_ssize_t = raw::c_long;
 pub type EGLint = i32;
 pub type EGLenum = raw::c_uint;
 pub type EGLNativeDisplayType = *const raw::c_void;
+
+#[cfg(windows)]
+pub type EGLNativePixmapType = windows_sys::Win32::Graphics::Gdi::HBITMAP; // FIXME: egl_native_pixmap_t instead
+#[cfg(not(windows))]
 pub type EGLNativePixmapType = *const raw::c_void; // FIXME: egl_native_pixmap_t instead
 
+#[cfg(windows)]
+pub type EGLNativeWindowType = windows_sys::Win32::Foundation::HWND;
+#[cfg(not(windows))]
 pub type EGLNativeWindowType = *const raw::c_void;

--- a/glutin_egl_sys/src/lib.rs
+++ b/glutin_egl_sys/src/lib.rs
@@ -46,16 +46,4 @@ pub type EGLenum = raw::c_uint;
 pub type EGLNativeDisplayType = *const raw::c_void;
 pub type EGLNativePixmapType = *const raw::c_void; // FIXME: egl_native_pixmap_t instead
 
-#[cfg(windows)]
-pub type EGLNativeWindowType = windows_sys::Win32::Foundation::HWND;
-#[cfg(target_os = "linux")]
-pub type EGLNativeWindowType = *const raw::c_void;
-#[cfg(target_os = "android")]
-pub type EGLNativeWindowType = *const raw::c_void;
-#[cfg(any(
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "netbsd",
-    target_os = "openbsd"
-))]
 pub type EGLNativeWindowType = *const raw::c_void;

--- a/glutin_egl_sys/src/lib.rs
+++ b/glutin_egl_sys/src/lib.rs
@@ -45,10 +45,11 @@ pub type EGLint = i32;
 pub type EGLenum = raw::c_uint;
 pub type EGLNativeDisplayType = *const raw::c_void;
 
+// FIXME: egl_native_pixmap_t instead
 #[cfg(windows)]
-pub type EGLNativePixmapType = windows_sys::Win32::Graphics::Gdi::HBITMAP; // FIXME: egl_native_pixmap_t instead
+pub type EGLNativePixmapType = windows_sys::Win32::Graphics::Gdi::HBITMAP;
 #[cfg(not(windows))]
-pub type EGLNativePixmapType = *const raw::c_void; // FIXME: egl_native_pixmap_t instead
+pub type EGLNativePixmapType = *const raw::c_void;
 
 #[cfg(windows)]
 pub type EGLNativeWindowType = windows_sys::Win32::Foundation::HWND;

--- a/glutin_examples/build.rs
+++ b/glutin_examples/build.rs
@@ -11,22 +11,22 @@ fn main() {
     // Setup alias to reduce `cfg` boilerplate.
     cfg_aliases! {
         // Systems.
-        android: { target_os = "android" },
-        wasm: { target_arch = "wasm32" },
-        macos: { target_os = "macos" },
-        ios: { target_os = "ios" },
-        apple: { any(target_os = "ios", target_os = "macos") },
-        free_unix: { all(unix, not(apple), not(android)) },
+        android_platform: { target_os = "android" },
+        wasm_platform: { target_family = "wasm" },
+        macos_platform: { target_os = "macos" },
+        ios_platform: { target_os = "ios" },
+        apple: { any(ios_platform, macos_platform) },
+        free_unix: { all(unix, not(apple), not(android_platform)) },
 
         // Native displays.
-        x11_platform: { all(feature = "x11", free_unix, not(wasm)) },
-        wayland_platform: { all(feature = "wayland", free_unix, not(wasm)) },
+        x11_platform: { all(feature = "x11", free_unix, not(wasm_platform)) },
+        wayland_platform: { all(feature = "wayland", free_unix, not(wasm_platform)) },
 
         // Backends.
-        egl_backend: { all(feature = "egl", any(windows, unix), not(apple), not(wasm)) },
-        glx_backend: { all(feature = "glx", x11_platform, not(wasm)) },
-        wgl_backend: { all(feature = "wgl", windows, not(wasm)) },
-        cgl_backend: { all(macos, not(wasm)) },
+        egl_backend: { all(feature = "egl", any(windows, unix), not(apple), not(wasm_platform)) },
+        glx_backend: { all(feature = "glx", x11_platform, not(wasm_platform)) },
+        wgl_backend: { all(feature = "wgl", windows, not(wasm_platform)) },
+        cgl_backend: { all(macos_platform, not(wasm_platform)) },
     }
 
     let dest = PathBuf::from(&env::var("OUT_DIR").unwrap());

--- a/glutin_examples/examples/android.rs
+++ b/glutin_examples/examples/android.rs
@@ -1,4 +1,4 @@
-#![cfg(target_os = "android")]
+#![cfg(android_platform)]
 
 use winit::event_loop::EventLoopBuilder;
 use winit::platform::android::EventLoopBuilderExtAndroid;

--- a/glutin_examples/src/lib.rs
+++ b/glutin_examples/src/lib.rs
@@ -106,7 +106,7 @@ pub fn main(event_loop: winit::event_loop::EventLoop<()>) {
         control_flow.set_wait();
         match event {
             Event::Resumed => {
-                #[cfg(target_os = "android")]
+                #[cfg(android_platform)]
                 println!("Android window available");
 
                 let window = window.take().unwrap_or_else(|| {


### PR DESCRIPTION
Fixes #1584

Just like for KHR and EXT the native window _is_ `egl::NativeWindowType` (which is a `*const c_void` under the hood).  By casting it to _a pointer of_ `egl::NativeWindowType` instead, and derferencing that, we'd be reading the first few bytes of whatever this opaque handle was pointing to (if it even is a valid pointer) and segfaulting on at least Android inside `libEGL`.  In other words, never dereference opaque handles which may not even be a valid memory address in the first place.

- [x] Tested on all platforms changed
    - [x] Android
    - [x] Wayland
    - [x] X11 (@kchibisov)
    - [x] Windows
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality (N/A)

## `native_window` types per function call

### Legend

❌ = not supported
✔️ = tested and working
Nothing = untested

||`eglCreateWindowSurface`|`eglCreatePlatformWindowSurface`|`eglCreatePlatformWindowSurfaceEXT`|
|-|-|-|-|
|Wayland|❌|`void *`✔️|`void *`✔️|
|Windows|`HWND`|`HWND`|`HWND`|
|X|`XID`✔️|`XID *`✔️|`XID *`✔️|
|Android|`void *`✔️|`void *`✔️|❌|

||`eglCreatePixmapSurface`|`eglCreatePlatformPixmapSurface`|`eglCreatePlatformPixmapSurfaceEXT`|
|-|-|-|-|
|Windows|`HBITMAP`|`HBITMAP`|`HBITMAP`|
|X|`XID`|`XID *`|`XID *`|
