### PR TITLE
wgl: add support for pixel buffer surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added `Device::drm_device_node_path()` and `Device::drm_render_device_node_path()` getters to EGL via `EGL_EXT_device_drm`.
 - Added support for `DrmDisplayHandle` in EGL's `Display::with_device()` using `EGL_DRM_MASTER_FD_EXT` from `EGL_EXT_device_drm`.
 - Properly set up OpenGL-specific stuff on the `NSView`, instead of relying on Winit to do it.
+- Added support for `Display::create_pbuffer_surface()` in WGL via `WGL_ARB_pbuffer`.
 
 # Version 0.32.0
 

--- a/glutin/src/api/wgl/config.rs
+++ b/glutin/src/api/wgl/config.rs
@@ -237,6 +237,11 @@ impl Display {
             attrs.push(1);
         }
 
+        if template.config_surface_types.contains(ConfigSurfaceTypes::PBUFFER) {
+            attrs.push(wgl_extra::DRAW_TO_PBUFFER_ARB as c_int);
+            attrs.push(1);
+        }
+
         if template.transparency {
             attrs.push(wgl_extra::TRANSPARENT_ARB as c_int);
             attrs.push(1);

--- a/glutin/src/api/wgl/context.rs
+++ b/glutin/src/api/wgl/context.rs
@@ -22,7 +22,7 @@ use crate::prelude::*;
 use crate::private::Sealed;
 use crate::surface::SurfaceTypeTrait;
 
-use super::config::Config;
+use super::{config::Config, surface::WGLSurface};
 use super::display::Display;
 use super::surface::Surface;
 
@@ -387,7 +387,12 @@ impl ContextInner {
 
     fn make_current<T: SurfaceTypeTrait>(&self, surface: &Surface<T>) -> Result<()> {
         unsafe {
-            if wgl::MakeCurrent(surface.hdc as _, self.raw.cast()) == 0 {
+            let hdc = match surface.raw {
+                WGLSurface::Window(_, hdc) => hdc  as _,
+                WGLSurface::PBuffer(_, hdc) => hdc as _,
+            };
+
+            if wgl::MakeCurrent(hdc, self.raw.cast()) == 0 {
                 Err(IoError::last_os_error().into())
             } else {
                 Ok(())

--- a/glutin/src/api/wgl/context.rs
+++ b/glutin/src/api/wgl/context.rs
@@ -24,7 +24,7 @@ use crate::surface::SurfaceTypeTrait;
 
 use super::config::Config;
 use super::display::Display;
-use super::surface::{Surface, WglSurface};
+use super::surface::Surface;
 
 impl Display {
     pub(crate) unsafe fn create_context(
@@ -387,12 +387,7 @@ impl ContextInner {
 
     fn make_current<T: SurfaceTypeTrait>(&self, surface: &Surface<T>) -> Result<()> {
         unsafe {
-            let hdc = match surface.raw {
-                WglSurface::Window(_, hdc) => hdc as _,
-                WglSurface::PBuffer(_, hdc) => hdc as _,
-            };
-
-            if wgl::MakeCurrent(hdc, self.raw.cast()) == 0 {
+            if wgl::MakeCurrent(surface.raw.hdc() as _, self.raw.cast()) == 0 {
                 Err(IoError::last_os_error().into())
             } else {
                 Ok(())

--- a/glutin/src/api/wgl/context.rs
+++ b/glutin/src/api/wgl/context.rs
@@ -22,9 +22,9 @@ use crate::prelude::*;
 use crate::private::Sealed;
 use crate::surface::SurfaceTypeTrait;
 
-use super::{config::Config, surface::WGLSurface};
+use super::config::Config;
 use super::display::Display;
-use super::surface::Surface;
+use super::surface::{Surface, WGLSurface};
 
 impl Display {
     pub(crate) unsafe fn create_context(
@@ -388,7 +388,7 @@ impl ContextInner {
     fn make_current<T: SurfaceTypeTrait>(&self, surface: &Surface<T>) -> Result<()> {
         unsafe {
             let hdc = match surface.raw {
-                WGLSurface::Window(_, hdc) => hdc  as _,
+                WGLSurface::Window(_, hdc) => hdc as _,
                 WGLSurface::PBuffer(_, hdc) => hdc as _,
             };
 

--- a/glutin/src/api/wgl/context.rs
+++ b/glutin/src/api/wgl/context.rs
@@ -24,7 +24,7 @@ use crate::surface::SurfaceTypeTrait;
 
 use super::config::Config;
 use super::display::Display;
-use super::surface::{Surface, WGLSurface};
+use super::surface::{Surface, WglSurface};
 
 impl Display {
     pub(crate) unsafe fn create_context(
@@ -388,8 +388,8 @@ impl ContextInner {
     fn make_current<T: SurfaceTypeTrait>(&self, surface: &Surface<T>) -> Result<()> {
         unsafe {
             let hdc = match surface.raw {
-                WGLSurface::Window(_, hdc) => hdc as _,
-                WGLSurface::PBuffer(_, hdc) => hdc as _,
+                WglSurface::Window(_, hdc) => hdc as _,
+                WglSurface::PBuffer(_, hdc) => hdc as _,
             };
 
             if wgl::MakeCurrent(hdc, self.raw.cast()) == 0 {

--- a/glutin/src/api/wgl/surface.rs
+++ b/glutin/src/api/wgl/surface.rs
@@ -69,12 +69,12 @@ impl Display {
                 attrs.as_ptr(),
             )
         };
-        if hbuf == std::ptr::null() {
+        if hbuf.is_null() {
             return Err(IoError::last_os_error().into());
         }
 
         let hdc = unsafe { extra.GetPbufferDCARB(hbuf) };
-        if hdc == std::ptr::null() {
+        if hdc.is_null() {
             return Err(IoError::last_os_error().into());
         }
 

--- a/glutin/src/api/wgl/surface.rs
+++ b/glutin/src/api/wgl/surface.rs
@@ -116,7 +116,7 @@ impl Display {
     }
 }
 
-/// A Wrapper around `WGLSurface`.
+/// A Wrapper around `WglSurface`.
 pub struct Surface<T: SurfaceTypeTrait> {
     display: Display,
     config: Config,

--- a/glutin/src/api/wgl/surface.rs
+++ b/glutin/src/api/wgl/surface.rs
@@ -225,7 +225,7 @@ impl<T: SurfaceTypeTrait> GlSurface<T> for Surface<T> {
                     .inner
                     .wgl_extra
                     .filter(|_| self.display.inner.features.contains(DisplayFeatures::SWAP_CONTROL))
-                    .ok_or(ErrorKind::NotSupported("pbuffer extensions are not supported"))?;
+                    .ok_or(ErrorKind::NotSupported("swap control extensions are not supported"))?;
 
                 let interval = match interval {
                     SwapInterval::DontWait => 0,
@@ -238,7 +238,7 @@ impl<T: SurfaceTypeTrait> GlSurface<T> for Surface<T> {
                     Ok(())
                 }
             },
-            _ => Err(ErrorKind::NotSupported("swap control not support for surface").into()),
+            _ => Err(ErrorKind::NotSupported("swap control not supported for surface").into()),
         }
     }
 

--- a/glutin/src/api/wgl/surface.rs
+++ b/glutin/src/api/wgl/surface.rs
@@ -135,12 +135,11 @@ impl<T: SurfaceTypeTrait> Surface<T> {
             WglSurface::Window(..) => None,
             WglSurface::PBuffer(hbuf, _) => {
                 let extra = self.display.inner.wgl_extra.unwrap();
-
                 let mut value = 0;
-                if unsafe { extra.QueryPbufferARB(hbuf, attr as _, &mut value) } != 0 {
-                    Some(value)
-                } else {
+                if unsafe { extra.QueryPbufferARB(hbuf, attr as _, &mut value) } == false.into() {
                     None
+                } else {
+                    Some(value)
                 }
             },
         }

--- a/glutin/src/surface.rs
+++ b/glutin/src/surface.rs
@@ -519,7 +519,7 @@ pub enum RawSurface {
     #[cfg(glx_backend)]
     Glx(u64),
 
-    /// HWND
+    /// Either a `HWND` or `HPBUFFEREXT` depending on [`SurfaceType`].
     #[cfg(wgl_backend)]
     Wgl(*const std::ffi::c_void),
 

--- a/glutin_wgl_sys/build.rs
+++ b/glutin_wgl_sys/build.rs
@@ -18,12 +18,13 @@ fn main() {
         let mut file = File::create(dest.join("wgl_extra_bindings.rs")).unwrap();
         Registry::new(Api::Wgl, (1, 0), Profile::Core, Fallbacks::All, [
             "WGL_ARB_context_flush_control",
-            "WGL_ARB_create_context",
             "WGL_ARB_create_context_no_error",
             "WGL_ARB_create_context_profile",
             "WGL_ARB_create_context_robustness",
+            "WGL_ARB_create_context",
             "WGL_ARB_extensions_string",
             "WGL_ARB_framebuffer_sRGB",
+            "WGL_ARB_pbuffer",
             "WGL_ARB_multisample",
             "WGL_ARB_pixel_format",
             "WGL_ARB_pixel_format_float",


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] ~Created or updated an example program if it would help users understand this functionality~

I didn't create an example, since this is standard functionality that was previously unexposed.
