### PR TITLE
glx: Support making a context current without surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add `PossiblyCurrentContext::make_not_current_in_place(&self)` for when `Send` capability of `NotCurrentContext` is not required.
 - Add `NotCurrentContext::make_current_surfaceless(self)` and `PossiblyCurrentContext::make_current_surfaceless(&self)` in the `Cgl` implementation to allow the use of surfaceless contexts on MacOS.
+- Add `NotCurrentContext::make_current_surfaceless(self)` and `PossiblyCurrentContext::make_current_surfaceless(&self)` in the `Glx` implementation to allow the use of surfaceless contexts with GLX.
 
 # Version 0.32.1
 


### PR DESCRIPTION
This mirrors the EGL behavior and follows in footsteps of #1710.

This change should be valid according to https://registry.khronos.org/OpenGL/extensions/ARB/GLX_ARB_create_context.txt (emphasis mine)
> "If either `<draw>` or `<read>` are not a valid GLX drawable, a
    GLXBadDrawable error is generated, unless **`draw` and `read` are both
    None** and the OpenGL version supported by `<ctx>` is 3.0 or greater. In
    this case the context is made current without a default framebuffer,
    as defined in chapter 4 of the OpenGL 3.0 Specification."



- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
