### PR TITLE
Add spellcheck to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,6 @@ jobs:
         tool: typos-cli
     - name: Check Formatting
       run: cargo +nightly fmt --all -- --check
-    - name: Check Formatting
-      run: cargo fmt --all -- --check
     - name: Run Typos
       run: typos
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,15 @@ jobs:
       with:
         rust-version: nightly
         components: rustfmt
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: typos-cli
     - name: Check Formatting
       run: cargo +nightly fmt --all -- --check
+    - name: Check Formatting
+      run: cargo fmt --all -- --check
+    - name: Run Typos
+      run: typos
 
   tests:
     name: Tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@
 
 # Version 0.30.3
 
-- Fixed wrong amount of rects commited in `Surface::swap_buffers_with_damage` with EGL.
+- Fixed wrong amount of rects committed in `Surface::swap_buffers_with_damage` with EGL.
 - Added missing `Eq`, `PartialEq`, and `Hash` impls for `surface::Rect`.
 
 # Version 0.30.2
@@ -92,9 +92,9 @@
 - **This version of `glutin` has been rewritten from the ground and no longer depends on `winit`, the `raw-window-handle` is now used instead of it.**
 - The Api is now built around `Display`, `Surface`, `Config`, and `Surface`. For more info see crate documentation and examples.
 - **Breaking:** Bump MSRV from `1.57` to `1.60`.
-- The ios support was removed for the lack of maintainance for now. In case there's a need for it, contributions are welcome.
+- The ios support was removed for the lack of maintenance for now. In case there's a need for it, contributions are welcome.
 - The context creation is no longer limited to winit's supported platforms.
-- The underlying Api providers are publically exposed now, so glutin could be used with just e.g. `EGL`.
+- The underlying Api providers are publicly exposed now, so glutin could be used with just e.g. `EGL`.
 - Fixed soundness issues with `Surface` MT safety, since before `EGLSurface` could be sent to a different thread, which is not safe.
 - Fallback to `Surface::swap_buffers` when `Surface::swap_buffers_with_damage` is not supported on `EGL`.
 

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,2 @@
+[type.md.extend-identifiers]
+ApiPrefence = "ApiPrefence"

--- a/glutin/src/api/cgl/surface.rs
+++ b/glutin/src/api/cgl/surface.rs
@@ -88,7 +88,7 @@ impl Display {
     }
 }
 
-/// A wrapper aroud `NSView`.
+/// A wrapper around `NSView`.
 pub struct Surface<T: SurfaceTypeTrait> {
     display: Display,
     config: Config,

--- a/glutin/src/api/glx/surface.rs
+++ b/glutin/src/api/glx/surface.rs
@@ -238,7 +238,7 @@ impl<T: SurfaceTypeTrait> GlSurface<T> for Surface<T> {
             },
             _ => {
                 return Err(
-                    ErrorKind::NotSupported("swap contol extrensions are not supported").into()
+                    ErrorKind::NotSupported("swap control extensions are not supported").into()
                 );
             },
         };

--- a/glutin/src/api/wgl/mod.rs
+++ b/glutin/src/api/wgl/mod.rs
@@ -87,7 +87,7 @@ unsafe fn load_extra_functions(
     // setups).
     unsafe { wm::RegisterClassExW(&class) };
 
-    // This dummy wnidow should match the real one enough to get the same OpenGL
+    // This dummy window should match the real one enough to get the same OpenGL
     // driver.
     let title =
         OsStr::new("dummy window").encode_wide().chain(Some(0).into_iter()).collect::<Vec<_>>();

--- a/glutin/src/api/wgl/surface.rs
+++ b/glutin/src/api/wgl/surface.rs
@@ -144,7 +144,7 @@ impl<T: SurfaceTypeTrait> GlSurface<T> for Surface<T> {
             },
             _ => {
                 return Err(
-                    ErrorKind::NotSupported("swap contol extrensions are not supported").into()
+                    ErrorKind::NotSupported("swap control extensions are not supported").into()
                 )
             },
         };

--- a/glutin/src/context.rs
+++ b/glutin/src/context.rs
@@ -51,7 +51,7 @@ pub trait NotCurrentGlContext: Sealed {
 
     /// Make [`Self::Surface`] on the calling thread producing the
     /// [`Self::PossiblyCurrentContext`] indicating that the context could
-    /// be current on the theard.
+    /// be current on the thread.
     ///
     /// # Platform specific
     ///

--- a/glutin/src/error.rs
+++ b/glutin/src/error.rs
@@ -14,7 +14,7 @@ pub struct Error {
     /// The raw message from the os in case it could be obtained.
     raw_os_message: Option<String>,
 
-    /// The simplified error kind to handle mathing.
+    /// The simplified error kind to handle matching.
     kind: ErrorKind,
 }
 
@@ -151,7 +151,7 @@ impl ErrorKind {
             InitializationFailed => "initialization failed",
             BadAccess => "access to the resource failed",
             OutOfMemory => "out of memory",
-            BadAttribute => "an anrecougnized attribute or attribute value was passed",
+            BadAttribute => "an unrecognized attribute or attribute value was passed",
             BadContext => "argument does not name a valid context",
             BadContextState => "the context is in a bad state",
             BadConfig => "argument does not name a valid config",
@@ -160,7 +160,7 @@ impl ErrorKind {
             BadSurface => "argument does not name a valid surface",
             BadPbuffer => "argument does not name a valid pbuffer",
             BadPixmap => "argument does not name a valid pixmap",
-            BadMatch => "arguments are inconsistance",
+            BadMatch => "arguments are inconsistent",
             BadParameter => "one or more argument values are invalid",
             BadNativePixmap => "argument does not refer to a valid native pixmap",
             BadNativeWindow => "argument does not refer to a valid native window",

--- a/glutin/src/platform/x11.rs
+++ b/glutin/src/platform/x11.rs
@@ -16,7 +16,7 @@ static XRENDER: Lazy<Option<Xrender>> = Lazy::new(|| Xrender::open().ok());
 
 /// The GlConfig extension trait to get X11 specific properties from a config.
 pub trait X11GlConfigExt {
-    /// The `X11VisualInfo` that must be used to inititalize the Xlib window.
+    /// The `X11VisualInfo` that must be used to initialize the Xlib window.
     fn x11_visual(&self) -> Option<X11VisualInfo>;
 }
 


### PR DESCRIPTION
As per the precedent set in winit, adds a spellchecker using the typos
crate to CI.

cc https://github.com/rust-windowing/winit/pull/3565

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
