### PR TITLE
Add MacOS (Cgl) make_current_surfaceless() implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Add `PossiblyCurrentContext::make_not_current_in_place(&self)` for when `Send` capability of `NotCurrentContext` is not required.
+- Add `NotCurrentContext::make_current_surfaceless(self)` and `PossiblyCurrentContext::make_current_surfaceless(&self)` in the `Cgl` implementation to allow the use of surfaceless contexts on MacOS.
 
 # Version 0.32.1
 

--- a/glutin/src/api/cgl/context.rs
+++ b/glutin/src/api/cgl/context.rs
@@ -255,6 +255,10 @@ impl ContextInner {
             self.update();
             self.raw.makeCurrentContext();
 
+            run_on_main(|_mtm| unsafe {
+                self.raw.setView(None);
+            });
+
             Ok(())
         })
     }

--- a/glutin/src/api/cgl/context.rs
+++ b/glutin/src/api/cgl/context.rs
@@ -74,6 +74,13 @@ pub struct NotCurrentContext {
 }
 
 impl NotCurrentContext {
+    /// Make a [`Self::PossiblyCurrentContext`] indicating that the context
+    /// could be current on the thread.
+    pub fn make_current_surfaceless(self) -> Result<PossiblyCurrentContext> {
+        self.inner.make_current_surfaceless()?;
+        Ok(PossiblyCurrentContext { inner: self.inner, _nosendsync: PhantomData })
+    }
+
     fn new(inner: ContextInner) -> Self {
         Self { inner, _nosync: PhantomData }
     }
@@ -141,6 +148,13 @@ pub struct PossiblyCurrentContext {
     pub(crate) inner: ContextInner,
     // The context could be current only on the one thread.
     _nosendsync: PhantomData<*mut ()>,
+}
+
+impl PossiblyCurrentContext {
+    /// Make this context current on the calling thread.
+    pub fn make_current_surfaceless(&self) -> Result<()> {
+        self.inner.make_current_surfaceless()
+    }
 }
 
 impl PossiblyCurrentGlContext for PossiblyCurrentContext {
@@ -231,6 +245,15 @@ impl ContextInner {
             run_on_main(|mtm| unsafe {
                 self.raw.setView(Some(view.get(mtm)));
             });
+
+            Ok(())
+        })
+    }
+
+    fn make_current_surfaceless(&self) -> Result<()> {
+        autoreleasepool(|_| {
+            self.update();
+            self.raw.makeCurrentContext();
 
             Ok(())
         })


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality

I have tested this on a complex OpenGL application which uses multiple "surfaceless" contexts on many threads while sharing textures and having those textures displayed on the `main` thread with a windowed OpenGL context, and everything appears to function correctly.
