### PR TITLE
Set up `NSView` the way Glutin requires it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed EGL's `Display::new()` making an `EGLDisplay::Khr` when the EGL version for the display is 1.4 or lower.
 - Added `Device::drm_device_node_path()` and `Device::drm_render_device_node_path()` getters to EGL via `EGL_EXT_device_drm`.
 - Added support for `DrmDisplayHandle` in EGL's `Display::with_device()` using `EGL_DRM_MASTER_FD_EXT` from `EGL_EXT_device_drm`.
+- Properly set up OpenGL-specific stuff on the `NSView`, instead of relying on Winit to do it.
 
 # Version 0.32.0
 

--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -66,10 +66,12 @@ features = [
 [target.'cfg(any(target_os = "macos"))'.dependencies.objc2-app-kit]
 version = "0.2.0"
 features = [
+    "NSApplication",
     "NSResponder",
     "NSView",
     "NSWindow",
     "NSOpenGL",
+    "NSOpenGLView",
 ]
 
 [build-dependencies]


### PR DESCRIPTION
In particular Glutin requires `wantsBestResolutionOpenGLSurface` and `wantsLayer` to be set correctly.

This is currently done by Winit:

https://github.com/rust-windowing/winit/blob/dfea49f48850670cdfe3dc91949a9f8f2e267a38/src/platform_impl/apple/appkit/window_delegate.rs#L640-L653

But it's really the job of Glutin to do this, Winit shouldn't be concerned with OpenGL-specific details. I'm going to submit a PR later to Winit to remove the code from there.

---

I decided to avoid the option to choose whether to do High DPI or not, like the `with_disallow_hidpi` flag in Winit, since I don't see why we should let the user control this? It was originally added in https://github.com/rust-windowing/winit/pull/821

I only have a device running macOS 10.14, so I can't actually test the behaviours here. But we're just mirroring what Winit is doing.
