### PR TITLE
egl: fix is_single_buffered being inverted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **Breaking:** `.*SurfaceAccessor` traits got removed; their methods now on respective `.*GlContext` traits instead.
 - **Breaking:** `GlContext` trait is now a part of the `prelude`.
 - Fixed lock on SwapBuffers with some GLX drivers.
+- Fixed EGL's `Surface::is_single_buffered` being inversed.
 
 # Version 0.30.8
 

--- a/glutin/src/api/egl/surface.rs
+++ b/glutin/src/api/egl/surface.rs
@@ -329,7 +329,7 @@ impl<T: SurfaceTypeTrait> GlSurface<T> for Surface<T> {
     }
 
     fn is_single_buffered(&self) -> bool {
-        unsafe { self.raw_attribute(egl::RENDER_BUFFER as EGLint) != egl::SINGLE_BUFFER as i32 }
+        unsafe { self.raw_attribute(egl::RENDER_BUFFER as EGLint) == egl::SINGLE_BUFFER as i32 }
     }
 
     fn swap_buffers(&self, context: &Self::Context) -> Result<()> {


### PR DESCRIPTION
The call was inverted due to API exposing double buffering in the early stages of development, however it was changed to be single buffered oriented, given that it mattered the most due to semantics change around swap buffers and the fact that you have triple buffering.

Fixes #1605.
