### PR TITLE
glx:wgl: don't pass default flush behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **Breaking:** `bitflags` which is used as a part of public API was updated to `2.0`.
 - **Breaking:** `.*SurfaceAccessor` traits got removed; their methods now on respective `.*GlContext` traits instead.
 - **Breaking:** `GlContext` trait is now a part of the `prelude`.
+- On GLX, fixed startup failure when passing default `Flush` with `KHR_context_flush_control`.
 
 # Version 0.30.7
 

--- a/glutin/src/api/glx/context.rs
+++ b/glutin/src/api/glx/context.rs
@@ -166,10 +166,10 @@ impl Display {
         // Flush control.
         if self.inner.features.contains(DisplayFeatures::CONTEXT_RELEASE_BEHAVIOR) {
             match context_attributes.release_behavior {
-                ReleaseBehavior::Flush => {
-                    attrs.push(glx_extra::CONTEXT_RELEASE_BEHAVIOR_ARB as c_int);
-                    attrs.push(glx_extra::CONTEXT_RELEASE_BEHAVIOR_FLUSH_ARB as c_int);
-                },
+                // This is the default behavior in specification.
+                //
+                // XXX passing it explicitly causing issues with older mesa versions.
+                ReleaseBehavior::Flush => (),
                 ReleaseBehavior::None => {
                     attrs.push(glx_extra::CONTEXT_RELEASE_BEHAVIOR_ARB as c_int);
                     attrs.push(glx_extra::CONTEXT_RELEASE_BEHAVIOR_NONE_ARB as c_int);

--- a/glutin/src/api/wgl/context.rs
+++ b/glutin/src/api/wgl/context.rs
@@ -173,10 +173,11 @@ impl Display {
         // Flush control.
         if self.inner.features.contains(DisplayFeatures::CONTEXT_RELEASE_BEHAVIOR) {
             match context_attributes.release_behavior {
-                ReleaseBehavior::Flush => {
-                    attrs.push(wgl_extra::CONTEXT_RELEASE_BEHAVIOR_ARB as c_int);
-                    attrs.push(wgl_extra::CONTEXT_RELEASE_BEHAVIOR_FLUSH_ARB as c_int);
-                },
+                // This is the default behavior in specification.
+                //
+                // XXX even though we check for extensions don't pass it because it could cause
+                // issues.
+                ReleaseBehavior::Flush => (),
                 ReleaseBehavior::None => {
                     attrs.push(wgl_extra::CONTEXT_RELEASE_BEHAVIOR_ARB as c_int);
                     attrs.push(wgl_extra::CONTEXT_RELEASE_BEHAVIOR_NONE_ARB as c_int);


### PR DESCRIPTION
Work around the weird driver bugs.

Links: https://github.com/alacritty/alacritty/issues/6824
