### PR TITLE
Fixed crash in `EglGetProcAddress` on Win32-x86 platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Fixed EGL's `Device::query_devices()` being too strict about required extensions
+- Fixed crash in `EglGetProcAddress` on Win32-x86 platform
 
 # Version 0.32.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 - Fixed EGL's `Device::query_devices()` being too strict about required extensions
-- Fixed crash in `EglGetProcAddress` on Win32-x86 platform
+- Fixed crash in `EglGetProcAddress` on Win32-x86 platform due to wrong calling convention
 
 # Version 0.32.0
 

--- a/glutin/src/api/egl/mod.rs
+++ b/glutin/src/api/egl/mod.rs
@@ -38,7 +38,7 @@ pub(crate) static EGL: Lazy<Option<Egl>> = Lazy::new(|| {
     unsafe { SymWrapper::new(&paths).map(Egl).ok() }
 });
 
-type EglGetProcAddress = unsafe extern "C" fn(*const ffi::c_void) -> *const ffi::c_void;
+type EglGetProcAddress = unsafe extern "system" fn(*const ffi::c_void) -> *const ffi::c_void;
 static EGL_GET_PROC_ADDRESS: OnceCell<libloading_os::Symbol<EglGetProcAddress>> = OnceCell::new();
 
 /// EGL interface.


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality

# Summary

Change the calling convention of the `EglGetProcAddress` declaration to `extern "system"` to automatically use the correct calling convention for the platform.

# Details

The `EglGetProcAddress` function uses the `stdcall` calling convention on the `Win32-x86` platform, but it was previously declared as `extern "C"` in the code.

On the `Win32-x86` platform, `extern "C"` functions use the `cdecl` calling convention by default.

This mismatch in calling conventions caused a crash.

By changing the declaration to `extern "system"`, the correct calling convention for the platform will be used automatically, preventing the crash.

# Testing

- Verified that the application no longer crashes on the `Win32-x86` platform.
- Ensured that the change does not affect other platforms.
