### PR TITLE
api: fix `NoError` and `debug` requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - **Breaking:** `GlContext` trait is now a part of the `prelude`.
 - Automatically cleanup the `EGLDisplay` when `EGL_KHR_display_reference` is present.
 - Add `api::egl::Display::terminate` to terminate the display when glutin doesn't manage it.
+- Fixed handling of `Robustness::NoError` and `debug` attribute when building context.
+- `Robustness::NoError` not being properly enabled with GLX/WGL.
 
 # Version 0.30.10
 

--- a/glutin/src/api/egl/context.rs
+++ b/glutin/src/api/egl/context.rs
@@ -80,13 +80,16 @@ impl Display {
             }
 
             let has_robustsess = self.inner.features.contains(DisplayFeatures::CONTEXT_ROBUSTNESS);
-            let has_no_error = self.inner.features.contains(DisplayFeatures::CONTEXT_NO_ERROR);
 
+            let mut requested_no_error = false;
             match context_attributes.robustness {
                 Robustness::NotRobust => (),
-                Robustness::NoError if has_no_error => {
+                Robustness::NoError
+                    if self.inner.features.contains(DisplayFeatures::CONTEXT_NO_ERROR) =>
+                {
                     attrs.push(egl::CONTEXT_OPENGL_NO_ERROR_KHR as EGLint);
                     attrs.push(egl::TRUE as EGLint);
+                    requested_no_error = true;
                 },
                 Robustness::RobustLoseContextOnReset if has_robustsess => {
                     attrs.push(egl::CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY as EGLint);
@@ -105,7 +108,7 @@ impl Display {
                 },
             }
 
-            if context_attributes.debug && is_one_five && !has_no_error {
+            if context_attributes.debug && is_one_five && !requested_no_error {
                 attrs.push(egl::CONTEXT_OPENGL_DEBUG as EGLint);
                 attrs.push(egl::TRUE as EGLint);
             }

--- a/glutin/src/api/glx/context.rs
+++ b/glutin/src/api/glx/context.rs
@@ -122,6 +122,7 @@ impl Display {
         }
 
         let mut flags: c_int = 0;
+        let mut requested_no_error = false;
         if self.inner.features.contains(DisplayFeatures::CONTEXT_ROBUSTNESS) {
             match context_attributes.robustness {
                 Robustness::NotRobust => (),
@@ -144,6 +145,8 @@ impl Display {
                     }
 
                     attrs.push(glx_extra::CONTEXT_OPENGL_NO_ERROR_ARB as c_int);
+                    attrs.push(1);
+                    requested_no_error = true;
                 },
             }
         } else if context_attributes.robustness != Robustness::NotRobust {
@@ -154,7 +157,7 @@ impl Display {
         }
 
         // Debug flag.
-        if context_attributes.debug {
+        if context_attributes.debug && !requested_no_error {
             flags |= glx_extra::CONTEXT_DEBUG_BIT_ARB as c_int;
         }
 

--- a/glutin/src/api/wgl/context.rs
+++ b/glutin/src/api/wgl/context.rs
@@ -129,6 +129,7 @@ impl Display {
         }
 
         let mut flags: c_int = 0;
+        let mut requested_no_error = false;
         if self.inner.features.contains(DisplayFeatures::CONTEXT_ROBUSTNESS) {
             match context_attributes.robustness {
                 Robustness::NotRobust => (),
@@ -151,6 +152,8 @@ impl Display {
                     }
 
                     attrs.push(wgl_extra::CONTEXT_OPENGL_NO_ERROR_ARB as c_int);
+                    attrs.push(1);
+                    requested_no_error = true;
                 },
             }
         } else if context_attributes.robustness != Robustness::NotRobust {
@@ -161,7 +164,7 @@ impl Display {
         }
 
         // Debug flag.
-        if context_attributes.debug {
+        if context_attributes.debug && !requested_no_error {
             flags |= wgl_extra::CONTEXT_DEBUG_BIT_ARB as c_int;
         }
 

--- a/glutin/src/context.rs
+++ b/glutin/src/context.rs
@@ -138,6 +138,7 @@ impl ContextAttributesBuilder {
     /// Sets the *debug* flag for the OpenGL context.
     ///
     /// Debug contexts are usually slower, but give better error reporting.
+    /// This option is ignored when using [`Robustness::NoError`].
     ///
     /// The default value for this flag is `false`.
     pub fn with_debug(mut self, debug: bool) -> Self {


### PR DESCRIPTION
The api/egl always disabled debug when `NO_ERROR` was present in extensions to avoid errors, however the error will be thrown only when using `NO_ERROR` and debug context at the same time.

Fix the same issues with GLX/WGL as well as properly enable `NO_ERROR` for those backends.

Fixes: #1635
