### PR TITLE
docs: add notes about Wayland specific behavior

### DIFF
--- a/glutin/src/context.rs
+++ b/glutin/src/context.rs
@@ -56,6 +56,9 @@ pub trait NotCurrentGlContext: Sealed {
     /// # Platform specific
     ///
     /// **macOS:** - **This will block if your main thread is blocked.**
+    /// **Wayland:** - This call may latch the underlying back buffer (will do
+    /// with mesa drivers), meaning that all resize operations will apply after
+    /// the next [`GlSurface::swap_buffers`].
     fn make_current<T: SurfaceTypeTrait>(
         self,
         surface: &Self::Surface<T>,

--- a/glutin/src/display.rs
+++ b/glutin/src/display.rs
@@ -61,7 +61,16 @@ pub trait GlDisplay: Sealed {
     /// Some platforms use [`RawWindowHandle`] for context creation, so it must
     /// point to a valid object.
     ///
+    /// # Platform-specific
+    ///
+    /// **Wayland:** - This call may latch the underlying back buffer of
+    /// the currently active context (will do with mesa drivers), meaning
+    /// that all resize operations will apply for it after the next
+    /// [`GlSurface::swap_buffers`]. To workaround this behavior the current
+    /// context should be made [`not current`].
+    ///
     /// [`RawWindowHandle`]: raw_window_handle::RawWindowHandle
+    /// [`not current`]: crate::context::PossiblyCurrentGlContext::make_not_current
     unsafe fn create_context(
         &self,
         config: &Self::Config,


### PR DESCRIPTION
The wayland platform has a back buffer latching behavior, some of it  is clear, like rendering to and querying `buffer_age`, such is specified in EGL_KHR_platform_wayland.

However some drivers(mesa) perform latching when creating or making context current, thus it's also documented for now.

In addition, the absence of traditional VSync was also documented.

Fixes #1589.
