### PR TITLE
Update `objc2` and `icrate` versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Updated `objc2` and `icrate` versions.
+
 # Version 0.31.2
 
 - Fixed EGL not setting context version with EGL versions before 1.5 and missing context ext.

--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -52,12 +52,10 @@ x11-dl = { version = "2.20.0", optional = true }
 [target.'cfg(any(target_os = "macos"))'.dependencies]
 cgl = "0.3.2"
 core-foundation = "0.9.3"
-# Enable `relax-void-encoding` until https://github.com/madsmtm/objc2/pull/526 is resolved
-objc2 = { version = "0.4.1", features = ["relax-void-encoding"] }
-dispatch = "0.2.0"
+objc2 = "0.5.0"
 
 [target.'cfg(any(target_os = "macos"))'.dependencies.icrate]
-version = "0.0.4"
+version = "0.1.0"
 features = [
     "dispatch",
     "Foundation",

--- a/glutin/src/api/cgl/appkit.rs
+++ b/glutin/src/api/cgl/appkit.rs
@@ -17,7 +17,7 @@ pub struct CGLContextObj {
 }
 
 unsafe impl RefEncode for CGLContextObj {
-    const ENCODING_REF: Encoding = Encoding::Pointer(&Encoding::Void);
+    const ENCODING_REF: Encoding = Encoding::Pointer(&Encoding::Struct("_CGLContextObject", &[]));
 }
 
 extern_class!(
@@ -42,7 +42,7 @@ extern_methods!(
 
         #[method_id(initWithFormat:shareContext:)]
         pub(crate) fn initWithFormat_shareContext(
-            this: Option<Allocated<Self>>,
+            this: Allocated<Self>,
             format: &NSOpenGLPixelFormat,
             share: Option<&NSOpenGLContext>,
         ) -> Option<Id<Self>>;
@@ -97,7 +97,7 @@ extern_methods!(
     unsafe impl NSOpenGLPixelFormat {
         #[method_id(initWithAttributes:)]
         unsafe fn initWithAttributes(
-            this: Option<Allocated<Self>>,
+            this: Allocated<Self>,
             attrs: *const NSOpenGLPixelFormatAttribute,
         ) -> Option<Id<Self>>;
 

--- a/glutin/src/api/cgl/surface.rs
+++ b/glutin/src/api/cgl/surface.rs
@@ -109,7 +109,7 @@ impl<T: SurfaceTypeTrait> GlSurface<T> for Surface<T> {
     fn width(&self) -> Option<u32> {
         let window = &self.ns_window;
         let view = &self.ns_view;
-        MainThreadMarker::run_on_main(|mtm| unsafe {
+        MainThreadMarker::run_on_main(|mtm| {
             let scale_factor = window.get(mtm).backingScaleFactor();
             let frame = view.get(mtm).frame();
             Some((frame.size.width * scale_factor) as u32)
@@ -119,7 +119,7 @@ impl<T: SurfaceTypeTrait> GlSurface<T> for Surface<T> {
     fn height(&self) -> Option<u32> {
         let window = &self.ns_window;
         let view = &self.ns_view;
-        MainThreadMarker::run_on_main(|mtm| unsafe {
+        MainThreadMarker::run_on_main(|mtm| {
             let scale_factor = window.get(mtm).backingScaleFactor();
             let frame = view.get(mtm).frame();
             Some((frame.size.height * scale_factor) as u32)


### PR DESCRIPTION
Blocked on https://github.com/madsmtm/objc2/issues/537 and should probably be done in tandem with https://github.com/rust-windowing/winit/pull/3256.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
