### PR TITLE
Fix lock on glxSwapBuffers with some drivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - **Breaking:** `bitflags` which is used as a part of public API was updated to `2.0`.
 - **Breaking:** `.*SurfaceAccessor` traits got removed; their methods now on respective `.*GlContext` traits instead.
 - **Breaking:** `GlContext` trait is now a part of the `prelude`.
+- Fixed lock on SwapBuffers with some GLX drivers.
 
 # Version 0.30.8
 

--- a/glutin/src/api/glx/context.rs
+++ b/glutin/src/api/glx/context.rs
@@ -185,7 +185,7 @@ impl Display {
         // Terminate list with zero.
         attrs.push(0);
 
-        super::last_glx_error(self.inner.raw, || unsafe {
+        super::last_glx_error(|| unsafe {
             extra.CreateContextAttribsARB(
                 self.inner.raw.cast(),
                 *config.inner.raw,
@@ -205,7 +205,7 @@ impl Display {
         let render_type =
             if config.float_pixels() { glx_extra::RGBA_FLOAT_TYPE_ARB } else { glx::RGBA_TYPE };
 
-        super::last_glx_error(self.inner.raw, || unsafe {
+        super::last_glx_error(|| unsafe {
             self.inner.glx.CreateNewContext(
                 self.inner.raw.cast(),
                 *config.inner.raw,
@@ -363,7 +363,7 @@ impl ContextInner {
         surface_draw: &Surface<T>,
         surface_read: &Surface<T>,
     ) -> Result<()> {
-        super::last_glx_error(self.display.inner.raw, || unsafe {
+        super::last_glx_error(|| unsafe {
             self.display.inner.glx.MakeContextCurrent(
                 self.display.inner.raw.cast(),
                 surface_draw.raw,
@@ -374,7 +374,7 @@ impl ContextInner {
     }
 
     fn make_not_current(&self) -> Result<()> {
-        super::last_glx_error(self.display.inner.raw, || unsafe {
+        super::last_glx_error(|| unsafe {
             self.display.inner.glx.MakeContextCurrent(
                 self.display.inner.raw.cast(),
                 0,
@@ -395,7 +395,7 @@ impl ContextInner {
 
 impl Drop for ContextInner {
     fn drop(&mut self) {
-        let _ = super::last_glx_error(self.display.inner.raw, || unsafe {
+        let _ = super::last_glx_error(|| unsafe {
             self.display.inner.glx.DestroyContext(self.display.inner.raw.cast(), *self.raw);
         });
     }

--- a/glutin/src/api/glx/mod.rs
+++ b/glutin/src/api/glx/mod.rs
@@ -21,8 +21,6 @@ pub mod context;
 pub mod display;
 pub mod surface;
 
-use display::GlxDisplay;
-
 /// When using Xlib we need to get errors from it somehow, however creating
 /// inner `XDisplay` to handle that or change the error hook is unsafe in
 /// multithreaded applications, given that error hook is per process and not
@@ -175,16 +173,17 @@ fn glx_error_hook(_display: *mut ffi::c_void, xerror_event: *mut ffi::c_void) ->
     }
 }
 
+/// Prevent error being overwritten when accessing the handler from the multiple
+/// threads.
+static ERROR_SECTION_LOCK: Mutex<()> = Mutex::new(());
+
 /// Get the error from the X11.
 ///
 /// XXX mesa and I'd guess other GLX implementations, send the error, by taking
 /// the Xlib Error handling hook, getting the current hook, and calling back to
 /// the user, meaning that no `XSync` should be done.
-fn last_glx_error<T, F: FnOnce() -> T>(display: GlxDisplay, callback: F) -> Result<T> {
-    // Ensure that the access is safe by locking the display.
-    unsafe {
-        (XLIB.as_ref().unwrap().XLockDisplay)(*display as *mut _);
-    }
+fn last_glx_error<T, F: FnOnce() -> T>(callback: F) -> Result<T> {
+    let _guard = ERROR_SECTION_LOCK.lock().unwrap();
 
     // Mark that we're syncing the error.
     SYNCING_GLX_ERROR.store(true, Ordering::Relaxed);
@@ -203,11 +202,6 @@ fn last_glx_error<T, F: FnOnce() -> T>(display: GlxDisplay, callback: F) -> Resu
 
     // Release the mark.
     SYNCING_GLX_ERROR.store(false, Ordering::Relaxed);
-
-    // Unlock the display once we've read the error.
-    unsafe {
-        (XLIB.as_ref().unwrap().XUnlockDisplay)(*display as *mut _);
-    }
 
     result
 }

--- a/glutin/src/api/glx/surface.rs
+++ b/glutin/src/api/glx/surface.rs
@@ -47,7 +47,7 @@ impl Display {
         attrs.push(0);
 
         let config = config.clone();
-        let surface = super::last_glx_error(self.inner.raw, || unsafe {
+        let surface = super::last_glx_error(|| unsafe {
             self.inner.glx.CreatePixmap(
                 self.inner.raw.cast(),
                 *config.inner.raw,
@@ -86,7 +86,7 @@ impl Display {
         attrs.push(0);
 
         let config = config.clone();
-        let surface = super::last_glx_error(self.inner.raw, || unsafe {
+        let surface = super::last_glx_error(|| unsafe {
             self.inner.glx.CreatePbuffer(self.inner.raw.cast(), *config.inner.raw, attrs.as_ptr())
         })?;
 
@@ -119,7 +119,7 @@ impl Display {
         attrs.push(0);
 
         let config = config.clone();
-        let surface = super::last_glx_error(self.inner.raw, || unsafe {
+        let surface = super::last_glx_error(|| unsafe {
             self.inner.glx.CreateWindow(
                 self.inner.raw.cast(),
                 *config.inner.raw,
@@ -169,7 +169,7 @@ impl<T: SurfaceTypeTrait> Surface<T> {
 
 impl<T: SurfaceTypeTrait> Drop for Surface<T> {
     fn drop(&mut self) {
-        let _ = super::last_glx_error(self.display.inner.raw, || unsafe {
+        let _ = super::last_glx_error(|| unsafe {
             match T::surface_type() {
                 SurfaceType::Pbuffer => {
                     self.display.inner.glx.DestroyPbuffer(self.display.inner.raw.cast(), self.raw);
@@ -211,7 +211,7 @@ impl<T: SurfaceTypeTrait> GlSurface<T> for Surface<T> {
     }
 
     fn swap_buffers(&self, _context: &Self::Context) -> Result<()> {
-        super::last_glx_error(self.display.inner.raw, || unsafe {
+        super::last_glx_error(|| unsafe {
             self.display.inner.glx.SwapBuffers(self.display.inner.raw.cast(), self.raw);
         })
     }
@@ -237,7 +237,7 @@ impl<T: SurfaceTypeTrait> GlSurface<T> for Surface<T> {
 
         // Apply the `EXT` first since it's per window.
         if !applied && self.display.inner.client_extensions.contains("GLX_EXT_swap_control") {
-            super::last_glx_error(self.display.inner.raw, || unsafe {
+            super::last_glx_error(|| unsafe {
                 // Check for error explicitly here, other apis do have indication for failure.
                 extra.SwapIntervalEXT(self.display.inner.raw.cast(), self.raw, interval as _);
                 applied = true;


### PR DESCRIPTION
The lock handling is done internally, so no need to put extra synchronization which confuses mesa.
