### PR TITLE
egl: Use EGL_KHR_display_reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **Breaking:** `GlContext` trait is now a part of the `prelude`.
 - Fixed lock on SwapBuffers with some GLX drivers.
 - Fixed EGL's `Surface::is_single_buffered` being inversed.
+- Use `EGL_KHR_display_reference` if available for EGL.
 
 # Version 0.30.8
 

--- a/glutin_egl_sys/build.rs
+++ b/glutin_egl_sys/build.rs
@@ -37,6 +37,7 @@ fn main() {
             "EGL_EXT_swap_buffers_with_damage",
             "EGL_KHR_create_context",
             "EGL_KHR_create_context_no_error",
+            "EGL_KHR_display_reference",
             "EGL_KHR_fence_sync",
             "EGL_KHR_platform_android",
             "EGL_KHR_platform_gbm",


### PR DESCRIPTION
This resolves a past issue where glutin would not be able to terminate a display due to risk of two displays being created from the same native display.

- [ ] Tested on all platforms changed
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [X] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [X] Created or updated an example program if it would help users understand this functionality
