### PR TITLE
Implement a workaround for `libglvnd` aliasing `eglGetPlatformDisplay` and `eglGetPlatformDisplayEXT` and causing errors at surface creation due to use of KHR functions when the EGL version for the dispaly is 1.4.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Fixed EGL's `Device::query_devices()` being too strict about required extensions
 - Fixed crash in `EglGetProcAddress` on Win32-x86 platform due to wrong calling convention
-- Fixed EGL's `Display::new` making an `EGLDisplay::Khr` when the underlying platform only supports `EGLDisplay::Ext` due to `libglvnd` using the same vendor functions for obtaining a display connection both for `eglGetPlatformDisplay` and `eglGetPlatformDisplayEXT`.
+- Implement a workaround for EGL's `Display::new` making an `EGLDisplay::Khr` when the underlying platform only supports `EGLDisplay::Ext` due to `libglvnd` using the same vendor functions for obtaining a display connection both for `eglGetPlatformDisplay` and `eglGetPlatformDisplayEXT`.
 
 # Version 0.32.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Fixed EGL's `Device::query_devices()` being too strict about required extensions
 - Fixed crash in `EglGetProcAddress` on Win32-x86 platform due to wrong calling convention
-- Implement a workaround for EGL's `Display::new()` making an `EGLDisplay::Khr` when the underlying platform only supports `EGLDisplay::Ext` due to `libglvnd` using the same vendor functions for obtaining a display connection for both `eglGetPlatformDisplay()` and `eglGetPlatformDisplayEXT()`.
+- Fixed EGL's `Display::new()` making an `EGLDisplay::Khr` when the EGL version for the display is 1.4 or lower.
 
 # Version 0.32.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fixed EGL's `Device::query_devices()` being too strict about required extensions
 - Fixed crash in `EglGetProcAddress` on Win32-x86 platform due to wrong calling convention
+- Fixed EGL's `Display::new` making an `EGLDisplay::Khr` when the underlying platform only supports `EGLDisplay::Ext` due to `libglvnd` using the same vendor functions for obtaining a display connection both for `eglGetPlatformDisplay` and `eglGetPlatformDisplayEXT`.
 
 # Version 0.32.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Fixed EGL's `Device::query_devices()` being too strict about required extensions
 - Fixed crash in `EglGetProcAddress` on Win32-x86 platform due to wrong calling convention
-- Implement a workaround for EGL's `Display::new` making an `EGLDisplay::Khr` when the underlying platform only supports `EGLDisplay::Ext` due to `libglvnd` using the same vendor functions for obtaining a display connection both for `eglGetPlatformDisplay` and `eglGetPlatformDisplayEXT`.
+- Implement a workaround for EGL's `Display::new()` making an `EGLDisplay::Khr` when the underlying platform only supports `EGLDisplay::Ext` due to `libglvnd` using the same vendor functions for obtaining a display connection for both `eglGetPlatformDisplay()` and `eglGetPlatformDisplayEXT()`.
 
 # Version 0.32.0
 

--- a/glutin/src/api/egl/display.rs
+++ b/glutin/src/api/egl/display.rs
@@ -512,6 +512,9 @@ impl Display {
             // for a platform that does not support KHR functions and only supports EXT
             // functions. As such, we check if the version is equal to 1.4 and downgrade to
             // `EglDisplay::Ext` if so.
+            // See: https://gitlab.freedesktop.org/glvnd/libglvnd/-/blob/606f6627cf481ee6dcb32387edc010c502cdf38b/src/EGL/libegl.c#L270-358
+            // https://gitlab.freedesktop.org/glvnd/libglvnd/-/blob/606f6627cf481ee6dcb32387edc010c502cdf38b/src/EGL/libegl.c#L409-461
+            // https://gitlab.freedesktop.org/glvnd/libglvnd/-/blob/606f6627cf481ee6dcb32387edc010c502cdf38b/include/glvnd/libeglabi.h#L231-232
             (EglDisplay::Khr(display), Version { major: 1, minor: 4 }) => EglDisplay::Ext(display),
             // We do not do anything otherwise.
             (display, _) => display,

--- a/glutin/src/api/egl/display.rs
+++ b/glutin/src/api/egl/display.rs
@@ -507,11 +507,11 @@ impl Display {
     #[cfg(free_unix)]
     fn sanitize_libglvnd_aliasing(display: EglDisplay, version: Version) -> EglDisplay {
         match (display, version) {
-            // libglvnd has an unsavoury quirk of unconditionally aliasing `getPlatformDisplay` (unavailable on EGL 1.4) and
-            // `getPlatformDisplayEXT`, which may result in an `EglDisplay::Khr` being created
-            // for a platform that does not support KHR functions and only supports EXT
-            // functions. As such, we check if the version is equal to 1.4 and downgrade to
-            // `EglDisplay::Ext` if so.
+            // libglvnd has an unsavoury quirk of unconditionally aliasing `getPlatformDisplay`
+            // (unavailable on EGL 1.4) and `getPlatformDisplayEXT`, which may result in
+            // an `EglDisplay::Khr` being created for a platform that does not support
+            // KHR functions and only supports EXT functions. As such, we check if the
+            // version is equal to 1.4 and downgrade to `EglDisplay::Ext` if so.
             // See: https://gitlab.freedesktop.org/glvnd/libglvnd/-/blob/606f6627cf481ee6dcb32387edc010c502cdf38b/src/EGL/libegl.c#L270-358
             // https://gitlab.freedesktop.org/glvnd/libglvnd/-/blob/606f6627cf481ee6dcb32387edc010c502cdf38b/src/EGL/libegl.c#L409-461
             // https://gitlab.freedesktop.org/glvnd/libglvnd/-/blob/606f6627cf481ee6dcb32387edc010c502cdf38b/include/glvnd/libeglabi.h#L231-232

--- a/glutin/src/api/egl/display.rs
+++ b/glutin/src/api/egl/display.rs
@@ -515,6 +515,7 @@ impl Display {
             // See: https://gitlab.freedesktop.org/glvnd/libglvnd/-/blob/606f6627cf481ee6dcb32387edc010c502cdf38b/src/EGL/libegl.c#L270-358
             // https://gitlab.freedesktop.org/glvnd/libglvnd/-/blob/606f6627cf481ee6dcb32387edc010c502cdf38b/src/EGL/libegl.c#L409-461
             // https://gitlab.freedesktop.org/glvnd/libglvnd/-/blob/606f6627cf481ee6dcb32387edc010c502cdf38b/include/glvnd/libeglabi.h#L231-232
+            // https://gitlab.freedesktop.org/glvnd/libglvnd/-/issues/251
             (EglDisplay::Khr(display), Version { major: 1, minor: 4 }) => EglDisplay::Ext(display),
             // We do not do anything otherwise.
             (display, _) => display,

--- a/glutin/src/api/egl/display.rs
+++ b/glutin/src/api/egl/display.rs
@@ -486,6 +486,7 @@ impl Display {
         };
 
         // Sanitize for libglvnd's aliasing.
+        #[cfg(free_unix)]
         let display = Self::sanitize_libglvnd_aliasing(display, version);
 
         // Load extensions.
@@ -503,6 +504,7 @@ impl Display {
         Ok(Self { inner })
     }
 
+    #[cfg(free_unix)]
     fn sanitize_libglvnd_aliasing(display: EglDisplay, version: Version) -> EglDisplay {
         match (display, version) {
             // libglvnd has an unsavoury quirk of aliasing `getPlatformDisplay` and

--- a/glutin/src/api/egl/display.rs
+++ b/glutin/src/api/egl/display.rs
@@ -507,7 +507,7 @@ impl Display {
     #[cfg(free_unix)]
     fn sanitize_libglvnd_aliasing(display: EglDisplay, version: Version) -> EglDisplay {
         match (display, version) {
-            // libglvnd has an unsavoury quirk of aliasing `getPlatformDisplay` and
+            // libglvnd has an unsavoury quirk of unconditionally aliasing `getPlatformDisplay` (unavailable on EGL 1.4) and
             // `getPlatformDisplayEXT`, which may result in an `EglDisplay::Khr` being created
             // for a platform that does not support KHR functions and only supports EXT
             // functions. As such, we check if the version is equal to 1.4 and downgrade to

--- a/glutin/src/api/egl/display.rs
+++ b/glutin/src/api/egl/display.rs
@@ -510,11 +510,9 @@ impl Display {
             // for a platform that does not support KHR functions and only supports EXT
             // functions. As such, we check if the version is equal to 1.4 and downgrade to
             // `EglDisplay::Ext` if so.
-            (EglDisplay::Khr(display), Version { major: 1, minor: 4 })
-                => EglDisplay::Ext(display),
+            (EglDisplay::Khr(display), Version { major: 1, minor: 4 }) => EglDisplay::Ext(display),
             // We do not do anything otherwise.
-            (display, _)
-                => display,
+            (display, _) => display,
         }
     }
 }


### PR DESCRIPTION
**Issue addressed**: EGL's `Display::new` making a `Khr` display (those are only valid for 1.5) when EGL version for the platform is actually 1.4, which causes errors when 1.5 surface creation is attempted afterwards. Caused by `libglvnd` "aliasing" `eglGetPlatformDisplay` and `eglGetPlatformDisplayEXT` (as in both functions call the same vendor function internally), which makes the former succeed and create a display that is only valid as an `Ext` display despite what otherwise would be expected according to specification.

**Solution**: Check for the version after performing an `eglInitialize` call, as it returns the actual version for the platform's implementation of EGL and therefore enables us to detect whether the aliasing issue occurred and downgrade the display from `Khr` to `Ext` if it did.

**Changes**: The only actual change is that it is checked in `Display::initialize_display` with the `Display::sanitize_libglvnd_aliasing` function whether (a) `EglDisplay` is of variant `Khr` and (b) version is equal to 1.4, and if both conditions are true, `EglDisplay` is downgraded from `Khr` to `Ext`. This seems to be safe, as `eglGetPlatformDisplay` and `eglGetPlatformDisplayEXT` in practice are made to be aliases of each other by `libglvnd`, and if any of the attributes passed are invalid for the underlying function, it is presumed that it would return with an error.

See issue #1689 for further details.
Also see [issue #251](https://gitlab.freedesktop.org/glvnd/libglvnd/-/issues/251) on `libglvnd`'s repository.