### PR TITLE
config: use platform specific default for `Api`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed EGL dereferencing raw window handles on everything but X11 in legacy `Window` and `Pixmap` surface creation.
 - On GLX, fixed startup failure when passing default `Flush` with `KHR_context_flush_control`.
+- **Behavior change:** the `Config`'s `Api` now has platform specific default instead of being unspecified.
 
 # Version 0.30.7
 

--- a/glutin/src/api/egl/config.rs
+++ b/glutin/src/api/egl/config.rs
@@ -125,7 +125,8 @@ impl Display {
             config_attributes.push(num_samples as EGLint);
         }
 
-        if let Some(requested_api) = template.api {
+        config_attributes.push(egl::RENDERABLE_TYPE as EGLint);
+        let api = if let Some(requested_api) = template.api {
             let mut api = 0;
             if requested_api.contains(Api::GLES1) {
                 api |= egl::OPENGL_ES_BIT;
@@ -139,9 +140,13 @@ impl Display {
             if requested_api.contains(Api::OPENGL) {
                 api |= egl::OPENGL_BIT;
             }
-            config_attributes.push(egl::RENDERABLE_TYPE as EGLint);
-            config_attributes.push(api as EGLint);
-        }
+            api
+        } else {
+            // NOTE: use ES2 by default to avoid matching pure ES1 configs,
+            // for more see https://github.com/rust-windowing/glutin/issues/1586.
+            egl::OPENGL_ES2_BIT
+        };
+        config_attributes.push(api as EGLint);
 
         // Add maximum height of pbuffer.
         if let Some(pbuffer_width) = template.max_pbuffer_width {

--- a/glutin/src/config.rs
+++ b/glutin/src/config.rs
@@ -164,9 +164,17 @@ impl ConfigTemplateBuilder {
         self
     }
 
-    /// The set of apis that are supported by configuration.
+    /// The set of apis that are supported by this configuration.
     ///
-    /// By default api isn't specified when requesting the configuration.
+    /// The default [`Api`] depends on the used graphics platform interface. If
+    /// you want to do config filtering based on the [`Api`] yourself, use
+    /// [`Api::empty`].
+    ///
+    /// # Api-specific
+    ///
+    /// - **EGL:** [`Api::GLES2`] bit is set by default to avoid matching
+    ///   [`Api::GLES1`] configs;
+    /// - **GLX/WGL/CGL:** [`Api::OPENGL`] is always present in the result.
     #[inline]
     pub fn with_api(mut self, api: Api) -> Self {
         self.template.api = Some(api);


### PR DESCRIPTION
Avoid pure ES1 configs with EGL by default. The old default behavior could be restored by using the `Api::empty`.

Fixes #1586.