### PR TITLE
Fix logic in egl Device::query_device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fixed EGL's `Device::query_devices()` being too strict about required extensions
+
 # Version 0.32.0
 
 - **Breaking:** updated `raw-window-handle` dependency to `0.6`.

--- a/glutin/src/api/egl/device.rs
+++ b/glutin/src/api/egl/device.rs
@@ -41,9 +41,9 @@ impl Device {
         //
         // Or we can check for the EGL_EXT_device_base extension since it contains both
         // extensions.
-        if (!no_display_extensions.contains("EGL_EXT_device_enumeration")
-            && !no_display_extensions.contains("EGL_EXT_device_query"))
-            || !no_display_extensions.contains("EGL_EXT_device_base")
+        if !no_display_extensions.contains("EGL_EXT_device_base")
+        && ( !no_display_extensions.contains("EGL_EXT_device_enumeration")
+          || !no_display_extensions.contains("EGL_EXT_device_query"))
         {
             return Err(ErrorKind::NotSupported("EGL does not support EGL_EXT_device_base").into());
         }

--- a/glutin/src/api/egl/device.rs
+++ b/glutin/src/api/egl/device.rs
@@ -4,7 +4,6 @@ use std::collections::HashSet;
 use std::ffi::{c_void, CStr};
 use std::ptr;
 
-use bitflags::Flags;
 use glutin_egl_sys::egl;
 use glutin_egl_sys::egl::types::EGLDeviceEXT;
 

--- a/glutin/src/api/egl/device.rs
+++ b/glutin/src/api/egl/device.rs
@@ -37,19 +37,20 @@ impl Device {
             CLIENT_EXTENSIONS.get_or_init(|| get_extensions(egl, egl::NO_DISPLAY));
 
         // Querying devices requires EGL_EXT_device_enumeration or EGL_EXT_device_base.
-        //
-        // The former depends on EGL_EXT_device_query, so also check that just in case.
         if !client_extensions.contains("EGL_EXT_device_base") {
-            let query = client_extensions.contains("EGL_EXT_device_query");
-            let enumr = client_extensions.contains("EGL_EXT_device_enumeration");
-            if !(query && enumr) {
-                let msg = if !enumr {
-                    "Enumerating devices is not supported by the EGL instance"
-                } else {
-                    // This should not happen as device_enumeration depends on device_query.
-                    "EGL_EXT_device_enumeration without EGL_EXT_device_query, buggy driver?"
-                };
-                return Err(ErrorKind::NotSupported(msg).into());
+            if !client_extensions.contains("EGL_EXT_device_enumeration") {
+                return Err(ErrorKind::NotSupported(
+                    "Enumerating devices is not supported by the EGL instance",
+                )
+                .into());
+            }
+            // EGL_EXT_device_enumeration depends on EGL_EXT_device_query,
+            // so also check that just in case.
+            if !client_extensions.contains("EGL_EXT_device_query") {
+                return Err(ErrorKind::NotSupported(
+                    "EGL_EXT_device_enumeration without EGL_EXT_device_query, buggy driver?",
+                )
+                .into());
             }
         }
 

--- a/glutin/src/api/egl/device.rs
+++ b/glutin/src/api/egl/device.rs
@@ -42,11 +42,11 @@ impl Device {
         if !client_extensions.contains("EGL_EXT_device_base") {
             let query = client_extensions.contains("EGL_EXT_device_query");
             let enumr = client_extensions.contains("EGL_EXT_device_enumeration");
-            if !(query & enumr) {
+            if !(query && enumr) {
                 let msg = if !enumr {
                     "Enumerating devices is not supported by the EGL instance"
                 } else {
-                    // this should not happen as device_enumeration depends on device_query
+                    // This should not happen as device_enumeration depends on device_query.
                     "EGL_EXT_device_enumeration without EGL_EXT_device_query, buggy driver?"
                 };
                 return Err(ErrorKind::NotSupported(msg).into());

--- a/glutin/src/api/egl/device.rs
+++ b/glutin/src/api/egl/device.rs
@@ -42,8 +42,8 @@ impl Device {
         // Or we can check for the EGL_EXT_device_base extension since it contains both
         // extensions.
         if !no_display_extensions.contains("EGL_EXT_device_base")
-        && ( !no_display_extensions.contains("EGL_EXT_device_enumeration")
-          || !no_display_extensions.contains("EGL_EXT_device_query"))
+            && (!no_display_extensions.contains("EGL_EXT_device_enumeration")
+                || !no_display_extensions.contains("EGL_EXT_device_query"))
         {
             return Err(ErrorKind::NotSupported("EGL does not support EGL_EXT_device_base").into());
         }

--- a/glutin/src/api/egl/device.rs
+++ b/glutin/src/api/egl/device.rs
@@ -43,7 +43,7 @@ impl Device {
             let query = client_extensions.contains("EGL_EXT_device_query");
             let enumr = client_extensions.contains("EGL_EXT_device_enumeration");
             if !(query & enumr) {
-                let msg = if query {
+                let msg = if !enumr {
                     "enumerating devices is not supported by the EGL instance"
                 } else {
                     // this should not happen as device_enumeration depends on device_query

--- a/glutin/src/api/egl/device.rs
+++ b/glutin/src/api/egl/device.rs
@@ -38,7 +38,7 @@ impl Device {
 
         // Querying devices requires EGL_EXT_device_enumeration or EGL_EXT_device_base.
         //
-        // The former depends on EGL_EXT_device_query, so also check that for validation.
+        // The former depends on EGL_EXT_device_query, so also check that just in case.
         if !client_extensions.contains("EGL_EXT_device_base") {
             let query = client_extensions.contains("EGL_EXT_device_query");
             let enumr = client_extensions.contains("EGL_EXT_device_enumeration");

--- a/glutin/src/api/egl/device.rs
+++ b/glutin/src/api/egl/device.rs
@@ -44,7 +44,7 @@ impl Device {
             let enumr = client_extensions.contains("EGL_EXT_device_enumeration");
             if !(query & enumr) {
                 let msg = if !enumr {
-                    "enumerating devices is not supported by the EGL instance"
+                    "Enumerating devices is not supported by the EGL instance"
                 } else {
                     // this should not happen as device_enumeration depends on device_query
                     "EGL_EXT_device_enumeration without EGL_EXT_device_query, buggy driver?"

--- a/glutin/src/api/egl/device.rs
+++ b/glutin/src/api/egl/device.rs
@@ -33,7 +33,7 @@ impl Device {
             None => return Err(ErrorKind::NotFound.into()),
         };
 
-        let no_display_extensions =
+        let client_extensions =
             CLIENT_EXTENSIONS.get_or_init(|| get_extensions(egl, egl::NO_DISPLAY));
 
         // Querying devices requires EGL_EXT_device_enumeration and
@@ -41,11 +41,13 @@ impl Device {
         //
         // Or we can check for the EGL_EXT_device_base extension since it contains both
         // extensions.
-        if !no_display_extensions.contains("EGL_EXT_device_base")
-            && (!no_display_extensions.contains("EGL_EXT_device_enumeration")
-                || !no_display_extensions.contains("EGL_EXT_device_query"))
+        if !client_extensions.contains("EGL_EXT_device_base")
+            && !client_extensions.contains("EGL_EXT_device_enumeration")
         {
-            return Err(ErrorKind::NotSupported("EGL does not support EGL_EXT_device_base").into());
+            return Err(ErrorKind::NotSupported(
+                "enumerating devices is not supported by the EGL instance",
+            )
+            .into());
         }
 
         let mut device_count = 0;


### PR DESCRIPTION
The previous test would mistakenly return an error if the extensions contain "EGL_EXT_device_base" but not the two others. As stated by the comment, and in https://registry.khronos.org/EGL/extensions/EXT/EGL_EXT_device_base.txt , it is supposed to contain the other two.

The cases that should not return an error are:
 - contains EGL_EXT_device_base (`B`)
 - contains both EGL_EXT_device_enumeration (`E`) and EGL_EXT_device_query (`Q`)
 
The overall effects of this patch in terms of those three extensions are:
   -  `!B &  E & !Q` leads to a different error message than before
   - ` B & !E & !Q`  no longer errors
   - `!B &  E &  Q`  no longer errors
 
