### PR TITLE
fix: fix feature = "cargo-clippy" deprecation

### DIFF
--- a/glutin-winit/src/lib.rs
+++ b/glutin-winit/src/lib.rs
@@ -6,7 +6,7 @@
 #![deny(clippy::all)]
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
-#![cfg_attr(feature = "cargo-clippy", deny(warnings))]
+#![cfg_attr(clippy, deny(warnings))]
 
 mod window;
 

--- a/glutin/src/lib.rs
+++ b/glutin/src/lib.rs
@@ -17,7 +17,7 @@
 #![deny(clippy::all)]
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
-#![cfg_attr(feature = "cargo-clippy", deny(warnings))]
+#![cfg_attr(clippy, deny(warnings))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(all(not(egl_backend), not(glx_backend), not(wgl_backend), not(cgl_backend)))]


### PR DESCRIPTION
https://blog.rust-lang.org/2024/02/28/Clippy-deprecating-feature-cargo-clippy.html