### PR TITLE
Add support for creating glutin EGL displays on Windows using Angle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **Breaking:** `GlContext` trait is now a part of the `prelude`.
 - Fixed lock on SwapBuffers with some GLX drivers.
 - Fixed EGL's `Surface::is_single_buffered` being inversed.
+- Added support for EGL on Windows using Angle. This assumes libEGL.dll/libGLESv2.dll present.
 
 # Version 0.30.8
 

--- a/glutin/src/display.rs
+++ b/glutin/src/display.rs
@@ -426,6 +426,11 @@ pub enum DisplayApiPreference {
     ///
     /// But despite this issues it should be preferred on at least Linux over
     /// GLX, given that GLX is phasing away.
+    ///
+    /// # Platform-specific
+    ///
+    /// **Windows:** ANGLE can be used if `libEGL.dll` and `libGLESv2.dll` are
+    ///              in the library search path.
     #[cfg(egl_backend)]
     Egl,
 

--- a/glutin_egl_sys/src/lib.rs
+++ b/glutin_egl_sys/src/lib.rs
@@ -32,6 +32,16 @@ pub mod egl {
     pub const PLATFORM_XCB_SCREEN_EXT: super::EGLenum = 0x31DE;
     // EGL_EXT_device_query_name
     pub const RENDERER_EXT: super::EGLenum = 0x335F;
+    // EGL_ANGLE_platform_angle - https://chromium.googlesource.com/angle/angle/+/HEAD/extensions/EGL_ANGLE_platform_angle.txt
+    pub const PLATFORM_ANGLE_ANGLE: super::EGLenum = 0x3202;
+    pub const PLATFORM_ANGLE_TYPE_ANGLE: super::EGLenum = 0x3203;
+    pub const PLATFORM_ANGLE_MAX_VERSION_MAJOR_ANGLE: super::EGLenum = 0x3204;
+    pub const PLATFORM_ANGLE_MAX_VERSION_MINOR_ANGLE: super::EGLenum = 0x3205;
+    pub const PLATFORM_ANGLE_DEBUG_LAYERS_ENABLED: super::EGLenum = 0x3451;
+    pub const PLATFORM_ANGLE_NATIVE_PLATFORM_TYPE_ANGLE: super::EGLenum = 0x348F;
+    pub const PLATFORM_ANGLE_TYPE_DEFAULT_ANGLE: super::EGLenum = 0x3206;
+    pub const PLATFORM_ANGLE_DEVICE_TYPE_HARDWARE_ANGLE: super::EGLenum = 0x320A;
+    pub const PLATFORM_ANGLE_DEVICE_TYPE_NULL_ANGLE: super::EGLenum = 0x345E;
 }
 
 pub use self::egl::types::{EGLContext, EGLDisplay};


### PR DESCRIPTION
Angle provides libEGL.dll, which glutin loads. The only change necessary is to get the platform display via EGL_PLATFORM_ANGLE_ANGLE and treating it as a legacy display.

Fixes #1508

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
