### PR TITLE
Reuse some features and code, fix inverted intradoc links

### DIFF
--- a/glutin-winit/Cargo.toml
+++ b/glutin-winit/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 [features]
 default = ["egl", "glx", "x11", "wayland", "wgl"]
 egl = ["glutin/egl"]
-glx = ["glutin/glx", "glutin/x11", "winit/x11", "x11"]
+glx = ["glutin/glx", "x11"]
 wgl = ["glutin/wgl"]
 x11 = ["glutin/x11", "winit/x11"]
 wayland = ["glutin/wayland", "winit/wayland"]

--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -14,10 +14,10 @@ edition = "2021"
 [features]
 default = ["egl", "glx", "x11", "wayland", "wgl"]
 egl = ["glutin_egl_sys", "libloading"]
-glx = ["x11", "x11-dl", "glutin_glx_sys", "libloading"]
+glx = ["x11", "glutin_glx_sys", "libloading"]
 wgl = ["glutin_wgl_sys", "windows-sys"]
 x11 = ["x11-dl"]
-wayland = ["wayland-sys"]
+wayland = ["wayland-sys", "egl"]
 
 [dependencies]
 bitflags = "2.2.1"

--- a/glutin/src/api/egl/config.rs
+++ b/glutin/src/api/egl/config.rs
@@ -370,7 +370,7 @@ impl GetGlDisplay for Config {
     type Target = Display;
 
     fn display(&self) -> Self::Target {
-        Display { inner: self.inner.display.inner.clone() }
+        self.inner.display.clone()
     }
 }
 

--- a/glutin/src/api/egl/display.rs
+++ b/glutin/src/api/egl/display.rs
@@ -46,7 +46,7 @@ impl Display {
     /// # Safety
     ///
     /// `raw_display` must point to a valid system display. Using zero or
-    /// `[std::ptr::null]` for the display will result in using
+    /// [`std::ptr::null()`] for the display will result in using
     /// `EGL_DEFAULT_DISPLAY`, which is not recommended or will
     /// work on a platform with a concept of native display, like Wayland.
     pub unsafe fn new(raw_display: RawDisplayHandle) -> Result<Self> {
@@ -80,7 +80,7 @@ impl Display {
 
     /// Create an EGL display using the specified device.
     ///
-    /// In most cases, prefer [`Display::new`] unless you need to render
+    /// In most cases, prefer [`Display::new()`] unless you need to render
     /// off screen or use other extensions like EGLStreams.
     ///
     /// This function may take an optional [`RawDisplayHandle`] argument. At the

--- a/glutin/src/api/glx/mod.rs
+++ b/glutin/src/api/glx/mod.rs
@@ -29,8 +29,8 @@ pub mod surface;
 /// The hook registrar must call to the function inside xlib error
 /// [`handler`].
 ///
-/// The `bool` value returned by that hook tells wether the error was handled by
-/// it or not. So when it returns `true` it means that your error handling
+/// The `bool` value returned by that hook tells whether the error was handled
+/// by it or not. So when it returns `true` it means that your error handling
 /// routine shouldn't handle the error as it was handled by the hook already.
 ///
 /// [`handler`]: https://tronche.com/gui/x/xlib/event-handling/protocol-errors/XSetErrorHandler.html

--- a/glutin/src/config.rs
+++ b/glutin/src/config.rs
@@ -108,7 +108,7 @@ impl ConfigTemplateBuilder {
         self
     }
 
-    /// Wether the floating pixel formats should be used.
+    /// Whether the floating pixel formats should be used.
     ///
     /// By default `false` is requested.
     #[inline]
@@ -181,7 +181,7 @@ impl ConfigTemplateBuilder {
         self
     }
 
-    /// Wether the stereo pairs should be present.
+    /// Whether the stereo pairs should be present.
     ///
     /// By default it isn't specified.
     #[inline]
@@ -190,7 +190,7 @@ impl ConfigTemplateBuilder {
         self
     }
 
-    /// Wether the single buffer should be used.
+    /// Whether the single buffer should be used.
     ///
     /// By default `false` is requested.
     #[inline]
@@ -199,7 +199,7 @@ impl ConfigTemplateBuilder {
         self
     }
 
-    /// Wether the configuration should support transparency.
+    /// Whether the configuration should support transparency.
     ///
     /// The default is `false`.
     ///
@@ -221,7 +221,7 @@ impl ConfigTemplateBuilder {
         self
     }
 
-    /// Wether the configuration should prefer hardware accelerated formats or
+    /// Whether the configuration should prefer hardware accelerated formats or
     /// not.
     ///
     /// By default hardware acceleration or its absence is not requested.

--- a/glutin/src/surface.rs
+++ b/glutin/src/surface.rs
@@ -486,7 +486,7 @@ impl<T: SurfaceTypeTrait> Sealed for Surface<T> {}
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SwapInterval {
     /// When this variant is used calling
-    /// `[crate::surface::GlSurface::swap_buffers]` will not block.
+    /// [`crate::surface::GlSurface::swap_buffers()`] will not block.
     DontWait,
 
     /// The swap is synchronized to the `n`'th video frame. This is typically

--- a/glutin_examples/src/lib.rs
+++ b/glutin_examples/src/lib.rs
@@ -23,10 +23,10 @@ pub mod gl {
 }
 
 pub fn main(event_loop: winit::event_loop::EventLoop<()>) -> Result<(), Box<dyn Error>> {
-    // Only windows requires the window to be present before creating the display.
+    // Only Windows requires the window to be present before creating the display.
     // Other platforms don't really need one.
     //
-    // XXX if you don't care about running on android or so you can safely remove
+    // XXX if you don't care about running on Android or so you can safely remove
     // this condition and always pass the window builder.
     let window_builder =
         if cfg!(wgl_backend) { Some(WindowBuilder::new().with_transparent(true)) } else { None };
@@ -65,8 +65,8 @@ pub fn main(event_loop: winit::event_loop::EventLoop<()>) -> Result<(), Box<dyn 
 
     let raw_window_handle = window.as_ref().map(|window| window.raw_window_handle());
 
-    // XXX The display could be obtained from the any object created by it, so we
-    // can query it from the config.
+    // XXX The display could be obtained from any object created by it, so we can
+    // query it from the config.
     let gl_display = gl_config.display();
 
     // The context creation part. It can be created before surface and that's how
@@ -112,7 +112,7 @@ pub fn main(event_loop: winit::event_loop::EventLoop<()>) -> Result<(), Box<dyn 
                         .unwrap()
                 });
 
-                let attrs = window.build_surface_attributes(<_>::default());
+                let attrs = window.build_surface_attributes(Default::default());
                 let gl_surface = unsafe {
                     gl_config.display().create_window_surface(&gl_config, &attrs).unwrap()
                 };


### PR DESCRIPTION
Found some very minor code cases that could reuse some other code.  Some features also already imply/enable other features and don't need to be repeated.

Some "intradoc" links were having `[]` inside backticks, meaning they won't be links but actual brackets in monospace in the final doc.

Finally, the `wayland` feature needs the `egl` backend to compile and function, and was likely intended to be turned on as a dependency.
