### PR TITLE
api: unify surfaceless APIs on context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,8 @@
 # Unreleased
 
 - Added `PossiblyCurrentContext::make_not_current_in_place(&self)` for when `Send` capability of `NotCurrentContext` is not required.
-- Added `NotCurrentContext::make_current_surfaceless(self)` and
-  `PossiblyCurrentContext::make_current_surfaceless(&self)` in the `Cgl`
-  implementation to allow the use of surfaceless contexts on MacOS.
-- Added `NotCurrentContext::make_current_surfaceless(self)` and
-  `PossiblyCurrentContext::make_current_surfaceless(&self)` in the `Glx`
-  implementation to allow the use of surfaceless contexts with GLX.
-- Added `NotCurrentContext::make_current_surfaceless(self)` and
-  `PossiblyCurrentContext::make_current_surfaceless(&self)` in the `Wgl`
-  implementation to allow the use of surfaceless contexts with WGL.
 - Added workaround for EGL drivers reporting `EGL_KHR_platform_gbm` without EGL 1.5 client.
-
+- **Breaking:** Added `make_current_surfaceless(self)` for `{Possibly,Not}CurrentGlContext`.
 
 # Version 0.32.1
 

--- a/glutin/src/api/cgl/context.rs
+++ b/glutin/src/api/cgl/context.rs
@@ -74,13 +74,6 @@ pub struct NotCurrentContext {
 }
 
 impl NotCurrentContext {
-    /// Make a [`Self::PossiblyCurrentContext`] indicating that the context
-    /// could be current on the thread.
-    pub fn make_current_surfaceless(self) -> Result<PossiblyCurrentContext> {
-        self.inner.make_current_surfaceless()?;
-        Ok(PossiblyCurrentContext { inner: self.inner, _nosendsync: PhantomData })
-    }
-
     fn new(inner: ContextInner) -> Self {
         Self { inner, _nosync: PhantomData }
     }
@@ -108,6 +101,11 @@ impl NotCurrentGlContext for NotCurrentContext {
         surface_read: &Self::Surface<T>,
     ) -> Result<Self::PossiblyCurrentContext> {
         Err(self.inner.make_current_draw_read(surface_draw, surface_read).into())
+    }
+
+    fn make_current_surfaceless(self) -> Result<PossiblyCurrentContext> {
+        self.inner.make_current_surfaceless()?;
+        Ok(PossiblyCurrentContext { inner: self.inner, _nosendsync: PhantomData })
     }
 }
 
@@ -150,13 +148,6 @@ pub struct PossiblyCurrentContext {
     _nosendsync: PhantomData<*mut ()>,
 }
 
-impl PossiblyCurrentContext {
-    /// Make this context current on the calling thread.
-    pub fn make_current_surfaceless(&self) -> Result<()> {
-        self.inner.make_current_surfaceless()
-    }
-}
-
 impl PossiblyCurrentGlContext for PossiblyCurrentContext {
     type NotCurrentContext = NotCurrentContext;
     type Surface<T: SurfaceTypeTrait> = Surface<T>;
@@ -188,6 +179,10 @@ impl PossiblyCurrentGlContext for PossiblyCurrentContext {
         surface_read: &Self::Surface<T>,
     ) -> Result<()> {
         Err(self.inner.make_current_draw_read(surface_draw, surface_read).into())
+    }
+
+    fn make_current_surfaceless(&self) -> Result<()> {
+        self.inner.make_current_surfaceless()
     }
 }
 

--- a/glutin/src/api/egl/context.rs
+++ b/glutin/src/api/egl/context.rs
@@ -172,13 +172,6 @@ pub struct NotCurrentContext {
 }
 
 impl NotCurrentContext {
-    /// Make a [`Self::PossiblyCurrentContext`] indicating that the context
-    /// could be current on the thread.
-    pub fn make_current_surfaceless(self) -> Result<PossiblyCurrentContext> {
-        self.inner.make_current_surfaceless()?;
-        Ok(PossiblyCurrentContext { inner: self.inner, _nosendsync: PhantomData })
-    }
-
     fn new(inner: ContextInner) -> Self {
         Self { inner }
     }
@@ -206,6 +199,11 @@ impl NotCurrentGlContext for NotCurrentContext {
         surface_read: &Surface<T>,
     ) -> Result<PossiblyCurrentContext> {
         self.inner.make_current_draw_read(surface_draw, surface_read)?;
+        Ok(PossiblyCurrentContext { inner: self.inner, _nosendsync: PhantomData })
+    }
+
+    fn make_current_surfaceless(self) -> Result<PossiblyCurrentContext> {
+        self.inner.make_current_surfaceless()?;
         Ok(PossiblyCurrentContext { inner: self.inner, _nosendsync: PhantomData })
     }
 }
@@ -247,13 +245,6 @@ pub struct PossiblyCurrentContext {
     _nosendsync: PhantomData<EGLContext>,
 }
 
-impl PossiblyCurrentContext {
-    /// Make this context current on the calling thread.
-    pub fn make_current_surfaceless(&self) -> Result<()> {
-        self.inner.make_current_surfaceless()
-    }
-}
-
 impl PossiblyCurrentGlContext for PossiblyCurrentContext {
     type NotCurrentContext = NotCurrentContext;
     type Surface<T: SurfaceTypeTrait> = Surface<T>;
@@ -284,6 +275,10 @@ impl PossiblyCurrentGlContext for PossiblyCurrentContext {
         surface_read: &Self::Surface<T>,
     ) -> Result<()> {
         self.inner.make_current_draw_read(surface_draw, surface_read)
+    }
+
+    fn make_current_surfaceless(&self) -> Result<()> {
+        self.inner.make_current_surfaceless()
     }
 }
 

--- a/glutin/src/api/glx/context.rs
+++ b/glutin/src/api/glx/context.rs
@@ -241,15 +241,6 @@ pub struct NotCurrentContext {
 }
 
 impl NotCurrentContext {
-    /// Make a [`Self::PossiblyCurrentContext`] indicating that the context
-    /// could be current on the thread.
-    ///
-    /// Requires the GLX_ARB_create_context extension and OpenGL 3.0 or greater.
-    pub fn make_current_surfaceless(self) -> Result<PossiblyCurrentContext> {
-        self.inner.make_current_surfaceless()?;
-        Ok(PossiblyCurrentContext { inner: self.inner, _nosendsync: PhantomData })
-    }
-
     fn new(inner: ContextInner) -> Self {
         Self { inner }
     }
@@ -277,6 +268,11 @@ impl NotCurrentGlContext for NotCurrentContext {
         surface_read: &Self::Surface<T>,
     ) -> Result<Self::PossiblyCurrentContext> {
         self.inner.make_current_draw_read(surface_draw, surface_read)?;
+        Ok(PossiblyCurrentContext { inner: self.inner, _nosendsync: PhantomData })
+    }
+
+    fn make_current_surfaceless(self) -> Result<PossiblyCurrentContext> {
+        self.inner.make_current_surfaceless()?;
         Ok(PossiblyCurrentContext { inner: self.inner, _nosendsync: PhantomData })
     }
 }
@@ -319,15 +315,6 @@ pub struct PossiblyCurrentContext {
     _nosendsync: PhantomData<GLXContext>,
 }
 
-impl PossiblyCurrentContext {
-    /// Make this context current on the calling thread.
-    ///
-    /// Requires the GLX_ARB_create_context extension and OpenGL 3.0 or greater.
-    pub fn make_current_surfaceless(&self) -> Result<()> {
-        self.inner.make_current_surfaceless()
-    }
-}
-
 impl PossiblyCurrentGlContext for PossiblyCurrentContext {
     type NotCurrentContext = NotCurrentContext;
     type Surface<T: SurfaceTypeTrait> = Surface<T>;
@@ -355,6 +342,10 @@ impl PossiblyCurrentGlContext for PossiblyCurrentContext {
         surface_read: &Self::Surface<T>,
     ) -> Result<()> {
         self.inner.make_current_draw_read(surface_draw, surface_read)
+    }
+
+    fn make_current_surfaceless(&self) -> Result<()> {
+        self.inner.make_current_surfaceless()
     }
 }
 

--- a/glutin/src/api/wgl/context.rs
+++ b/glutin/src/api/wgl/context.rs
@@ -232,15 +232,6 @@ impl NotCurrentContext {
     fn new(inner: ContextInner) -> Self {
         Self { inner }
     }
-
-    /// Make a [`Self::PossiblyCurrentContext`] indicating that the context
-    /// could be current on the thread.
-    ///
-    /// Requires the WGL_ARB_create_context extension and OpenGL 3.0 or greater.
-    pub fn make_current_surfaceless(self) -> Result<PossiblyCurrentContext> {
-        self.inner.make_current_surfaceless()?;
-        Ok(PossiblyCurrentContext { inner: self.inner, _nosendsync: PhantomData })
-    }
 }
 
 impl NotCurrentGlContext for NotCurrentContext {
@@ -265,6 +256,11 @@ impl NotCurrentGlContext for NotCurrentContext {
         surface_read: &Self::Surface<T>,
     ) -> Result<Self::PossiblyCurrentContext> {
         Err(self.inner.make_current_draw_read(surface_draw, surface_read).into())
+    }
+
+    fn make_current_surfaceless(self) -> Result<PossiblyCurrentContext> {
+        self.inner.make_current_surfaceless()?;
+        Ok(PossiblyCurrentContext { inner: self.inner, _nosendsync: PhantomData })
     }
 }
 
@@ -304,15 +300,6 @@ pub struct PossiblyCurrentContext {
     _nosendsync: PhantomData<HGLRC>,
 }
 
-impl PossiblyCurrentContext {
-    /// Make this context current on the calling thread.
-    ///
-    /// Requires the WGL_ARB_create_context extension and OpenGL 3.0 or greater.
-    pub fn make_current_surfaceless(&self) -> Result<()> {
-        self.inner.make_current_surfaceless()
-    }
-}
-
 impl PossiblyCurrentGlContext for PossiblyCurrentContext {
     type NotCurrentContext = NotCurrentContext;
     type Surface<T: SurfaceTypeTrait> = Surface<T>;
@@ -348,6 +335,10 @@ impl PossiblyCurrentGlContext for PossiblyCurrentContext {
         surface_read: &Self::Surface<T>,
     ) -> Result<()> {
         Err(self.inner.make_current_draw_read(surface_draw, surface_read).into())
+    }
+
+    fn make_current_surfaceless(&self) -> Result<()> {
+        self.inner.make_current_surfaceless()
     }
 }
 

--- a/glutin/src/context.rs
+++ b/glutin/src/context.rs
@@ -97,7 +97,7 @@ pub trait PossiblyCurrentGlContext: Sealed {
     /// Returns `true` if this context is the current one in this thread.
     fn is_current(&self) -> bool;
 
-    /// Make the context not current to the current thread and change its type
+    /// Make the context not current on the calling thread and change its type
     /// to [`Self::NotCurrentContext`].
     ///
     /// # Platform specific

--- a/glutin/src/context.rs
+++ b/glutin/src/context.rs
@@ -49,9 +49,9 @@ pub trait NotCurrentGlContext: Sealed {
     /// guaranteed to be current.
     fn treat_as_possibly_current(self) -> Self::PossiblyCurrentContext;
 
-    /// Make [`Self::Surface`] current on the calling thread producing the
-    /// [`Self::PossiblyCurrentContext`] indicating that the context could
-    /// be current on the calling thread.
+    /// Make context current on the calling thread producing the
+    /// [`Self::PossiblyCurrentContext`]. The `surface` is used as a target for
+    /// default framebuffer.
     ///
     /// # Platform specific
     ///
@@ -64,8 +64,8 @@ pub trait NotCurrentGlContext: Sealed {
         surface: &Self::Surface<T>,
     ) -> Result<Self::PossiblyCurrentContext>;
 
-    /// The same as [`Self::make_current`], but provides a way to set read and
-    /// draw surfaces.
+    /// The same as [`Self::make_current`], but provides a way to set draw and
+    /// read surfaces.
     ///
     /// # Api specific
     ///
@@ -77,13 +77,12 @@ pub trait NotCurrentGlContext: Sealed {
     ) -> Result<Self::PossiblyCurrentContext>;
 
     /// Make context current on the calling thread without a default
-    /// framebuffer producing the [`Self::PossiblyCurrentContext`] indicating
-    /// that the context could be current on the calling thread.
+    /// framebuffer producing the [`Self::PossiblyCurrentContext`].
     ///
     /// # Api specific
     ///
     /// - **WGL/GLX:** requires OpenGL 3.0 or greater context and
-    ///   ARB_create_context extensions.
+    ///   `ARB_create_context` extensions.
     fn make_current_surfaceless(self) -> Result<Self::PossiblyCurrentContext>;
 }
 
@@ -99,28 +98,28 @@ pub trait PossiblyCurrentGlContext: Sealed {
     fn is_current(&self) -> bool;
 
     /// Make the context not current to the current thread and returns a
-    /// [`Self::NotCurrentContext`] to indicate that the context is a not
-    /// current to allow sending it to the different thread.
+    /// [`Self::NotCurrentContext`].
     ///
     /// # Platform specific
     ///
     /// - **macOS: this will block if your main thread is blocked.**
     fn make_not_current(self) -> Result<Self::NotCurrentContext>;
 
-    /// Make the context not current to the current thread. If you need to
+    /// Make the context not current on the current thread. If you need to
     /// send the context to another thread, use [`Self::make_not_current`]
     /// instead.
     fn make_not_current_in_place(&self) -> Result<()>;
 
-    /// Make [`Self::Surface`] current on the calling thread.
+    /// Make context current on the calling. The `surface` is used as a target
+    /// for default framebuffer.
     ///
     /// # Platform specific
     ///
     /// - **macOS: this will block if your main thread is blocked.**
     fn make_current<T: SurfaceTypeTrait>(&self, surface: &Self::Surface<T>) -> Result<()>;
 
-    /// The same as [`Self::make_current`], but provides a way to set read and
-    /// draw surfaces explicitly.
+    /// The same as [`Self::make_current`], but provides a way to set draw and
+    /// read surfaces explicitly.
     ///
     /// # Api specific
     ///
@@ -137,7 +136,7 @@ pub trait PossiblyCurrentGlContext: Sealed {
     /// # Api specific
     ///
     /// - **WGL/GLX:** requires OpenGL 3.0 or greater context and
-    ///   ARB_create_context extensions.
+    ///   `ARB_create_context` extensions.
     fn make_current_surfaceless(&self) -> Result<()>;
 }
 
@@ -552,7 +551,7 @@ impl PossiblyCurrentGlContext for PossiblyCurrentContext {
     }
 
     fn make_not_current_in_place(&self) -> Result<()> {
-        Ok(gl_api_dispatch!(self; Self(context) => context.make_not_current_in_place()?))
+        gl_api_dispatch!(self; Self(context) => context.make_not_current_in_place())
     }
 
     fn make_current<T: SurfaceTypeTrait>(&self, surface: &Self::Surface<T>) -> Result<()> {

--- a/glutin/src/context.rs
+++ b/glutin/src/context.rs
@@ -49,9 +49,9 @@ pub trait NotCurrentGlContext: Sealed {
     /// guaranteed to be current.
     fn treat_as_possibly_current(self) -> Self::PossiblyCurrentContext;
 
-    /// Make context current on the calling thread producing the
+    /// Make context current on the calling thread and change its type to
     /// [`Self::PossiblyCurrentContext`]. The `surface` is used as a target for
-    /// default framebuffer.
+    /// the default framebuffer.
     ///
     /// # Platform specific
     ///
@@ -77,7 +77,7 @@ pub trait NotCurrentGlContext: Sealed {
     ) -> Result<Self::PossiblyCurrentContext>;
 
     /// Make context current on the calling thread without a default
-    /// framebuffer producing the [`Self::PossiblyCurrentContext`].
+    /// framebuffer and change its type to [`Self::PossiblyCurrentContext`].
     ///
     /// # Api specific
     ///
@@ -97,21 +97,21 @@ pub trait PossiblyCurrentGlContext: Sealed {
     /// Returns `true` if this context is the current one in this thread.
     fn is_current(&self) -> bool;
 
-    /// Make the context not current to the current thread and returns a
-    /// [`Self::NotCurrentContext`].
+    /// Make the context not current to the current thread and change its type
+    /// to [`Self::NotCurrentContext`].
     ///
     /// # Platform specific
     ///
     /// - **macOS: this will block if your main thread is blocked.**
     fn make_not_current(self) -> Result<Self::NotCurrentContext>;
 
-    /// Make the context not current on the current thread. If you need to
+    /// Make the context not current on the calling thread. If you need to
     /// send the context to another thread, use [`Self::make_not_current`]
     /// instead.
     fn make_not_current_in_place(&self) -> Result<()>;
 
-    /// Make context current on the calling. The `surface` is used as a target
-    /// for default framebuffer.
+    /// Make context current on the calling thread. The `surface` is used as a
+    /// target for the default framebuffer.
     ///
     /// # Platform specific
     ///


### PR DESCRIPTION
The API was implemented by all backend, this patch simply promotes it to the top-level trait.