### PR TITLE
Relax encoding requirements for `CGLContextObj`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fixed `CGLContextObj` having an invalid encoding on newer macOS versions.
+
 # Version 0.31.0
 
 - Bump MSRV from `1.60` to `1.65`.

--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -52,7 +52,8 @@ x11-dl = { version = "2.20.0", optional = true }
 [target.'cfg(any(target_os = "macos"))'.dependencies]
 cgl = "0.3.2"
 core-foundation = "0.9.3"
-objc2 = "0.4.1"
+# Enable `relax-void-encoding` until https://github.com/madsmtm/objc2/pull/526 is resolved
+objc2 = { version = "0.4.1", features = ["relax-void-encoding"] }
 dispatch = "0.2.0"
 
 [target.'cfg(any(target_os = "macos"))'.dependencies.icrate]

--- a/glutin/src/api/cgl/appkit.rs
+++ b/glutin/src/api/cgl/appkit.rs
@@ -17,7 +17,7 @@ pub struct CGLContextObj {
 }
 
 unsafe impl RefEncode for CGLContextObj {
-    const ENCODING_REF: Encoding = Encoding::Pointer(&Encoding::Struct("_CGLContextObject", &[]));
+    const ENCODING_REF: Encoding = Encoding::Pointer(&Encoding::Void);
 }
 
 extern_class!(


### PR DESCRIPTION
Fixes https://github.com/rust-windowing/glutin/issues/1640. The issue is that `CGLContextObj` changed its encoding in macOS Sonoma 14.0. The encoding of a type is something that `objc2` uses to debug-assert that the definition is written correctly, but of course, if the Rust code assumes that the encoding is one thing, and it then changes, then the debug assertion will now fail.

The correct fix will land at some point in https://github.com/madsmtm/objc2/pull/526, which will also help with such a problem not happening again, but we can fix the issue in the interim using the `relax-void-encoding` escape-hatch.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
