### PR TITLE
Implement priority hints for EGL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Added `NotCurrentContext::make_current_surfaceless(self)` and
   `PossiblyCurrentContext::make_current_surfaceless(&self)` in the `Wgl`
   implementation to allow the use of surfaceless contexts with WGL.
-
+- Added `GlContext::priority`/`ContextAttributesBuilder::with_priority` to get/set context priority.
 
 # Version 0.32.1
 

--- a/glutin/src/api/cgl/context.rs
+++ b/glutin/src/api/cgl/context.rs
@@ -10,7 +10,9 @@ use objc2_app_kit::{NSOpenGLCPSwapInterval, NSView};
 use objc2_foundation::{run_on_main, MainThreadBound};
 
 use crate::config::GetGlConfig;
-use crate::context::{AsRawContext, ContextApi, ContextAttributes, RawContext, Robustness};
+use crate::context::{
+    AsRawContext, ContextApi, ContextAttributes, Priority, RawContext, Robustness,
+};
 use crate::display::GetGlDisplay;
 use crate::error::{ErrorKind, Result};
 use crate::prelude::*;
@@ -115,6 +117,10 @@ impl GlContext for NotCurrentContext {
     fn context_api(&self) -> ContextApi {
         self.inner.context_api()
     }
+
+    fn priority(&self) -> Priority {
+        Priority::Medium
+    }
 }
 
 impl GetGlConfig for NotCurrentContext {
@@ -194,6 +200,10 @@ impl PossiblyCurrentGlContext for PossiblyCurrentContext {
 impl GlContext for PossiblyCurrentContext {
     fn context_api(&self) -> ContextApi {
         self.inner.context_api()
+    }
+
+    fn priority(&self) -> Priority {
+        Priority::Medium
     }
 }
 

--- a/glutin/src/api/glx/context.rs
+++ b/glutin/src/api/glx/context.rs
@@ -10,8 +10,8 @@ use glutin_glx_sys::{glx, glx_extra};
 
 use crate::config::GetGlConfig;
 use crate::context::{
-    self, AsRawContext, ContextApi, ContextAttributes, GlProfile, RawContext, ReleaseBehavior,
-    Robustness, Version,
+    self, AsRawContext, ContextApi, ContextAttributes, GlProfile, Priority, RawContext,
+    ReleaseBehavior, Robustness, Version,
 };
 use crate::display::{DisplayFeatures, GetGlDisplay};
 use crate::error::{ErrorKind, Result};
@@ -285,6 +285,10 @@ impl GlContext for NotCurrentContext {
     fn context_api(&self) -> ContextApi {
         self.inner.context_api()
     }
+
+    fn priority(&self) -> Priority {
+        Priority::Medium
+    }
 }
 
 impl GetGlConfig for NotCurrentContext {
@@ -361,6 +365,10 @@ impl PossiblyCurrentGlContext for PossiblyCurrentContext {
 impl GlContext for PossiblyCurrentContext {
     fn context_api(&self) -> ContextApi {
         self.inner.context_api()
+    }
+
+    fn priority(&self) -> Priority {
+        Priority::Medium
     }
 }
 

--- a/glutin/src/api/wgl/context.rs
+++ b/glutin/src/api/wgl/context.rs
@@ -13,8 +13,8 @@ use windows_sys::Win32::Graphics::Gdi::{self as gdi, HDC};
 
 use crate::config::GetGlConfig;
 use crate::context::{
-    self, AsRawContext, ContextApi, ContextAttributes, GlProfile, RawContext, ReleaseBehavior,
-    Robustness, Version,
+    self, AsRawContext, ContextApi, ContextAttributes, GlProfile, Priority, RawContext,
+    ReleaseBehavior, Robustness, Version,
 };
 use crate::display::{DisplayFeatures, GetGlDisplay};
 use crate::error::{ErrorKind, Result};
@@ -272,6 +272,10 @@ impl GlContext for NotCurrentContext {
     fn context_api(&self) -> ContextApi {
         self.inner.context_api()
     }
+
+    fn priority(&self) -> Priority {
+        Priority::Medium
+    }
 }
 
 impl GetGlDisplay for NotCurrentContext {
@@ -372,6 +376,10 @@ impl GetGlConfig for PossiblyCurrentContext {
 impl GlContext for PossiblyCurrentContext {
     fn context_api(&self) -> ContextApi {
         self.inner.context_api()
+    }
+
+    fn priority(&self) -> Priority {
+        Priority::Medium
     }
 }
 

--- a/glutin/src/context.rs
+++ b/glutin/src/context.rs
@@ -34,6 +34,9 @@ pub trait GlContext: Sealed {
     ///
     /// The returned value's [`Version`] will always be `None`.
     fn context_api(&self) -> ContextApi;
+
+    /// Get the [`Priority`] used by the context.
+    fn priority(&self) -> Priority;
 }
 
 /// A trait to group common not current operations.
@@ -67,7 +70,7 @@ pub trait NotCurrentGlContext: Sealed {
     /// The same as [`Self::make_current`], but provides a way to set read and
     /// draw surfaces.
     ///
-    /// # Api-specific:
+    /// # Api specific
     ///
     /// - **WGL/CGL:** not supported.
     fn make_current_draw_read<T: SurfaceTypeTrait>(
@@ -112,7 +115,7 @@ pub trait PossiblyCurrentGlContext: Sealed {
     /// The same as [`Self::make_current`] but provides a way to set read and
     /// draw surfaces explicitly.
     ///
-    /// # Api-specific:
+    /// # Api specific
     ///
     /// - **CGL/WGL:** not supported.
     fn make_current_draw_read<T: SurfaceTypeTrait>(
@@ -190,7 +193,7 @@ impl ContextAttributesBuilder {
     ///
     /// By default the profile is unspecified.
     ///
-    /// # Api-specific
+    /// # Api specific
     ///
     /// - **macOS:** not supported, the latest is picked automatically.
     pub fn with_profile(mut self, profile: GlProfile) -> Self {
@@ -206,11 +209,29 @@ impl ContextAttributesBuilder {
         self
     }
 
+    /// Set the priority hint, which might not be honored if the API does not
+    /// support it, if there are constraints on the number of high priority
+    /// contexts available in the system, or system policy limits access to
+    /// high priority contexts to appropriate system privilege level the
+    /// context creation may fail.
+    ///
+    /// By default no priority is specified, which corresponds to
+    /// [`Priority::Medium`].
+    ///
+    /// # Api specific
+    ///
+    /// - **WGL/GLX:** not implemented.
+    /// - **CGL:** not supported.
+    pub fn with_priority(mut self, priority: Priority) -> Self {
+        self.attributes.priority = Some(priority);
+        self
+    }
+
     /// Build the context attributes.
     ///
     /// The `raw_window_handle` isn't required and here for WGL compatibility.
     ///
-    /// # Api-specific
+    /// # Api specific
     ///
     /// - **WGL:** you **must** pass a `raw_window_handle` if you plan to use
     ///   this context with that window.
@@ -232,6 +253,8 @@ pub struct ContextAttributes {
     pub(crate) profile: Option<GlProfile>,
 
     pub(crate) api: Option<ContextApi>,
+
+    pub(crate) priority: Option<Priority>,
 
     pub(crate) shared_context: Option<RawContext>,
 
@@ -338,7 +361,7 @@ pub enum ReleaseBehavior {
     /// Doesn't do anything. Most notably doesn't flush. Not supported by all
     /// drivers.
     ///
-    /// # Api-specific
+    /// # Api specific
     ///
     /// - **macOS:** not supported, [`Self::Flush`] is always used.
     None,
@@ -446,6 +469,10 @@ impl NotCurrentGlContext for NotCurrentContext {
 impl GlContext for NotCurrentContext {
     fn context_api(&self) -> ContextApi {
         gl_api_dispatch!(self; Self(context) => context.context_api())
+    }
+
+    fn priority(&self) -> Priority {
+        gl_api_dispatch!(self; Self(context) => context.priority())
     }
 }
 
@@ -571,6 +598,10 @@ impl GlContext for PossiblyCurrentContext {
     fn context_api(&self) -> ContextApi {
         gl_api_dispatch!(self; Self(context) => context.context_api())
     }
+
+    fn priority(&self) -> Priority {
+        gl_api_dispatch!(self; Self(context) => context.priority())
+    }
 }
 
 impl GetGlConfig for PossiblyCurrentContext {
@@ -615,6 +646,25 @@ pub enum RawContext {
     /// Pointer to NSOpenGLContext.
     #[cfg(cgl_backend)]
     Cgl(*const ffi::c_void),
+}
+
+/// Priority hint
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+pub enum Priority {
+    /// Lowest priority, contexts using this priority give way for most other
+    /// contexts.
+    Low,
+    /// Default priority.
+    #[default]
+    Medium,
+    /// High priority is usually required for VR applications.
+    High,
+    /// Realtime priority contexts are executed immediately and preempt any
+    /// current context running.
+    ///
+    /// When such context is not supported, [`Priority::High`] will be requested
+    /// instead.
+    Realtime,
 }
 
 /// Pick `GlProfile` and `Version` based on the provided params.

--- a/glutin_egl_sys/build.rs
+++ b/glutin_egl_sys/build.rs
@@ -35,6 +35,7 @@ fn main() {
             "EGL_EXT_platform_wayland",
             "EGL_EXT_platform_x11",
             "EGL_EXT_swap_buffers_with_damage",
+            "EGL_IMG_context_priority",
             "EGL_KHR_create_context",
             "EGL_KHR_create_context_no_error",
             "EGL_KHR_display_reference",
@@ -47,6 +48,7 @@ fn main() {
             "EGL_KHR_swap_buffers_with_damage",
             "EGL_KHR_wait_sync",
             "EGL_MESA_platform_gbm",
+            "EGL_NV_context_priority_realtime",
         ]);
 
         if target.contains("ios") {


### PR DESCRIPTION
Fixes https://github.com/rust-windowing/glutin/issues/1645
Fixes https://github.com/rust-windowing/glutin/issues/1694

This PR adds a way to specify the priority for contexts. I mostly used the term hint, as its not guaranteed for various reasons that the context actually gets the priority.

Don't know if it makes sense to guarantee the priority. In Chromium it's also only used as a hint.

I also probably should extend the extension check as it is not correctly reported on Android.
https://github.com/chromium/chromium/blob/main/ui/gl/gl_display.cc#L814

Theoretically the extension also exists for GLX but Mesa for example doesn't support it.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
