### PR TITLE
Add PossiblyCurrentContext::make_not_current_as_possibly_current

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Add `PossiblyCurrentContext::make_not_current_in_place(&self)` for when `Send` capability of `NotCurrentContext` is not required.
+
 # Version 0.32.1
 
 - Fixed EGL's `Device::query_devices()` being too strict about required extensions.

--- a/glutin/src/api/cgl/context.rs
+++ b/glutin/src/api/cgl/context.rs
@@ -148,8 +148,12 @@ impl PossiblyCurrentGlContext for PossiblyCurrentContext {
     type Surface<T: SurfaceTypeTrait> = Surface<T>;
 
     fn make_not_current(self) -> Result<Self::NotCurrentContext> {
-        self.inner.make_not_current()?;
+        self.make_not_current_in_place()?;
         Ok(NotCurrentContext::new(self.inner))
+    }
+
+    fn make_not_current_in_place(&self) -> Result<()> {
+        self.inner.make_not_current()
     }
 
     fn is_current(&self) -> bool {

--- a/glutin/src/api/egl/context.rs
+++ b/glutin/src/api/egl/context.rs
@@ -259,8 +259,12 @@ impl PossiblyCurrentGlContext for PossiblyCurrentContext {
     type Surface<T: SurfaceTypeTrait> = Surface<T>;
 
     fn make_not_current(self) -> Result<Self::NotCurrentContext> {
-        self.inner.make_not_current()?;
+        self.make_not_current_in_place()?;
         Ok(NotCurrentContext::new(self.inner))
+    }
+
+    fn make_not_current_in_place(&self) -> Result<()> {
+        self.inner.make_not_current()
     }
 
     fn is_current(&self) -> bool {

--- a/glutin/src/api/glx/context.rs
+++ b/glutin/src/api/glx/context.rs
@@ -302,8 +302,12 @@ impl PossiblyCurrentGlContext for PossiblyCurrentContext {
     type Surface<T: SurfaceTypeTrait> = Surface<T>;
 
     fn make_not_current(self) -> Result<Self::NotCurrentContext> {
-        self.inner.make_not_current()?;
+        self.make_not_current_in_place()?;
         Ok(NotCurrentContext::new(self.inner))
+    }
+
+    fn make_not_current_in_place(&self) -> Result<()> {
+        self.inner.make_not_current()
     }
 
     fn is_current(&self) -> bool {

--- a/glutin/src/api/wgl/context.rs
+++ b/glutin/src/api/wgl/context.rs
@@ -288,6 +288,11 @@ impl PossiblyCurrentGlContext for PossiblyCurrentContext {
     type Surface<T: SurfaceTypeTrait> = Surface<T>;
 
     fn make_not_current(self) -> Result<Self::NotCurrentContext> {
+        self.make_not_current_in_place()?;
+        Ok(NotCurrentContext::new(self.inner))
+    }
+
+    fn make_not_current_in_place(&self) -> Result<()> {
         unsafe {
             if self.is_current() {
                 let hdc = wgl::GetCurrentDC();
@@ -295,9 +300,8 @@ impl PossiblyCurrentGlContext for PossiblyCurrentContext {
                     return Err(IoError::last_os_error().into());
                 }
             }
-
-            Ok(NotCurrentContext::new(self.inner))
         }
+        Ok(())
     }
 
     fn is_current(&self) -> bool {

--- a/glutin/src/context.rs
+++ b/glutin/src/context.rs
@@ -97,6 +97,11 @@ pub trait PossiblyCurrentGlContext: Sealed {
     /// - **macOS: this will block if your main thread is blocked.**
     fn make_not_current(self) -> Result<Self::NotCurrentContext>;
 
+    /// Make the context not current to the current thread. If you need to
+    /// send the context toanother thread, use [`Self::make_not_current`]
+    /// instead.
+    fn make_not_current_in_place(&self) -> Result<()>;
+
     /// Make [`Self::Surface`] current on the calling thread.
     ///
     /// # Platform specific
@@ -515,6 +520,10 @@ impl PossiblyCurrentGlContext for PossiblyCurrentContext {
         Ok(
             gl_api_dispatch!(self; Self(context) => context.make_not_current()?; as NotCurrentContext),
         )
+    }
+
+    fn make_not_current_in_place(&self) -> Result<()> {
+        Ok(gl_api_dispatch!(self; Self(context) => context.make_not_current_in_place()?))
     }
 
     fn make_current<T: SurfaceTypeTrait>(&self, surface: &Self::Surface<T>) -> Result<()> {

--- a/glutin/src/context.rs
+++ b/glutin/src/context.rs
@@ -98,7 +98,7 @@ pub trait PossiblyCurrentGlContext: Sealed {
     fn make_not_current(self) -> Result<Self::NotCurrentContext>;
 
     /// Make the context not current to the current thread. If you need to
-    /// send the context toanother thread, use [`Self::make_not_current`]
+    /// send the context to another thread, use [`Self::make_not_current`]
     /// instead.
     fn make_not_current_in_place(&self) -> Result<()>;
 


### PR DESCRIPTION
Fixes #1704 

Allow making the context not current by reference.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
