### PR TITLE
chore: bump raw-window-handle to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- **Breaking:** Bump `raw-window-handle` to version `0.6.0`
+
 # Version 0.31.1
 
 - Fixed `CGLContextObj` having an invalid encoding on newer macOS versions.

--- a/glutin-winit/Cargo.toml
+++ b/glutin-winit/Cargo.toml
@@ -19,8 +19,8 @@ wayland = ["glutin/wayland", "winit/wayland"]
 
 [dependencies]
 glutin = { version = "0.31.0", path = "../glutin", default-features = false }
-raw-window-handle = "0.5.2"
-winit = { version = "0.29.2", default-features = false, features = ["rwh_05"] }
+raw-window-handle = "0.6.0"
+winit = { version = "0.29.2", default-features = false, features = ["rwh_06"] }
 
 [build-dependencies]
 cfg_aliases = "0.1.1"

--- a/glutin-winit/src/lib.rs
+++ b/glutin-winit/src/lib.rs
@@ -23,7 +23,7 @@ use glutin::prelude::*;
 #[cfg(wgl_backend)]
 use raw_window_handle::HasRawWindowHandle;
 
-use raw_window_handle::{HasRawDisplayHandle, RawWindowHandle};
+use raw_window_handle::{HasDisplayHandle, RawWindowHandle};
 use winit::error::OsError;
 use winit::event_loop::EventLoopWindowTarget;
 use winit::window::{Window, WindowBuilder};
@@ -170,7 +170,7 @@ fn create_display<T>(
         ApiPreference::FallbackEgl => DisplayApiPreference::WglThenEgl(_raw_window_handle),
     };
 
-    unsafe { Ok(Display::new(window_target.raw_display_handle(), _preference)?) }
+    unsafe { Ok(Display::new(window_target.display_handle()?.into(), _preference)?) }
 }
 
 /// Finalize [`Window`] creation by applying the options from the [`Config`], be

--- a/glutin-winit/src/window.rs
+++ b/glutin-winit/src/window.rs
@@ -5,7 +5,7 @@ use glutin::surface::{
     GlSurface, ResizeableSurface, Surface, SurfaceAttributes, SurfaceAttributesBuilder,
     SurfaceTypeTrait, WindowSurface,
 };
-use raw_window_handle::HasRawWindowHandle;
+use raw_window_handle::HasWindowHandle;
 use winit::window::Window;
 
 /// [`Window`] extensions for working with [`glutin`] surfaces.
@@ -53,7 +53,8 @@ impl GlWindow for Window {
         builder: SurfaceAttributesBuilder<WindowSurface>,
     ) -> SurfaceAttributes<WindowSurface> {
         let (w, h) = self.inner_size().non_zero().expect("invalid zero inner size");
-        builder.build(self.raw_window_handle(), w, h)
+        let raw_window_handle = self.window_handle().expect("invalid window handle").as_raw();
+        builder.build(raw_window_handle, w, h)
     }
 
     fn resize_surface(

--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -23,7 +23,7 @@ wayland = ["wayland-sys"]
 bitflags = "2.2.1"
 libloading = { version = "0.8.0", optional = true }
 once_cell = "1.13"
-raw-window-handle = "0.5.2"
+raw-window-handle = "0.6.0"
 
 [target.'cfg(windows)'.dependencies]
 glutin_egl_sys = { version = "0.6.0", path = "../glutin_egl_sys", optional = true }

--- a/glutin/src/api/egl/config.rs
+++ b/glutin/src/api/egl/config.rs
@@ -196,9 +196,9 @@ impl Display {
                 // XXX This can't be done by passing visual in the EGL attributes
                 // when calling `eglChooseConfig` since the visual is ignored.
                 match template.native_window {
-                    Some(RawWindowHandle::Xcb(xcb)) if xcb.visual_id > 0 => {
-                        xcb.visual_id as u32 == config.native_visual()
-                    },
+                    Some(RawWindowHandle::Xcb(xcb)) => xcb
+                        .visual_id
+                        .map_or(false, |visual_id| visual_id.get() == config.native_visual()),
                     Some(RawWindowHandle::Xlib(xlib)) if xlib.visual_id > 0 => {
                         xlib.visual_id as u32 == config.native_visual()
                     },
@@ -386,7 +386,9 @@ impl X11GlConfigExt for Config {
         match *self.inner.display.inner._native_display? {
             raw_window_handle::RawDisplayHandle::Xlib(display_handle) => unsafe {
                 let xid = self.native_visual();
-                X11VisualInfo::from_xid(display_handle.display as *mut _, xid as _)
+                display_handle.display.and_then(|display| {
+                    X11VisualInfo::from_xid(display.as_ptr() as *mut _, xid as _)
+                })
             },
             _ => None,
         }

--- a/glutin/src/api/egl/surface.rs
+++ b/glutin/src/api/egl/surface.rs
@@ -493,20 +493,10 @@ impl NativeWindow {
             RawWindowHandle::Xcb(window_handle) => Self::Xcb(window_handle.window.get()),
             #[cfg(android_platform)]
             RawWindowHandle::AndroidNdk(window_handle) => {
-                if window_handle.a_native_window.is_null() {
-                    return Err(ErrorKind::BadNativeWindow.into());
-                }
-
-                Self::Android(window_handle.a_native_window)
+                Self::Android(window_handle.a_native_window.as_ptr())
             },
             #[cfg(windows)]
-            RawWindowHandle::Win32(window_handle) => {
-                if window_handle.hwnd.is_null() {
-                    return Err(ErrorKind::BadNativeWindow.into());
-                }
-
-                Self::Win32(window_handle.hwnd as _)
-            },
+            RawWindowHandle::Win32(window_handle) => Self::Win32(window_handle.hwnd.get()),
             #[cfg(free_unix)]
             RawWindowHandle::Gbm(window_handle) => {
                 Self::Gbm(window_handle.gbm_surface.as_ptr() as _)

--- a/glutin/src/api/glx/display.rs
+++ b/glutin/src/api/glx/display.rs
@@ -45,11 +45,11 @@ impl Display {
         // Don't load GLX when unsupported platform was requested.
         let (display, screen) = match display {
             RawDisplayHandle::Xlib(handle) => {
-                if handle.display.is_null() {
+                let Some(display) = handle.display else {
                     return Err(ErrorKind::BadDisplay.into());
-                }
+                };
 
-                (GlxDisplay(handle.display as *mut _), handle.screen as i32)
+                (GlxDisplay(display.as_ptr() as *mut _), handle.screen as i32)
             },
             _ => {
                 return Err(

--- a/glutin_examples/Cargo.toml
+++ b/glutin_examples/Cargo.toml
@@ -22,11 +22,11 @@ wayland = ["glutin-winit/wayland", "winit/wayland-dlopen", "winit/wayland-csd-ad
 glutin = { path = "../glutin", default-features = false }
 glutin-winit = { path = "../glutin-winit", default-features = false }
 png = { version = "0.17.6", optional = true }
-raw-window-handle = "0.5"
-winit = { version = "0.29.2", default-features = false, features = ["rwh_05"] }
+raw-window-handle = "0.6"
+winit = { version = "0.29.2", default-features = false, features = ["rwh_06"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
-winit = { version = "0.29.2", default-features = false, features = ["android-native-activity", "rwh_05"] }
+winit = { version = "0.29.2", default-features = false, features = ["android-native-activity", "rwh_06"] }
 
 [build-dependencies]
 gl_generator = "0.14"

--- a/glutin_examples/src/lib.rs
+++ b/glutin_examples/src/lib.rs
@@ -3,7 +3,7 @@ use std::ffi::{CStr, CString};
 use std::num::NonZeroU32;
 use std::ops::Deref;
 
-use raw_window_handle::HasRawWindowHandle;
+use raw_window_handle::HasWindowHandle;
 use winit::event::{Event, WindowEvent};
 use winit::window::WindowBuilder;
 
@@ -63,7 +63,10 @@ pub fn main(event_loop: winit::event_loop::EventLoop<()>) -> Result<(), Box<dyn 
 
     println!("Picked a config with {} samples", gl_config.num_samples());
 
-    let raw_window_handle = window.as_ref().map(|window| window.raw_window_handle());
+    let raw_window_handle = window
+        .as_ref()
+        .and_then(|window| window.window_handle().ok())
+        .map(|window_handle| window_handle.as_raw());
 
     // XXX The display could be obtained from the any object created by it, so we
     // can query it from the config.


### PR DESCRIPTION
> [!WARNING]
> I'm still very new to Rust so please review these changes *very* carefully.

Marked as a draft until all platforms are implemented:
- [x] Linux
- [x] Android
- [ ] Windows
- [ ] macOS

Bump `raw-window-handle` to version `0.6.0` which introduced a couple of API changes.

- [ ] Tested on all platforms changed (these changes affect all platforms but I'm only able to test them on Wayland)
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users