### PR TITLE
Workaround for fallback to GLES1 on supported GLES2 platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Added workaround for fallback to GLES1 on supported GLES2 platforms (See https://github.com/rust-windowing/glutin/issues/1647).
+
 # Version 0.31.1
 
 - Fixed `CGLContextObj` having an invalid encoding on newer macOS versions.

--- a/glutin/src/api/egl/context.rs
+++ b/glutin/src/api/egl/context.rs
@@ -119,6 +119,16 @@ impl Display {
             }
         }
 
+        // Workaround for fallback to GLES1 on supported GLES2 platforms
+        // Reference: https://github.com/rust-windowing/glutin/issues/1647
+        // Setting the EGL context client version to the specified major version
+        if let Some(version) = version {
+            if version.major == 2 {
+                attrs.push(egl::CONTEXT_CLIENT_VERSION as EGLint);
+                attrs.push(version.major as EGLint);
+            }
+        }
+
         attrs.push(egl::NONE as EGLint);
 
         let shared_context = if let Some(shared_context) =


### PR DESCRIPTION
This aims to safely fix the issue reported in https://github.com/rust-windowing/glutin/issues/1647. Tested on my device. Shouldn't break any other functionalities. 

Please note that I only purpose this workaround for major version `2` in order to decrease the risk of breakage, since I have no idea how this will preform on other major versions. Either ways, I don't believe major version `3` should be needing this.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
