### PR TITLE
egl_sys: Drop duplicate manual definition of `(EGL_)TEXTURE_FORMAT`

### DIFF
--- a/glutin_egl_sys/src/egl.rs
+++ b/glutin_egl_sys/src/egl.rs
@@ -157,8 +157,6 @@ pub const TEXTURE_Y_U_V_WL: i32 = 0x31D7;
 pub const TEXTURE_Y_UV_WL: i32 = 0x31D8;
 pub const TEXTURE_Y_XUXV_WL: i32 = 0x31D9;
 pub const TEXTURE_EXTERNAL_WL: i32 = 0x31DA;
-// Accepted in the <attribute> parameter of eglQueryWaylandBufferWL.
-pub const EGL_TEXTURE_FORMAT: i32 = 0x3080;
 pub const WAYLAND_Y_INVERTED_WL: i32 = 0x31DB;
 
 #[allow(non_snake_case)]


### PR DESCRIPTION
For https://github.com/rust-windowing/glutin/pull/1668#discussion_r1631607958

The generated code already defines `TEXTURE_FORMAT` to `0x3080` with the usual `EGL_` prefix stripped; we shouldn't be redefining it (with this unnecessary prefix) in manual code.

- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
