### PR TITLE
egl/display: Pass *pointer to* output variable when querying `DEVICE_EXT`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fixed EGL's `Device::query_devices()` being too strict about required extensions
 - Fixed crash in `EglGetProcAddress` on Win32-x86 platform due to wrong calling convention
+- Fixed EGL's `Display::device()` always returning an error due to invalid pointer-argument passing inside
 
 # Version 0.32.0
 


### PR DESCRIPTION
Supersedes #1695

By casting a `null_mut()` ptr and passing it directly _by value_ to `QueryDisplayAttribEXT()`, the function ignores writing the output as it didn't receive an address (it received `NULL`) to write the device to.  Instead we should take the _pointer address of this `null_mut()` pointer_ and provide that to the function instead so that it can _overwrite_ it with a pointer to the requested `eglDevice`.

- [x] Tested on all platforms changed
  - Tested by adding `dbg!(display.device())` to `examples/egl_device.rs`.  This returns `BadParameter` before this patch, and the device afterwards.
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] (N/A) Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] (N/A) Created or updated an example program if it would help users understand this functionality
