### PR TITLE
feat: add openharmony support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Added `Device::drm_device_node_path()` and `Device::drm_render_device_node_path()` getters to EGL via `EGL_EXT_device_drm`.
 - Added support for `DrmDisplayHandle` in EGL's `Display::with_device()` using `EGL_DRM_MASTER_FD_EXT` from `EGL_EXT_device_drm`.
 - Properly set up OpenGL-specific stuff on the `NSView`, instead of relying on Winit to do it.
-- Add `OpenHarmony` platform support.
+- Added `OpenHarmony` platform support with EGL.
 
 # Version 0.32.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added `Device::drm_device_node_path()` and `Device::drm_render_device_node_path()` getters to EGL via `EGL_EXT_device_drm`.
 - Added support for `DrmDisplayHandle` in EGL's `Display::with_device()` using `EGL_DRM_MASTER_FD_EXT` from `EGL_EXT_device_drm`.
 - Properly set up OpenGL-specific stuff on the `NSView`, instead of relying on Winit to do it.
+- Add `OpenHarmony` platform support.
 
 # Version 0.32.0
 

--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -23,7 +23,7 @@ wayland = ["wayland-sys", "egl"]
 bitflags = "2.2.1"
 libloading = { version = "0.8.0", optional = true }
 once_cell = "1.13"
-raw-window-handle = "0.6"
+raw-window-handle = "0.6.2"
 
 [target.'cfg(windows)'.dependencies]
 glutin_egl_sys = { version = "0.7.0", path = "../glutin_egl_sys", optional = true }

--- a/glutin/build.rs
+++ b/glutin/build.rs
@@ -5,11 +5,12 @@ fn main() {
     cfg_aliases! {
         // Systems.
         android_platform: { target_os = "android" },
+        ohos_platform: { target_env = "ohos" },
         wasm_platform: { target_family = "wasm" },
         macos_platform: { target_os = "macos" },
         ios_platform: { target_os = "ios" },
         apple: { any(ios_platform, macos_platform) },
-        free_unix: { all(unix, not(apple), not(android_platform)) },
+        free_unix: { all(unix, not(apple), not(android_platform), not(ohos_platform)) },
 
         // Native displays.
         x11_platform: { all(feature = "x11", free_unix, not(wasm_platform)) },

--- a/glutin/src/api/egl/display.rs
+++ b/glutin/src/api/egl/display.rs
@@ -441,7 +441,7 @@ impl Display {
             RawDisplayHandle::Xlib(XlibDisplayHandle { display, .. }) => {
                 display.map_or(egl::DEFAULT_DISPLAY as *mut _, |d| d.as_ptr())
             },
-            RawDisplayHandle::Android(_) => egl::DEFAULT_DISPLAY as *mut _,
+            RawDisplayHandle::Android(_) | RawDisplayHandle::Ohos(_) => egl::DEFAULT_DISPLAY as *mut _,
             _ => {
                 return Err(
                     ErrorKind::NotSupported("provided display handle is not supported").into()

--- a/glutin/src/api/egl/display.rs
+++ b/glutin/src/api/egl/display.rs
@@ -441,7 +441,9 @@ impl Display {
             RawDisplayHandle::Xlib(XlibDisplayHandle { display, .. }) => {
                 display.map_or(egl::DEFAULT_DISPLAY as *mut _, |d| d.as_ptr())
             },
-            RawDisplayHandle::Android(_) | RawDisplayHandle::Ohos(_) => egl::DEFAULT_DISPLAY as *mut _,
+            RawDisplayHandle::Android(_) | RawDisplayHandle::Ohos(_) => {
+                egl::DEFAULT_DISPLAY as *mut _
+            },
             _ => {
                 return Err(
                     ErrorKind::NotSupported("provided display handle is not supported").into()

--- a/glutin/src/api/egl/surface.rs
+++ b/glutin/src/api/egl/surface.rs
@@ -456,6 +456,9 @@ enum NativeWindow {
     #[cfg(android_platform)]
     Android(*mut ffi::c_void),
 
+    #[cfg(ohos_platform)]
+    Ohos(*mut ffi::c_void),
+
     #[cfg(windows)]
     Win32(isize),
 
@@ -497,6 +500,10 @@ impl NativeWindow {
             #[cfg(android_platform)]
             RawWindowHandle::AndroidNdk(window_handle) => {
                 Self::Android(window_handle.a_native_window.as_ptr())
+            },
+            #[cfg(ohos_platform)]
+            RawWindowHandle::OhosNdk(window_handle) => {
+                Self::Ohos(window_handle.native_window.as_ptr())
             },
             #[cfg(windows)]
             RawWindowHandle::Win32(window_handle) => Self::Win32(window_handle.hwnd.get() as _),
@@ -542,6 +549,8 @@ impl NativeWindow {
             Self::Win32(hwnd) => hwnd,
             #[cfg(android_platform)]
             Self::Android(a_native_window) => a_native_window,
+            #[cfg(ohos_platform)]
+            Self::Ohos(native_window) => native_window,
             #[cfg(free_unix)]
             Self::Gbm(gbm_surface) => gbm_surface,
         }
@@ -573,6 +582,8 @@ impl NativeWindow {
             Self::Win32(hwnd) => *hwnd as *const ffi::c_void as *mut _,
             #[cfg(android_platform)]
             Self::Android(a_native_window) => *a_native_window,
+            #[cfg(ohos_platform)]
+            Self::Ohos(native_window) => *native_window,
             #[cfg(free_unix)]
             Self::Gbm(gbm_surface) => *gbm_surface,
         }


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality

Add openharmony platform support, now we can build it successfully with [XComponent](https://developer.huawei.com/consumer/en/doc/harmonyos-guides-V5/napi-xcomponent-guidelines-V5). It doesn't effect any other code, so i think i needn't to add more docs or tests.

And you can find a full example with [example](https://github.com/ohos-rs/ohos-native-bindings/tree/master/examples/xcomponent). If you want more info, please let me know, thanks !