### PR TITLE
Use `objc2` v0.6.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,13 +78,6 @@ jobs:
     runs-on: ${{ matrix.platform.os }}
     steps:
     - uses: actions/checkout@v3
-    # Used to cache cargo-web
-    - name: Cache cargo folder
-      uses: actions/cache@v1
-      with:
-        path: ~/.cargo
-        key: ${{ matrix.platform.target }}-cargo-${{ matrix.rust_version }}
-
     - uses: hecrj/setup-rust-action@v1
       with:
         rust-version: ${{ matrix.rust_version }}${{ matrix.platform.host }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust_version: [1.70.0, stable, nightly]
+        rust_version: [1.71.0, stable, nightly]
         platform:
           - { target: x86_64-pc-windows-msvc,   os: windows-latest,  }
           - { target: i686-pc-windows-msvc,     os: windows-latest,  }
@@ -59,10 +59,10 @@ jobs:
           - { target: x86_64-apple-darwin,      os: macos-latest,    }
         exclude:
           # Android is tested on stable-3
-          - rust_version: '1.70.0'
+          - rust_version: '1.71.0'
             platform: { target: aarch64-linux-android,    os: ubuntu-latest, cmd: 'apk --'   }
         include:
-          - rust_version: '1.70.0'
+          - rust_version: '1.71.0'
             platform: { target: aarch64-linux-android,    os: ubuntu-latest, cmd: 'apk --'   }
 
 
@@ -110,6 +110,5 @@ jobs:
 
     - name: Lint with clippy
       shell: bash
-      if: (matrix.rust_version == '1.70.0') && !contains(matrix.platform.options, '--no-default-features')
+      if: (matrix.rust_version == '1.71.0') && !contains(matrix.platform.options, '--no-default-features')
       run: cargo clippy --workspace --all-targets --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES -- -Dwarnings
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - **Breaking:** Added `make_current_surfaceless(self)` for `{Possibly,Not}CurrentGlContext`.
 - Bump MSRV from `1.70` to `1.71`.
+- Updated `objc2` dependency to `v0.6`.
 
 # Version 0.32.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - **Breaking:** Added `make_current_surfaceless(self)` for `{Possibly,Not}CurrentGlContext`.
+- Bump MSRV from `1.70` to `1.71`.
 
 # Version 0.32.2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,7 @@ members = [
     "glutin_wgl_sys",
     "glutin_gles2_sys",
 ]
+
+[workspace.package]
+# MSRV. Also update in ci.yml
+rust-version = "1.71.0"

--- a/glutin-winit/Cargo.toml
+++ b/glutin-winit/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/rust-windowing/glutin"
 edition = "2021"
-rust-version = "1.70.0"
+rust-version.workspace = true
 
 [features]
 default = ["egl", "glx", "x11", "wayland", "wgl"]

--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-windowing/glutin"
 documentation = "https://docs.rs/glutin"
-rust-version = "1.70.0"
+rust-version.workspace = true
 edition = "2021"
 
 [features]

--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -46,33 +46,41 @@ glutin_egl_sys = { version = "0.7.1", path = "../glutin_egl_sys" }
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
 glutin_egl_sys = { version = "0.7.1", path = "../glutin_egl_sys", optional = true }
 glutin_glx_sys = { version = "0.6.1", path = "../glutin_glx_sys", optional = true }
-wayland-sys = { version = "0.31.1", default-features = false, features = ["egl", "client", "dlopen"], optional = true }
+wayland-sys = { version = "0.31.1", default-features = false, features = [
+    "egl",
+    "client",
+    "dlopen",
+], optional = true }
 x11-dl = { version = "2.20.0", optional = true }
 
 [target.'cfg(any(target_os = "macos"))'.dependencies]
 cgl = "0.3.2"
-core-foundation = "0.9.3"
-objc2 = "0.5.1"
-dispatch = "0.2.0"
-
-[target.'cfg(any(target_os = "macos"))'.dependencies.objc2-foundation]
-version = "0.2.0"
-features = [
-    "dispatch",
+dispatch2 = { version = "0.3.0", default-features = false, features = [
+    "std",
+    "objc2",
+] }
+objc2 = "0.6.1"
+objc2-core-foundation = { version = "0.3.1", default-features = false, features = [
+    "std",
+    "CFBase",
+    "CFString",
+    "CFBundle",
+] }
+objc2-foundation = { version = "0.3.1", default-features = false, features = [
+    "std",
     "NSArray",
     "NSThread",
-]
-
-[target.'cfg(any(target_os = "macos"))'.dependencies.objc2-app-kit]
-version = "0.2.0"
-features = [
+] }
+objc2-app-kit = { version = "0.3.1", default-features = false, features = [
+    "std",
+    "objc2-core-foundation",
     "NSApplication",
     "NSResponder",
     "NSView",
     "NSWindow",
     "NSOpenGL",
     "NSOpenGLView",
-]
+] }
 
 [build-dependencies]
 cfg_aliases = "0.2.1"

--- a/glutin/src/api/cgl/appkit.rs
+++ b/glutin/src/api/cgl/appkit.rs
@@ -3,11 +3,11 @@
 #![allow(non_snake_case)]
 
 use objc2::encode::{Encoding, RefEncode};
-use objc2::rc::{Allocated, Id};
-use objc2::{extern_class, extern_methods, mutability, ClassType};
+use objc2::rc::{Allocated, Retained};
+use objc2::{extern_class, extern_methods, AllocAnyThread, MainThreadMarker};
 #[allow(deprecated)]
 use objc2_app_kit::{NSOpenGLContextParameter, NSOpenGLPixelFormatAttribute, NSView};
-use objc2_foundation::{MainThreadMarker, NSObject};
+use objc2_foundation::NSObject;
 
 pub type GLint = i32;
 
@@ -21,98 +21,86 @@ unsafe impl RefEncode for CGLContextObj {
 }
 
 extern_class!(
+    #[unsafe(super(NSObject))]
     #[derive(Debug, PartialEq, Eq, Hash)]
     pub(crate) struct NSOpenGLContext;
-
-    // Strict order required by macro, tracked in https://github.com/madsmtm/objc2/issues/479
-    #[rustfmt::skip]
-    unsafe impl ClassType for NSOpenGLContext {
-        type Super = NSObject;
-        type Mutability = mutability::InteriorMutable;
-    }
 );
 
 unsafe impl Send for NSOpenGLContext {}
 unsafe impl Sync for NSOpenGLContext {}
 
-extern_methods!(
-    unsafe impl NSOpenGLContext {
-        #[method_id(currentContext)]
-        pub(crate) fn currentContext() -> Option<Id<Self>>;
+impl NSOpenGLContext {
+    extern_methods!(
+        #[unsafe(method(currentContext))]
+        pub(crate) fn currentContext() -> Option<Retained<Self>>;
 
-        #[method_id(initWithFormat:shareContext:)]
+        #[unsafe(method(initWithFormat:shareContext:))]
         pub(crate) fn initWithFormat_shareContext(
             this: Allocated<Self>,
             format: &NSOpenGLPixelFormat,
             share: Option<&NSOpenGLContext>,
-        ) -> Option<Id<Self>>;
+        ) -> Option<Retained<Self>>;
 
-        #[method(clearCurrentContext)]
+        #[unsafe(method(clearCurrentContext))]
         pub(crate) fn clearCurrentContext();
 
-        #[method(makeCurrentContext)]
+        #[unsafe(method(makeCurrentContext))]
         pub(crate) fn makeCurrentContext(&self);
 
-        #[method(update)]
+        #[unsafe(method(update))]
         pub(crate) fn update(&self);
 
-        #[method(flushBuffer)]
+        #[unsafe(method(flushBuffer))]
         pub(crate) fn flushBuffer(&self);
 
-        #[method_id(view)]
-        pub(crate) fn view(&self, mtm: MainThreadMarker) -> Option<Id<NSView>>;
+        #[unsafe(method(view))]
+        pub(crate) fn view(&self, mtm: MainThreadMarker) -> Option<Retained<NSView>>;
 
-        #[method(setView:)]
+        #[unsafe(method(setView:))]
         pub(crate) unsafe fn setView(&self, view: Option<&NSView>);
 
         #[allow(deprecated)]
-        #[method(setValues:forParameter:)]
+        #[unsafe(method(setValues:forParameter:))]
         pub(crate) unsafe fn setValues_forParameter(
             &self,
             vals: *const GLint,
             param: NSOpenGLContextParameter,
         );
 
-        #[method(CGLContextObj)]
+        #[unsafe(method(CGLContextObj))]
         pub(crate) fn CGLContextObj(&self) -> *mut CGLContextObj;
-    }
-);
+    );
+}
 
 extern_class!(
+    #[unsafe(super(NSObject))]
     #[derive(Debug, PartialEq, Eq, Hash)]
     pub(crate) struct NSOpenGLPixelFormat;
-
-    // Strict order required by macro, tracked in https://github.com/madsmtm/objc2/issues/479
-    #[rustfmt::skip]
-    unsafe impl ClassType for NSOpenGLPixelFormat {
-        type Super = NSObject;
-        type Mutability = mutability::Immutable;
-    }
 );
 
 unsafe impl Send for NSOpenGLPixelFormat {}
 unsafe impl Sync for NSOpenGLPixelFormat {}
 
-extern_methods!(
-    unsafe impl NSOpenGLPixelFormat {
-        #[method_id(initWithAttributes:)]
+impl NSOpenGLPixelFormat {
+    extern_methods!(
+        #[unsafe(method(initWithAttributes:))]
         unsafe fn initWithAttributes(
             this: Allocated<Self>,
             attrs: *const NSOpenGLPixelFormatAttribute,
-        ) -> Option<Id<Self>>;
+        ) -> Option<Retained<Self>>;
 
-        pub(crate) unsafe fn newWithAttributes(
-            attrs: &[NSOpenGLPixelFormatAttribute],
-        ) -> Option<Id<Self>> {
-            unsafe { Self::initWithAttributes(Self::alloc(), attrs.as_ptr()) }
-        }
-
-        #[method(getValues:forAttribute:forVirtualScreen:)]
+        #[unsafe(method(getValues:forAttribute:forVirtualScreen:))]
         pub(crate) unsafe fn getValues_forAttribute_forVirtualScreen(
             &self,
             vals: *mut GLint,
             param: NSOpenGLPixelFormatAttribute,
             screen: GLint,
         );
+    );
+
+    pub(crate) unsafe fn newWithAttributes(
+        attrs: &[NSOpenGLPixelFormatAttribute],
+    ) -> Option<Retained<Self>> {
+        unsafe { Self::initWithAttributes(Self::alloc(), attrs.as_ptr()) }
     }
-);
+}

--- a/glutin/src/api/cgl/config.rs
+++ b/glutin/src/api/cgl/config.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 use std::{fmt, iter};
 
-use objc2::rc::Id;
+use objc2::rc::Retained;
 #[allow(deprecated)]
 use objc2_app_kit::{
     NSOpenGLPFAAccelerated, NSOpenGLPFAAllowOfflineRenderers, NSOpenGLPFAAlphaSize,
@@ -219,7 +219,7 @@ impl GetGlDisplay for Config {
 
 impl AsRawConfig for Config {
     fn raw_config(&self) -> RawConfig {
-        RawConfig::Cgl(Id::as_ptr(&self.inner.raw).cast())
+        RawConfig::Cgl(Retained::as_ptr(&self.inner.raw).cast())
     }
 }
 
@@ -228,7 +228,7 @@ impl Sealed for Config {}
 pub(crate) struct ConfigInner {
     display: Display,
     pub(crate) transparency: bool,
-    pub(crate) raw: Id<NSOpenGLPixelFormat>,
+    pub(crate) raw: Retained<NSOpenGLPixelFormat>,
 }
 
 impl PartialEq for ConfigInner {

--- a/glutin/src/api/cgl/context.rs
+++ b/glutin/src/api/cgl/context.rs
@@ -4,10 +4,10 @@ use std::fmt;
 use std::marker::PhantomData;
 
 use cgl::CGLSetParameter;
-use objc2::rc::{autoreleasepool, Id};
-use objc2::ClassType;
+use dispatch2::{run_on_main, MainThreadBound};
+use objc2::rc::{autoreleasepool, Retained};
+use objc2::AllocAnyThread;
 use objc2_app_kit::{NSOpenGLCPSwapInterval, NSView};
-use objc2_foundation::{run_on_main, MainThreadBound};
 
 use crate::config::GetGlConfig;
 use crate::context::{
@@ -139,7 +139,7 @@ impl GetGlDisplay for NotCurrentContext {
 
 impl AsRawContext for NotCurrentContext {
     fn raw_context(&self) -> RawContext {
-        RawContext::Cgl(Id::as_ptr(&self.inner.raw).cast())
+        RawContext::Cgl(Retained::as_ptr(&self.inner.raw).cast())
     }
 }
 
@@ -220,7 +220,7 @@ impl GetGlDisplay for PossiblyCurrentContext {
 
 impl AsRawContext for PossiblyCurrentContext {
     fn raw_context(&self) -> RawContext {
-        RawContext::Cgl(Id::as_ptr(&self.inner.raw).cast())
+        RawContext::Cgl(Retained::as_ptr(&self.inner.raw).cast())
     }
 }
 
@@ -229,7 +229,7 @@ impl Sealed for PossiblyCurrentContext {}
 pub(crate) struct ContextInner {
     display: Display,
     config: Config,
-    pub(crate) raw: Id<NSOpenGLContext>,
+    pub(crate) raw: Retained<NSOpenGLContext>,
 }
 
 impl ContextInner {
@@ -294,7 +294,7 @@ impl ContextInner {
         })
     }
 
-    pub(crate) fn is_view_current(&self, view: &MainThreadBound<Id<NSView>>) -> bool {
+    pub(crate) fn is_view_current(&self, view: &MainThreadBound<Retained<NSView>>) -> bool {
         run_on_main(|mtm| {
             self.raw.view(mtm).expect("context to have a current view") == *view.get(mtm)
         })

--- a/glutin/src/api/cgl/display.rs
+++ b/glutin/src/api/cgl/display.rs
@@ -3,9 +3,7 @@
 use std::ffi::{self, CStr};
 use std::marker::PhantomData;
 
-use core_foundation::base::TCFType;
-use core_foundation::bundle::{CFBundleGetBundleWithIdentifier, CFBundleGetFunctionPointerForName};
-use core_foundation::string::CFString;
+use objc2_core_foundation::{CFBundle, CFString};
 use raw_window_handle::RawDisplayHandle;
 
 use crate::config::ConfigTemplate;
@@ -87,12 +85,10 @@ impl GlDisplay for Display {
     }
 
     fn get_proc_address(&self, addr: &CStr) -> *const ffi::c_void {
-        let symbol_name = CFString::new(addr.to_str().unwrap());
-        let framework_name = CFString::new("com.apple.opengl");
-        unsafe {
-            let framework = CFBundleGetBundleWithIdentifier(framework_name.as_concrete_TypeRef());
-            CFBundleGetFunctionPointerForName(framework, symbol_name.as_concrete_TypeRef()).cast()
-        }
+        let symbol_name = CFString::from_str(addr.to_str().unwrap());
+        let framework_name = CFString::from_static_str("com.apple.opengl");
+        let framework = CFBundle::bundle_with_identifier(Some(&framework_name)).unwrap();
+        CFBundle::function_pointer_for_name(&framework, Some(&symbol_name))
     }
 
     fn version_string(&self) -> String {

--- a/glutin_egl_sys/Cargo.toml
+++ b/glutin_egl_sys/Cargo.toml
@@ -6,7 +6,7 @@ description = "The egl bindings for glutin"
 repository = "https://github.com/rust-windowing/glutin"
 license = "Apache-2.0"
 readme = "README.md"
-rust-version = "1.70.0"
+rust-version.workspace = true
 edition = "2021"
 
 [build-dependencies]

--- a/glutin_examples/Cargo.toml
+++ b/glutin_examples/Cargo.toml
@@ -6,7 +6,7 @@ description = "Examples for glutin"
 repository = "https://github.com/rust-windowing/glutin"
 license = "Apache-2.0"
 readme = "../README.md"
-rust-version = "1.70.0"
+rust-version.workspace = true
 edition = "2021"
 publish = false
 

--- a/glutin_gles2_sys/Cargo.toml
+++ b/glutin_gles2_sys/Cargo.toml
@@ -6,7 +6,7 @@ description = "The gles2 bindings for glutin"
 repository = "https://github.com/rust-windowing/glutin"
 license = "Apache-2.0"
 readme = "README.md"
-rust-version = "1.70.0"
+rust-version.workspace = true
 edition = "2021"
 
 [build-dependencies]

--- a/glutin_glx_sys/Cargo.toml
+++ b/glutin_glx_sys/Cargo.toml
@@ -6,7 +6,7 @@ description = "The glx bindings for glutin"
 repository = "https://github.com/rust-windowing/glutin"
 license = "Apache-2.0"
 readme = "README.md"
-rust-version = "1.70.0"
+rust-version.workspace = true
 edition = "2021"
 
 [build-dependencies]

--- a/glutin_wgl_sys/Cargo.toml
+++ b/glutin_wgl_sys/Cargo.toml
@@ -6,7 +6,7 @@ description = "The wgl bindings for glutin"
 repository = "https://github.com/rust-windowing/glutin"
 license = "Apache-2.0"
 readme = "README.md"
-rust-version = "1.70.0"
+rust-version.workspace = true
 edition = "2021"
 
 [build-dependencies]


### PR DESCRIPTION
Update to `objc2` v0.6.1, and use the new `objc2-core-foundation` crate.

This requires an MSRV bump to 1.71 to get access to `extern "C-unwind"`.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
