### PR TITLE
wgl: add `make_current_surfaceless`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Unreleased
 
-- Add `PossiblyCurrentContext::make_not_current_in_place(&self)` for when `Send` capability of `NotCurrentContext` is not required.
-- Add `NotCurrentContext::make_current_surfaceless(self)` and `PossiblyCurrentContext::make_current_surfaceless(&self)` in the `Cgl` implementation to allow the use of surfaceless contexts on MacOS.
-- Add `NotCurrentContext::make_current_surfaceless(self)` and `PossiblyCurrentContext::make_current_surfaceless(&self)` in the `Glx` implementation to allow the use of surfaceless contexts with GLX.
+- Added `PossiblyCurrentContext::make_not_current_in_place(&self)` for when `Send` capability of `NotCurrentContext` is not required.
+- Added `NotCurrentContext::make_current_surfaceless(self)` and
+  `PossiblyCurrentContext::make_current_surfaceless(&self)` in the `Cgl`
+  implementation to allow the use of surfaceless contexts on MacOS.
+- Added `NotCurrentContext::make_current_surfaceless(self)` and
+  `PossiblyCurrentContext::make_current_surfaceless(&self)` in the `Glx`
+  implementation to allow the use of surfaceless contexts with GLX.
+- Added `NotCurrentContext::make_current_surfaceless(self)` and
+  `PossiblyCurrentContext::make_current_surfaceless(&self)` in the `Wgl`
+  implementation to allow the use of surfaceless contexts with WGL.
+
 
 # Version 0.32.1
 


### PR DESCRIPTION
This follows the EGL api to make surfaceless platforms.

--

I haven't tested in on windows, but it's the exact same thing as with glx.
