### PR TITLE
chore: remove `.*SurfaceAccessor` traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Bump MSRV from `1.60` to `1.65`.
 - Fixed EGL dereferencing raw window handles on everything but X11 in legacy `Window` and `Pixmap` surface creation.
 - **Breaking:** `bitflags` which is used as a part of public API was updated to `2.0`.
+- **Breaking:** `.*SurfaceAccessor` traits got removed; their methods now on respective `.*GlContext` traits instead.
+- **Breaking:** `GlContext` trait is now a part of the `prelude`.
 
 # Version 0.30.7
 

--- a/glutin/src/api/cgl/context.rs
+++ b/glutin/src/api/cgl/context.rs
@@ -75,25 +75,24 @@ impl NotCurrentContext {
 
 impl NotCurrentGlContext for NotCurrentContext {
     type PossiblyCurrentContext = PossiblyCurrentContext;
+    type Surface<T: SurfaceTypeTrait> = Surface<T>;
 
     fn treat_as_possibly_current(self) -> PossiblyCurrentContext {
         PossiblyCurrentContext { inner: self.inner, _nosendsync: PhantomData }
     }
-}
 
-impl<T: SurfaceTypeTrait> NotCurrentGlContextSurfaceAccessor<T> for NotCurrentContext {
-    type PossiblyCurrentContext = PossiblyCurrentContext;
-    type Surface = Surface<T>;
-
-    fn make_current(self, surface: &Self::Surface) -> Result<Self::PossiblyCurrentContext> {
+    fn make_current<T: SurfaceTypeTrait>(
+        self,
+        surface: &Self::Surface<T>,
+    ) -> Result<Self::PossiblyCurrentContext> {
         self.inner.make_current(surface)?;
         Ok(PossiblyCurrentContext { inner: self.inner, _nosendsync: PhantomData })
     }
 
-    fn make_current_draw_read(
+    fn make_current_draw_read<T: SurfaceTypeTrait>(
         self,
-        surface_draw: &Self::Surface,
-        surface_read: &Self::Surface,
+        surface_draw: &Self::Surface<T>,
+        surface_read: &Self::Surface<T>,
     ) -> Result<Self::PossiblyCurrentContext> {
         Err(self.inner.make_current_draw_read(surface_draw, surface_read).into())
     }
@@ -140,6 +139,7 @@ pub struct PossiblyCurrentContext {
 
 impl PossiblyCurrentGlContext for PossiblyCurrentContext {
     type NotCurrentContext = NotCurrentContext;
+    type Surface<T: SurfaceTypeTrait> = Surface<T>;
 
     fn make_not_current(self) -> Result<Self::NotCurrentContext> {
         self.inner.make_not_current()?;
@@ -153,19 +153,15 @@ impl PossiblyCurrentGlContext for PossiblyCurrentContext {
             false
         }
     }
-}
 
-impl<T: SurfaceTypeTrait> PossiblyCurrentContextGlSurfaceAccessor<T> for PossiblyCurrentContext {
-    type Surface = Surface<T>;
-
-    fn make_current(&self, surface: &Self::Surface) -> Result<()> {
+    fn make_current<T: SurfaceTypeTrait>(&self, surface: &Self::Surface<T>) -> Result<()> {
         self.inner.make_current(surface)
     }
 
-    fn make_current_draw_read(
+    fn make_current_draw_read<T: SurfaceTypeTrait>(
         &self,
-        surface_draw: &Self::Surface,
-        surface_read: &Self::Surface,
+        surface_draw: &Self::Surface<T>,
+        surface_read: &Self::Surface<T>,
     ) -> Result<()> {
         Err(self.inner.make_current_draw_read(surface_draw, surface_read).into())
     }

--- a/glutin/src/api/egl/context.rs
+++ b/glutin/src/api/egl/context.rs
@@ -176,22 +176,21 @@ impl NotCurrentContext {
 
 impl NotCurrentGlContext for NotCurrentContext {
     type PossiblyCurrentContext = PossiblyCurrentContext;
+    type Surface<T: SurfaceTypeTrait> = Surface<T>;
 
     fn treat_as_possibly_current(self) -> Self::PossiblyCurrentContext {
         PossiblyCurrentContext { inner: self.inner, _nosendsync: PhantomData }
     }
-}
 
-impl<T: SurfaceTypeTrait> NotCurrentGlContextSurfaceAccessor<T> for NotCurrentContext {
-    type PossiblyCurrentContext = PossiblyCurrentContext;
-    type Surface = Surface<T>;
-
-    fn make_current(self, surface: &Surface<T>) -> Result<PossiblyCurrentContext> {
+    fn make_current<T: SurfaceTypeTrait>(
+        self,
+        surface: &Surface<T>,
+    ) -> Result<PossiblyCurrentContext> {
         self.inner.make_current_draw_read(surface, surface)?;
         Ok(PossiblyCurrentContext { inner: self.inner, _nosendsync: PhantomData })
     }
 
-    fn make_current_draw_read(
+    fn make_current_draw_read<T: SurfaceTypeTrait>(
         self,
         surface_draw: &Surface<T>,
         surface_read: &Surface<T>,
@@ -247,6 +246,7 @@ impl PossiblyCurrentContext {
 
 impl PossiblyCurrentGlContext for PossiblyCurrentContext {
     type NotCurrentContext = NotCurrentContext;
+    type Surface<T: SurfaceTypeTrait> = Surface<T>;
 
     fn make_not_current(self) -> Result<Self::NotCurrentContext> {
         self.inner.make_not_current()?;
@@ -259,19 +259,15 @@ impl PossiblyCurrentGlContext for PossiblyCurrentContext {
             self.inner.display.inner.egl.GetCurrentContext() == *self.inner.raw
         }
     }
-}
 
-impl<T: SurfaceTypeTrait> PossiblyCurrentContextGlSurfaceAccessor<T> for PossiblyCurrentContext {
-    type Surface = Surface<T>;
-
-    fn make_current(&self, surface: &Self::Surface) -> Result<()> {
+    fn make_current<T: SurfaceTypeTrait>(&self, surface: &Self::Surface<T>) -> Result<()> {
         self.inner.make_current_draw_read(surface, surface)
     }
 
-    fn make_current_draw_read(
+    fn make_current_draw_read<T: SurfaceTypeTrait>(
         &self,
-        surface_draw: &Self::Surface,
-        surface_read: &Self::Surface,
+        surface_draw: &Self::Surface<T>,
+        surface_read: &Self::Surface<T>,
     ) -> Result<()> {
         self.inner.make_current_draw_read(surface_draw, surface_read)
     }

--- a/glutin/src/api/glx/context.rs
+++ b/glutin/src/api/glx/context.rs
@@ -232,25 +232,24 @@ impl NotCurrentContext {
 
 impl NotCurrentGlContext for NotCurrentContext {
     type PossiblyCurrentContext = PossiblyCurrentContext;
+    type Surface<T: SurfaceTypeTrait> = Surface<T>;
 
     fn treat_as_possibly_current(self) -> PossiblyCurrentContext {
         PossiblyCurrentContext { inner: self.inner, _nosendsync: PhantomData }
     }
-}
 
-impl<T: SurfaceTypeTrait> NotCurrentGlContextSurfaceAccessor<T> for NotCurrentContext {
-    type PossiblyCurrentContext = PossiblyCurrentContext;
-    type Surface = Surface<T>;
-
-    fn make_current(self, surface: &Self::Surface) -> Result<Self::PossiblyCurrentContext> {
+    fn make_current<T: SurfaceTypeTrait>(
+        self,
+        surface: &Self::Surface<T>,
+    ) -> Result<Self::PossiblyCurrentContext> {
         self.inner.make_current_draw_read(surface, surface)?;
         Ok(PossiblyCurrentContext { inner: self.inner, _nosendsync: PhantomData })
     }
 
-    fn make_current_draw_read(
+    fn make_current_draw_read<T: SurfaceTypeTrait>(
         self,
-        surface_draw: &Self::Surface,
-        surface_read: &Self::Surface,
+        surface_draw: &Self::Surface<T>,
+        surface_read: &Self::Surface<T>,
     ) -> Result<Self::PossiblyCurrentContext> {
         self.inner.make_current_draw_read(surface_draw, surface_read)?;
         Ok(PossiblyCurrentContext { inner: self.inner, _nosendsync: PhantomData })
@@ -297,6 +296,7 @@ pub struct PossiblyCurrentContext {
 
 impl PossiblyCurrentGlContext for PossiblyCurrentContext {
     type NotCurrentContext = NotCurrentContext;
+    type Surface<T: SurfaceTypeTrait> = Surface<T>;
 
     fn make_not_current(self) -> Result<Self::NotCurrentContext> {
         self.inner.make_not_current()?;
@@ -306,19 +306,15 @@ impl PossiblyCurrentGlContext for PossiblyCurrentContext {
     fn is_current(&self) -> bool {
         unsafe { self.inner.display.inner.glx.GetCurrentContext() == *self.inner.raw }
     }
-}
 
-impl<T: SurfaceTypeTrait> PossiblyCurrentContextGlSurfaceAccessor<T> for PossiblyCurrentContext {
-    type Surface = Surface<T>;
-
-    fn make_current(&self, surface: &Self::Surface) -> Result<()> {
+    fn make_current<T: SurfaceTypeTrait>(&self, surface: &Self::Surface<T>) -> Result<()> {
         self.inner.make_current_draw_read(surface, surface)
     }
 
-    fn make_current_draw_read(
+    fn make_current_draw_read<T: SurfaceTypeTrait>(
         &self,
-        surface_draw: &Self::Surface,
-        surface_read: &Self::Surface,
+        surface_draw: &Self::Surface<T>,
+        surface_read: &Self::Surface<T>,
     ) -> Result<()> {
         self.inner.make_current_draw_read(surface_draw, surface_read)
     }

--- a/glutin/src/prelude.rs
+++ b/glutin/src/prelude.rs
@@ -10,12 +10,6 @@
 //! ```
 
 pub use crate::config::GlConfig;
-pub use crate::context::{
-    NotCurrentGlContext, NotCurrentGlContextSurfaceAccessor,
-    PossiblyCurrentContextGlSurfaceAccessor, PossiblyCurrentGlContext,
-};
+pub use crate::context::{GlContext, NotCurrentGlContext, PossiblyCurrentGlContext};
 pub use crate::display::GlDisplay;
 pub use crate::surface::GlSurface;
-
-// TODO(breaking release) - make pub.
-pub(crate) use crate::context::GlContext;


### PR DESCRIPTION
These traits were hacks to avoid the lack of GATs and provide a detached trait with generic. Given that glutin MSRV is now `1.65` which has GATs, we could safely remove said traits. Their methods simply got moved to `.*GlContext` traits, where they originally belonged to.

While the change is breaking, normal user code which was using `prelude` is not affected by it.
