### PR TITLE
egl: fix create_pbuffer_surface() by not setting invalid RENDER_BUFFER attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed lock on SwapBuffers with some GLX drivers.
 - Fixed EGL's `Surface::is_single_buffered` being inversed.
 - Added support for EGL on Windows using Angle. This assumes libEGL.dll/libGLESv2.dll present.
+- EGL's `Display::create_pbuffer_surface()` no longer sets the invalid `RENDER_BUFFER` attribute.
 
 # Version 0.30.8
 

--- a/glutin/src/api/egl/surface.rs
+++ b/glutin/src/api/egl/surface.rs
@@ -47,13 +47,6 @@ impl Display {
         attrs.push(egl::HEIGHT as EGLint);
         attrs.push(height.get() as EGLint);
 
-        // Add information about render buffer.
-        attrs.push(egl::RENDER_BUFFER as EGLint);
-        let buffer =
-            if surface_attributes.single_buffer { egl::SINGLE_BUFFER } else { egl::BACK_BUFFER }
-                as EGLint;
-        attrs.push(buffer);
-
         // Push `egl::NONE` to terminate the list.
         attrs.push(egl::NONE as EGLint);
 


### PR DESCRIPTION
RENDER_BUFFER is not a vaild attribute for pbuffer surface

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
