### PR TITLE
chore: bump cfg_aliases to 0.2.1

### DIFF
--- a/glutin-winit/Cargo.toml
+++ b/glutin-winit/Cargo.toml
@@ -24,4 +24,4 @@ raw-window-handle = "0.6"
 winit = { version = "0.29.2", default-features = false, features = ["rwh_06"] }
 
 [build-dependencies]
-cfg_aliases = "0.1.1"
+cfg_aliases = "0.2.1"

--- a/glutin-winit/build.rs
+++ b/glutin-winit/build.rs
@@ -23,19 +23,4 @@ fn main() {
         wgl_backend: { all(feature = "wgl", windows, not(wasm_platform)) },
         cgl_backend: { all(macos_platform, not(wasm_platform)) },
     }
-
-    println!("cargo:rustc-check-cfg=cfg(android_platform)");
-    println!("cargo:rustc-check-cfg=cfg(wasm_platform)");
-    println!("cargo:rustc-check-cfg=cfg(macos_platform)");
-    println!("cargo:rustc-check-cfg=cfg(ios_platform)");
-    println!("cargo:rustc-check-cfg=cfg(apple)");
-    println!("cargo:rustc-check-cfg=cfg(free_unix)");
-
-    println!("cargo:rustc-check-cfg=cfg(x11_platform)");
-    println!("cargo:rustc-check-cfg=cfg(wayland_platform)");
-
-    println!("cargo:rustc-check-cfg=cfg(egl_backend)");
-    println!("cargo:rustc-check-cfg=cfg(glx_backend)");
-    println!("cargo:rustc-check-cfg=cfg(wgl_backend)");
-    println!("cargo:rustc-check-cfg=cfg(cgl_backend)");
 }

--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -73,7 +73,7 @@ features = [
 ]
 
 [build-dependencies]
-cfg_aliases = "0.1.1"
+cfg_aliases = "0.2.1"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/glutin/build.rs
+++ b/glutin/build.rs
@@ -21,19 +21,4 @@ fn main() {
         wgl_backend: { all(feature = "wgl", windows, not(wasm_platform)) },
         cgl_backend: { all(macos_platform, not(wasm_platform)) },
     }
-
-    println!("cargo:rustc-check-cfg=cfg(android_platform)");
-    println!("cargo:rustc-check-cfg=cfg(wasm_platform)");
-    println!("cargo:rustc-check-cfg=cfg(macos_platform)");
-    println!("cargo:rustc-check-cfg=cfg(ios_platform)");
-    println!("cargo:rustc-check-cfg=cfg(apple)");
-    println!("cargo:rustc-check-cfg=cfg(free_unix)");
-
-    println!("cargo:rustc-check-cfg=cfg(x11_platform)");
-    println!("cargo:rustc-check-cfg=cfg(wayland_platform)");
-
-    println!("cargo:rustc-check-cfg=cfg(egl_backend)");
-    println!("cargo:rustc-check-cfg=cfg(glx_backend)");
-    println!("cargo:rustc-check-cfg=cfg(wgl_backend)");
-    println!("cargo:rustc-check-cfg=cfg(cgl_backend)");
 }

--- a/glutin_examples/Cargo.toml
+++ b/glutin_examples/Cargo.toml
@@ -30,7 +30,7 @@ winit = { version = "0.29.2", default-features = false, features = ["android-nat
 
 [build-dependencies]
 gl_generator = "0.14"
-cfg_aliases = "0.1.1"
+cfg_aliases = "0.2.1"
 
 [[example]]
 name = "android"

--- a/glutin_examples/build.rs
+++ b/glutin_examples/build.rs
@@ -29,21 +29,6 @@ fn main() {
         cgl_backend: { all(macos_platform, not(wasm_platform)) },
     }
 
-    println!("cargo:rustc-check-cfg=cfg(android_platform)");
-    println!("cargo:rustc-check-cfg=cfg(wasm_platform)");
-    println!("cargo:rustc-check-cfg=cfg(macos_platform)");
-    println!("cargo:rustc-check-cfg=cfg(ios_platform)");
-    println!("cargo:rustc-check-cfg=cfg(apple)");
-    println!("cargo:rustc-check-cfg=cfg(free_unix)");
-
-    println!("cargo:rustc-check-cfg=cfg(x11_platform)");
-    println!("cargo:rustc-check-cfg=cfg(wayland_platform)");
-
-    println!("cargo:rustc-check-cfg=cfg(egl_backend)");
-    println!("cargo:rustc-check-cfg=cfg(glx_backend)");
-    println!("cargo:rustc-check-cfg=cfg(wgl_backend)");
-    println!("cargo:rustc-check-cfg=cfg(cgl_backend)");
-
     let dest = PathBuf::from(&env::var("OUT_DIR").unwrap());
 
     println!("cargo:rerun-if-changed=build.rs");


### PR DESCRIPTION
This correctly handles recent nightly lint that requires to explicitly define the CFG guards.