### PR TITLE
egl/display: workaround gbm platforms on EGL 1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Added `NotCurrentContext::make_current_surfaceless(self)` and
   `PossiblyCurrentContext::make_current_surfaceless(&self)` in the `Wgl`
   implementation to allow the use of surfaceless contexts with WGL.
-- Added workaround for EGL drivers reporting `EGL_KHR_platform_gbm` with EGL 1.4.
+- Added workaround for EGL drivers reporting `EGL_KHR_platform_gbm` without EGL 1.5 client.
 
 
 # Version 0.32.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Added `NotCurrentContext::make_current_surfaceless(self)` and
   `PossiblyCurrentContext::make_current_surfaceless(&self)` in the `Wgl`
   implementation to allow the use of surfaceless contexts with WGL.
-- Added workaround for EGL drivers reporting KHR_platform_gbm with EGL 1.4.
+- Added workaround for EGL drivers reporting `EGL_KHR_platform_gbm` with EGL 1.4.
 
 
 # Version 0.32.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added `NotCurrentContext::make_current_surfaceless(self)` and
   `PossiblyCurrentContext::make_current_surfaceless(&self)` in the `Wgl`
   implementation to allow the use of surfaceless contexts with WGL.
+- Added workaround for EGL drivers reporting KHR_platform_gbm with EGL 1.4.
 
 
 # Version 0.32.1

--- a/glutin/src/api/egl/display.rs
+++ b/glutin/src/api/egl/display.rs
@@ -363,8 +363,8 @@ impl Display {
                 )
             },
             RawDisplayHandle::Gbm(handle)
-                // NOTE: Some drivers report that they support KHR extension with 1.4 EGL display, so
-                // workaround here by checking the KHR gbm display as well. The MESA and KHR has
+                // NOTE: Some drivers report that they support the KHR GBM extension without EGL 1.5 client, so
+                // work around that here by checking the KHR GBM extension as well. The MESA and KHR extensions have
                 // the same constant values, thus it'll work regardless.
                 //
                 // They do require EXT during the runtime as well, so we don't change the display

--- a/glutin/src/api/egl/display.rs
+++ b/glutin/src/api/egl/display.rs
@@ -362,7 +362,18 @@ impl Display {
                     handle.connection.map_or(egl::DEFAULT_DISPLAY as *mut _, |c| c.as_ptr()),
                 )
             },
-            RawDisplayHandle::Gbm(handle) if extensions.contains("EGL_MESA_platform_gbm") => {
+            RawDisplayHandle::Gbm(handle)
+                // NOTE: Some drivers report that they support KHR extension with 1.4 EGL display, so
+                // workaround here by checking the KHR gbm display as well. The MESA and KHR has
+                // the same constant values, thus it'll work regardless.
+                //
+                // They do require EXT during the runtime as well, so we don't change the display
+                // to Khr here.
+                //
+                // See https://github.com/rust-windowing/glutin/issues/1708.
+                if extensions.contains("EGL_MESA_platform_gbm")
+                    || extensions.contains("EGL_KHR_platform_gbm") =>
+            {
                 (egl::PLATFORM_GBM_MESA, handle.gbm_device.as_ptr())
             },
             RawDisplayHandle::Drm(_) => {

--- a/glutin/src/api/egl/display.rs
+++ b/glutin/src/api/egl/display.rs
@@ -363,12 +363,10 @@ impl Display {
                 )
             },
             RawDisplayHandle::Gbm(handle)
-                // NOTE: Some drivers report that they support the KHR GBM extension without EGL 1.5 client, so
-                // work around that here by checking the KHR GBM extension as well. The MESA and KHR extensions have
-                // the same constant values, thus it'll work regardless.
-                //
-                // They do require EXT during the runtime as well, so we don't change the display
-                // to Khr here.
+                // NOTE: Some drivers report that they support the KHR GBM extension without EGL
+                // 1.5 client, so work around that here by checking the KHR GBM extension as well.
+                // The MESA and KHR extensions have the same constant values, thus it'll work
+                // regardless.
                 //
                 // See https://github.com/rust-windowing/glutin/issues/1708.
                 if extensions.contains("EGL_MESA_platform_gbm")


### PR DESCRIPTION
Some EGL drivers report the KHR extension with EGL 1.4, which doesn't make any sense, however given that the constant for MESA and KHR is the same, we can check for KHR in MESA branch, but still use the Ext functions.

Fixes #1708.
